### PR TITLE
Fix a logic error when create a new Chat in ChatManager

### DIFF
--- a/smack-im/src/main/java/org/jivesoftware/smack/chat/ChatManager.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/chat/ChatManager.java
@@ -151,12 +151,13 @@ public class ChatManager extends Manager{
         connection.addSyncStanzaListener(new StanzaListener() {
             public void processPacket(Stanza packet) {
                 Message message = (Message) packet;
-                Chat chat;
-                if (message.getThread() == null) {
-                	chat = getUserChat(message.getFrom());
-                }
-                else {
+                Chat chat = null;
+                if (message.getThread() != null) {
                     chat = getThreadChat(message.getThread());
+                }
+
+                if (chat == null) {
+                    chat = getUserChat(message.getFrom());
                 }
 
                 if(chat == null) {


### PR DESCRIPTION
When us smack library for android app, I found a logic error when create Chat in file ChatManager.java.
As doc says: "Smack will attempt match the incoming messages to the best fit existing chat, first try thread-id, if no match found,  then based on the JID. It will attempt to find a chat with the same full JID, failing that, it will try the base JID. If no existing chat to the user can found, then a new one is created.
But the code seems can't handle this scenario: "A message with a thread id is received, no thread id matched, but jid matched". The original code will create a new chat, but in fact, it should use a chat with jid matched in the local map.