### PR TITLE
Fix typo in exception

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/caps/provider/CapsExtensionProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/caps/provider/CapsExtensionProvider.java
@@ -51,7 +51,7 @@ public class CapsExtensionProvider extends ExtensionElementProvider<CapsExtensio
         if (hash != null && version != null && node != null) {
             return new CapsExtension(node, version, hash);
         } else {
-            throw new SmackException("Caps elment with missing attributes");
+            throw new SmackException("Caps element with missing attributes");
         }
     }
 


### PR DESCRIPTION
Hello,

there is a small typo in an exception in CapsExtensionProvider, the word "element" is missing an e. Just a minor thing, but I thought this would be a a good playground to try to make a first contribution on a GitHub project. :)

Regards,
Daniel