### PR TITLE
HOXT: Fix getIQChildElementBuilder in AbstractHttpOverXmpp.java + Update documentation

### DIFF
--- a/documentation/extensions/hoxt.md
+++ b/documentation/extensions/hoxt.md
@@ -73,11 +73,11 @@ HttpOverXmppReq req = new HttpOverXmppReq(HttpMethod.POST, "/mailbox");
 req.setVersion("1.1");
 
 // prepare headers
-Set<Header> set = new HashSet<Header>();
-set.add(new Header("Host", "juliet.capulet.com"));
-set.add(new Header("Content-Type", "application/x-www-form- urlencoded"));
-set.add(new Header("Content-Length", Integer.toString(urlEncodedMessage.length())));
-req.setHeaders(new HeadersExtension(set));
+List<Header> list = new ArrayList<Header>();
+list.add(new Header("Host", "juliet.capulet.com"));
+list.add(new Header("Content-Type", "application/x-www-form- urlencoded"));
+list.add(new Header("Content-Length", Integer.toString(urlEncodedMessage.length())));
+req.setHeaders(new HeadersExtension(list));
 
 // provide body or request (not mandatory, - empty body is used for GET)
 AbstractHttpOverXmpp.Text child = new AbstractHttpOverXmpp.Text(urlEncodedMessage);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/packet/AbstractHttpOverXmpp.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/packet/AbstractHttpOverXmpp.java
@@ -42,8 +42,8 @@ public abstract class AbstractHttpOverXmpp extends IQ {
 
     protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
         IQChildElementXmlStringBuilder builder = getIQHoxtChildElementBuilder(xml);
-        builder.append(headers.toXML());
-        builder.append(data.toXML());
+        builder.optAppend(headers.toXML());
+        builder.optAppend(data.toXML());
 
         return builder;
     }


### PR DESCRIPTION
* `NullPointerException` was raised when not setting any header or data in an  HttpOverXmppReq or Resp. Fixed by using `optAppend` instead of `append`. 
* The documentation used a `Set` for storing the head bu this is not accepted by `HeadersExtension` constructor.
* Error occurs if no version in set in a Req or Res. This is not fixed as I am not sure what should be the correct behavior. Two possibilities:
  * Mandatory to specify version, then an exception should probably be raised when it is not done.
  * Version number is set by default to "1.1" if not provided. In that case should the Host header be set by default as well?   

PS: Sorry I messed up the previous request trying to squash the commits.