### PR TITLE
Fixing a typo for host_unknown

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/StreamError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/StreamError.java
@@ -158,7 +158,7 @@ public class StreamError extends AbstractError implements PlainStreamElement {
         conflict,
         connection_timeout,
         host_gone,
-        host_unkown,
+        host_unknown,
         improper_addressing,
         internal_server_error,
         invalid_from,


### PR DESCRIPTION
Hi there,
   I was performing some tests and I noticed that when I tried to connect to an invalid vhost I got a strange exception

> java.lang.IllegalStateException: Could not transform string 'host_unknown' to XMPPErrorConditoin
>	at org.jivesoftware.smack.packet.StreamError$Condition.fromString(StreamError.java:186)
>	at org.jivesoftware.smack.util.PacketParserUtils.parseStreamError(PacketParserUtils.java:841)
>	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1016)
>	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$200(XMPPTCPConnection.java:931)
>	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:950)
> Caused by: java.lang.IllegalArgumentException: No enum constant org.jivesoftware.smack.packet.StreamError.Condition.host_unknown
>	at java.lang.Enum.valueOf(Enum.java:236)
>	at org.jivesoftware.smack.packet.StreamError$Condition.valueOf(StreamError.java:148)
>	at org.jivesoftware.smack.packet.StreamError$Condition.fromString(StreamError.java:184)
>	... 4 more

Investigating a little I found out that in *StreamError.java* there is an **host_unkown** that needs to be turned in **host_unknown**

Not a big deal, but I wanted to let you know so that you could fix it.

Regards,
  Luca