### PR TITLE
Updated support for HTTP over XMPP (XEP-0332)

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/packet/Base64BinaryChunk.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/packet/Base64BinaryChunk.java
@@ -31,21 +31,25 @@ public class Base64BinaryChunk implements PacketExtension {
     public static final String ELEMENT_CHUNK = "chunk";
     public static final String ATTRIBUTE_STREAM_ID = "streamId";
     public static final String ATTRIBUTE_LAST = "last";
+    public static final String ATTRIBUTE_NR = "nr";
 
     private final String streamId;
     private final boolean last;
     private final String text;
+    private final int nr;
 
     /**
      * Creates the extension.
      *
      * @param text     value of text attribute
      * @param streamId value of streamId attribute
+     * @param nr       value of nr attribute
      * @param last     value of last attribute
      */
-    public Base64BinaryChunk(String text, String streamId, boolean last) {
+    public Base64BinaryChunk(String text, String streamId, int nr, boolean last) {
         this.text = text;
         this.streamId = streamId;
+        this.nr = nr;
         this.last = last;
     }
 
@@ -54,9 +58,10 @@ public class Base64BinaryChunk implements PacketExtension {
      *
      * @param text     value of text attribute
      * @param streamId value of streamId attribute
+     * @param nr       value of nr attribute
      */
-    public Base64BinaryChunk(String text, String streamId) {
-        this(text, streamId, false);
+    public Base64BinaryChunk(String text, String streamId, int nr) {
+        this(text, streamId, nr, false);
     }
 
     /**
@@ -86,6 +91,15 @@ public class Base64BinaryChunk implements PacketExtension {
         return text;
     }
 
+    /**
+     * Returns nr attribute.
+     *
+     * @return nr attribute
+     */
+    public int getNr() {
+        return nr;
+    }
+
     @Override
     public String getElementName() {
         return ELEMENT_CHUNK;
@@ -101,6 +115,8 @@ public class Base64BinaryChunk implements PacketExtension {
         StringBuilder builder = new StringBuilder();
         builder.append("<chunk xmlns='urn:xmpp:http' streamId='");
         builder.append(streamId);
+        builder.append("' nr='");
+        builder.append(nr);
         builder.append("' last='");
         builder.append(Boolean.toString(last));
         builder.append("'>");

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/provider/Base64BinaryChunkProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/provider/Base64BinaryChunkProvider.java
@@ -38,8 +38,10 @@ public class Base64BinaryChunkProvider implements PacketExtensionProvider {
     @Override
     public PacketExtension parseExtension(XmlPullParser parser) throws Exception {
         String streamId = parser.getAttributeValue("", Base64BinaryChunk.ATTRIBUTE_STREAM_ID);
+        String nrString = parser.getAttributeValue("", Base64BinaryChunk.ATTRIBUTE_NR);
         String lastString = parser.getAttributeValue("", Base64BinaryChunk.ATTRIBUTE_LAST);
         boolean last = false;
+        int nr = Integer.parseInt(nrString);
 
         if (lastString != null) {
             last = Boolean.parseBoolean(lastString);
@@ -64,6 +66,6 @@ public class Base64BinaryChunkProvider implements PacketExtensionProvider {
             }
         }
 
-        return new Base64BinaryChunk(text, streamId, last);
+        return new Base64BinaryChunk(text, streamId, nr, last);
     }
 }

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/hoxt/provider/Base64BinaryChunkProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/hoxt/provider/Base64BinaryChunkProviderTest.java
@@ -32,7 +32,7 @@ public class Base64BinaryChunkProviderTest {
     @Test
     public void isNonLatsChunkParsedCorrectly() throws Exception {
         String base64Text = "iVBORw0KGgoAAAANSUhEUgAAASwAAAGQCAYAA";
-        String string = "<chunk xmlns='urn:xmpp:http' streamId='Stream0001'>" + base64Text + "</chunk>";
+        String string = "<chunk xmlns='urn:xmpp:http' streamId='Stream0001' nr='0'>" + base64Text + "</chunk>";
 
         Base64BinaryChunkProvider provider = new Base64BinaryChunkProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(string);
@@ -44,12 +44,13 @@ public class Base64BinaryChunkProviderTest {
         assertEquals("Stream0001", chunk.getStreamId());
         assertFalse(chunk.isLast());
         assertEquals(base64Text, chunk.getText());
+        assertEquals(0, chunk.getNr());
     }
 
     @Test
     public void isLatsChunkParsedCorrectly() throws Exception {
         String base64Text = "2uPzi9u+tVWJd+e+y1AAAAABJRU5ErkJggg==";
-        String string = "<chunk xmlns='urn:xmpp:http' streamId='Stream0001' last='true'>" + base64Text + "</chunk>";
+        String string = "<chunk xmlns='urn:xmpp:http' streamId='Stream0001' nr='1' last='true'>" + base64Text + "</chunk>";
 
         Base64BinaryChunkProvider provider = new Base64BinaryChunkProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(string);
@@ -61,5 +62,6 @@ public class Base64BinaryChunkProviderTest {
         assertEquals("Stream0001", chunk.getStreamId());
         assertTrue(chunk.isLast());
         assertEquals(base64Text, chunk.getText());
+        assertEquals(1, chunk.getNr());
     }
 }


### PR DESCRIPTION
Updated Base64BinaryChunk packet and provider to support latest
version of specification (0.3):
- added support for new nr attribute.
