### PR TITLE
Check if android.jar exists

### DIFF
--- a/smack-android/build.gradle
+++ b/smack-android/build.gradle
@@ -18,7 +18,12 @@ dependencies {
 def getAndroidRuntimeJar() {
 	def androidHome = new File("$System.env.ANDROID_HOME")
 	if (!androidHome.isDirectory()) throw new Exception("ANDROID_HOME not found or set")
-	new File("$androidHome/platforms/android-$smackMinAndroidSdk/android.jar")
+	def androidJar = new File("$androidHome/platforms/android-$smackMinAndroidSdk/android.jar")
+	if (androidJar.isFile()) {
+		return androidJar
+	} else {
+		throw new Exception("Can't find android.jar for $smackMinAndroidSdk api. Please install corresponding SDK platform package")
+	}
 }
 
 def getAndroidJavadocOffline() {


### PR DESCRIPTION
I had no api 8 android.jar installed in my sdk and error message was quite confusing: 

```
Fatal Error: Unable to find package java.lang in classpath or bootclasspath
```

Now it will write:

```
A problem occurred evaluating project ':smack-android'.
> Can't find android.jar for 8 api. Please install corresponding SDK platform package
```

Please change the text at something else if you wish
