### PR TITLE
Set jid to passed parameter, not null

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Bind.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Bind.java
@@ -40,7 +40,7 @@ public class Bind extends IQ {
 
     public Bind(String resource, String jid) {
         this.resource = resource;
-        this.jid = null;
+        this.jid = jid;
     }
 
     public String getResource() {


### PR DESCRIPTION
Setting `jid` to `null` was probably not the intended behaviour of this constructor and means that the `IQReplyFilter` will later reject responses that it shouldn't, because the `AbstractXmppConnection` will automatically construct a JID based on the authenticated username.

In particular, this breaks attempting to connect to the PVP.net XMPP server.
