### PR TITLE
Minor Changes to XHTMLText.java

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
@@ -238,6 +238,15 @@ public class XHTMLText {
         text.rightAngleBracket();
         return this;
     }
+    
+    /**
+     * Appends a tag that indicates that a line item section ends.
+     * 
+     */
+    public XHTMLText appendCloseLineItemTag() {
+        text.closeElement(LI);
+        return this;
+    }
 
     /**
      * Appends a tag that creates an ordered list. "Ordered" means that the order of the items 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
@@ -403,7 +403,6 @@ public class XHTMLText {
      * @return the text of the XHTMLText   
      */
     public String toString() {
-        appendCloseBodyTag();
         return text.toString();
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
@@ -398,8 +398,6 @@ public class XHTMLText {
     /**
      * Returns the text of the XHTMLText.
      * 
-     * Note: Automatically adds the closing body tag.
-     * 
      * @return the text of the XHTMLText   
      */
     public String toString() {


### PR DESCRIPTION
- removed auto adding of body tag in toString() method. It too me longer than I would like to admit to debug my code to find out why a random **\</body\>** was showing up. If returning the **\</body\>** tag at the end of the string is still needed might I recommend it not change the underlying text.
- added method to close **\<li\>** tag