### PR TITLE
empty string conditionText should be treated similar to null

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/StreamError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/StreamError.java
@@ -105,7 +105,7 @@ public class StreamError extends AbstractError implements PlainStreamElement {
 
     public StreamError(Condition condition, String conditionText, Map<String, String> descriptiveTexts, List<PacketExtension> extensions) {
         super(descriptiveTexts, extensions);
-        if (conditionText != null && !conditionText.isEmpty()) {
+        if (conditionText != null && !"".equals(conditionText)) {
             switch (condition) {
             case see_other_host:
                 break;


### PR DESCRIPTION
ejabberd sends the following stanza when a user is kicked off from reaching max simultaneous connections:

``` xml
<error xmlns='http://etherx.jabber.org/streams'>
    <conflict xmlns='urn:ietf:params:xml:ns:xmpp-streams'/>
    <text xmlns='urn:ietf:params:xml:ns:xmpp-streams' lang=''>Replaced by new connection</text>
</error>
```

StreamError does not parse this correctly due to conditionText == "" and throws IllegalArgumentException "'conflict' can not contain a condition text". Expected behavior is to treat empty string as no conditionText, or pass in null to StreamError's constructor, not "".

Tested on android sdk v21.
