### PR TITLE
Workgroup.class not thread safe

### DIFF
--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/user/Workgroup.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/user/Workgroup.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.workgroup.user;
 
-import java.util.ArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -76,8 +76,8 @@ public class Workgroup {
     private String workgroupJID;
     private XMPPConnection connection;
     private boolean inQueue;
-    private List<WorkgroupInvitationListener> invitationListeners;
-    private List<QueueListener> queueListeners;
+    private CopyOnWriteArraySet<WorkgroupInvitationListener> invitationListeners;
+    private CopyOnWriteArraySet<QueueListener> queueListeners;
 
     private int queuePosition = -1;
     private int queueRemainingTime = -1;
@@ -101,8 +101,8 @@ public class Workgroup {
         this.workgroupJID = workgroupJID;
         this.connection = connection;
         inQueue = false;
-        invitationListeners = new ArrayList<WorkgroupInvitationListener>();
-        queueListeners = new ArrayList<QueueListener>();
+        invitationListeners = new CopyOnWriteArraySet<>();
+        queueListeners = new CopyOnWriteArraySet<>();
 
         // Register as a queue listener for internal usage by this instance.
         addQueueListener(new QueueListener() {
@@ -429,11 +429,7 @@ public class Workgroup {
      * @param queueListener the queue listener.
      */
     public void addQueueListener(QueueListener queueListener) {
-        synchronized (queueListeners) {
-            if (!queueListeners.contains(queueListener)) {
-                queueListeners.add(queueListener);
-            }
-        }
+        queueListeners.add(queueListener);
     }
 
     /**
@@ -442,9 +438,7 @@ public class Workgroup {
      * @param queueListener the queue listener.
      */
     public void removeQueueListener(QueueListener queueListener) {
-        synchronized (queueListeners) {
-            queueListeners.remove(queueListener);
-        }
+        queueListeners.remove(queueListener);
     }
 
     /**
@@ -454,11 +448,7 @@ public class Workgroup {
      * @param invitationListener the invitation listener.
      */
     public void addInvitationListener(WorkgroupInvitationListener invitationListener) {
-        synchronized (invitationListeners) {
-            if (!invitationListeners.contains(invitationListener)) {
-                invitationListeners.add(invitationListener);
-            }
-        }
+        invitationListeners.add(invitationListener);
     }
 
     /**
@@ -467,53 +457,36 @@ public class Workgroup {
      * @param invitationListener the invitation listener.
      */
     public void removeQueueListener(WorkgroupInvitationListener invitationListener) {
-        synchronized (invitationListeners) {
-            invitationListeners.remove(invitationListener);
-        }
+        invitationListeners.remove(invitationListener);
     }
 
     private void fireInvitationEvent(WorkgroupInvitation invitation) {
-        synchronized (invitationListeners) {
-            for (Iterator<WorkgroupInvitationListener> i = invitationListeners.iterator(); i.hasNext();) {
-                WorkgroupInvitationListener listener = i.next();
-                listener.invitationReceived(invitation);
-            }
+        for (WorkgroupInvitationListener listener : invitationListeners ){
+    	    listener.invitationReceived(invitation);
         }
     }
 
     private void fireQueueJoinedEvent() {
-        synchronized (queueListeners) {
-            for (Iterator<QueueListener> i = queueListeners.iterator(); i.hasNext();) {
-                QueueListener listener = i.next();
-                listener.joinedQueue();
-            }
+        for (QueueListener listener : queueListeners){
+    	    listener.joinedQueue();
         }
     }
 
     private void fireQueueDepartedEvent() {
-        synchronized (queueListeners) {
-            for (Iterator<QueueListener> i = queueListeners.iterator(); i.hasNext();) {
-                QueueListener listener = i.next();
-                listener.departedQueue();
-            }
+        for (QueueListener listener : queueListeners) {
+            listener.departedQueue();
         }
     }
 
     private void fireQueuePositionEvent(int currentPosition) {
-        synchronized (queueListeners) {
-            for (Iterator<QueueListener> i = queueListeners.iterator(); i.hasNext();) {
-                QueueListener listener = i.next();
-                listener.queuePositionUpdated(currentPosition);
-            }
+        for (QueueListener listener : queueListeners) {
+            listener.queuePositionUpdated(currentPosition);
         }
     }
 
     private void fireQueueTimeEvent(int secondsRemaining) {
-        synchronized (queueListeners) {
-            for (Iterator<QueueListener> i = queueListeners.iterator(); i.hasNext();) {
-                QueueListener listener = i.next();
-                listener.queueWaitTimeUpdated(secondsRemaining);
-            }
+        for (QueueListener listener : queueListeners) {
+            listener.queueWaitTimeUpdated(secondsRemaining);
         }
     }
 


### PR DESCRIPTION
Hy,

I had a problem with the class Workgroup (org.jivesoftware.smackx.workgroup.user.Wourkgroup.java). Every time i would run the 'client' which made a connection with the Openfire server via Fastpath i would get this error:

```java
Jan 13, 2015 1:59:18 PM org.jivesoftware.smack.XMPPConnection$ListenerNotification run
SEVERE: Exception in packet listener
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:859)
	at java.util.ArrayList$Itr.next(ArrayList.java:831)
	at org.jivesoftware.smackx.workgroup.user.Workgroup.fireInvitationEvent(Workgroup.java:464)
	at org.jivesoftware.smackx.workgroup.user.Workgroup.handlePacket(Workgroup.java:552)
	at org.jivesoftware.smackx.workgroup.user.Workgroup.access$300(Workgroup.java:59)
	at org.jivesoftware.smackx.workgroup.user.Workgroup$3.processPacket(Workgroup.java:131)
	at org.jivesoftware.smack.XMPPConnection$ListenerWrapper.notifyListener(XMPPConnection.java:1233)
	at org.jivesoftware.smack.XMPPConnection$ListenerNotification.run(XMPPConnection.java:1143)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```

The error states that there is a leak somewhere in the Workgroup.class that iterates via an arraylist. I checked the source and it seems that there is a synchronized block for every iteration, like so:
```java
synchronized (queueListeners) {
     //code
}

synchronized (invitationListeners) { 
     //code
}
```
I replaced all the synchronized blocks for a CopyOnWriteArrayList object on the queueListeners and invitationListeners. 

```java
-        invitationListeners = new ArrayList<WorkgroupInvitationListener>();
-        queueListeners = new ArrayList<QueueListener>();
+        invitationListeners = new CopyOnWriteArrayList<WorkgroupInvitationListener>();
+        queueListeners = new CopyOnWriteArrayList<QueueListener>();
```
EDIT:
I replaced all the synchronized blocks for a CopyOnWriteArraySet object on the queueListeners and invitationListeners. 

```java
-        invitationListeners = new ArrayList<WorkgroupInvitationListener>();
-        queueListeners = new ArrayList<QueueListener>();
+        invitationListeners = new CopyOnWriteArraySet<>();
+        queueListeners = new CopyOnWriteArraySet<>();
```
The problem is solved.