### PR TITLE
Generify Packet class returned by PackageCollector everythere

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/PacketCollector.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/PacketCollector.java
@@ -103,8 +103,9 @@ public class PacketCollector {
      * @return the next packet result, or <tt>null</tt> if there are no more
      *      results.
      */
-    public Packet pollResult() {
-    	return resultQueue.poll();
+    @SuppressWarnings("unchecked")
+    public <P extends Packet> P pollResult() {
+        return (P) resultQueue.poll();
     }
 
     /**
@@ -113,9 +114,10 @@ public class PacketCollector {
      * 
      * @return the next available packet.
      */
-    public Packet nextResultBlockForever() {
+    @SuppressWarnings("unchecked")
+    public <P extends Packet> P nextResultBlockForever() {
         try {
-            return resultQueue.take();
+            return (P) resultQueue.take();
         }
         catch (InterruptedException e) {
             throw new RuntimeException(e);
@@ -128,7 +130,7 @@ public class PacketCollector {
      * 
      * @return the next availabe packet.
      */
-    public Packet nextResult() {
+    public <P extends Packet> P nextResult() {
         return nextResult(connection.getPacketReplyTimeout());
     }
 


### PR DESCRIPTION
This will help to get rid of repetitive class casts, and make
PacketCollector api more inline with itself (since some methods
are already generic return methods)
