### PR TITLE
SASL Proxy Auth support

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
@@ -31,6 +31,7 @@ import org.jivesoftware.smack.util.CollectionUtil;
 import org.jivesoftware.smack.util.Objects;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jxmpp.jid.DomainBareJid;
+import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.stringprep.XmppStringprepException;
 
@@ -77,6 +78,7 @@ public abstract class ConnectionConfiguration {
     // Holds the socket factory that is used to generate the socket in the connection
     private final SocketFactory socketFactory;
 
+    private final BareJid authzid; 
     private final CharSequence username;
     private final String password;
     private final Resourcepart resource;
@@ -110,6 +112,7 @@ public abstract class ConnectionConfiguration {
     private final Set<String> enabledSaslMechanisms;
 
     protected ConnectionConfiguration(Builder<?,?> builder) {
+        authzid = builder.authzid;
         username = builder.username;
         password = builder.password;
         callbackHandler = builder.callbackHandler;
@@ -150,6 +153,15 @@ public abstract class ConnectionConfiguration {
 
         // If the enabledSaslmechanisms are set, then they must not be empty
         assert(enabledSaslMechanisms != null ? !enabledSaslMechanisms.isEmpty() : true);
+    }
+    
+    /**
+     * Returns the bare jid to be requested as the authorization identifier.
+     * 
+     * @return the authorization identifier.
+     */
+    public BareJid getAuthzid() {
+        return authzid;
     }
 
     /**
@@ -423,6 +435,7 @@ public abstract class ConnectionConfiguration {
         private String[] enabledSSLProtocols;
         private String[] enabledSSLCiphers;
         private HostnameVerifier hostnameVerifier;
+        private BareJid authzid;
         private CharSequence username;
         private String password;
         private Resourcepart resource;
@@ -440,6 +453,23 @@ public abstract class ConnectionConfiguration {
         private Set<String> enabledSaslMechanisms;
 
         protected Builder() {
+        }
+        
+        /**
+         * Set the XMPP entity's authorization identifier.
+         * <p>
+         * In XMPP, authorization identifiers are bare jids. In general, callers should allow the server to select the
+         * authorization identifier automatically, and not call this. Note that setting the authzid does not set the XMPP
+         * service domain, which should typically match.
+         * Calling this will also cause SASL mechanisms which do not support an authorization identifier to be dropped.
+         * </p>
+         * 
+         * @param authzid The BareJid to be requested as the authorization identifier.
+         * @return a reference to this builder.
+         */
+        public B setAuthzid(BareJid authzid) {
+            this.authzid = authzid;
+            return getThis();
         }
 
         /**

--- a/smack-core/src/main/java/org/jivesoftware/smack/SASLAuthentication.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SASLAuthentication.java
@@ -206,7 +206,7 @@ public final class SASLAuthentication {
     public void authenticate(BareJid authzid, String username, String password)
                     throws XMPPErrorException, SASLErrorException, IOException,
                     SmackException, InterruptedException {
-        currentMechanism = selectMechanism();
+        currentMechanism = selectMechanism(authzid != null);
         final CallbackHandler callbackHandler = configuration.getCallbackHandler();
         final String host = connection.getHost();
         final DomainBareJid xmppServiceDomain = connection.getXMPPServiceDomain();
@@ -333,7 +333,7 @@ public final class SASLAuthentication {
         return lastUsedMech.getName();
     }
 
-    private SASLMechanism selectMechanism() throws SmackException {
+    private SASLMechanism selectMechanism(boolean authzidNeeded) throws SmackException {
         Iterator<SASLMechanism> it = REGISTERED_MECHANISMS.iterator();
         final List<String> serverMechanisms = getServerMechanisms();
         if (serverMechanisms.isEmpty()) {
@@ -350,6 +350,11 @@ public final class SASLAuthentication {
             }
             if (!configuration.isEnabledSaslMechanism(mechanismName)) {
                 continue;
+            }
+            if (authzidNeeded || configuration.getAuthzid() != null) {
+                if (!mechanism.authzidSupported()) {
+                    continue;
+                }
             }
             if (serverMechanisms.contains(mechanismName)) {
                 // Create a new instance of the SASLMechanism for every authentication attempt.

--- a/smack-core/src/main/java/org/jivesoftware/smack/SASLAuthentication.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SASLAuthentication.java
@@ -25,6 +25,7 @@ import org.jivesoftware.smack.sasl.SASLMechanism;
 import org.jivesoftware.smack.sasl.packet.SaslStreamElements.SASLFailure;
 import org.jivesoftware.smack.sasl.packet.SaslStreamElements.Success;
 import org.jxmpp.jid.DomainBareJid;
+import org.jxmpp.jid.BareJid;
 
 import javax.security.auth.callback.CallbackHandler;
 
@@ -180,6 +181,31 @@ public final class SASLAuthentication {
     public void authenticate(String username, String password)
                     throws XMPPErrorException, SASLErrorException, IOException,
                     SmackException, InterruptedException {
+      this.authenticate(null, username, password);
+    }
+
+    /**
+     * Performs SASL authentication of the specified user. If SASL authentication was successful
+     * then resource binding and session establishment will be performed. This method will return
+     * the full JID provided by the server while binding a resource to the connection.<p>
+     *
+     * The server may assign a full JID with a username or resource different than the requested
+     * by this method.
+     *
+     * This variant allows the caller to specify an explicit authorization identifier.
+     *
+     * @param authzid the authorization identifier (typically null).
+     * @param username the username that is authenticating with the server.
+     * @param password the password to send to the server.
+     * @throws XMPPErrorException
+     * @throws SASLErrorException
+     * @throws IOException
+     * @throws SmackException
+     * @throws InterruptedException
+     */
+    public void authenticate(BareJid authzid, String username, String password)
+                    throws XMPPErrorException, SASLErrorException, IOException,
+                    SmackException, InterruptedException {
         currentMechanism = selectMechanism();
         final CallbackHandler callbackHandler = configuration.getCallbackHandler();
         final String host = connection.getHost();
@@ -187,10 +213,10 @@ public final class SASLAuthentication {
 
         synchronized (this) {
             if (callbackHandler != null) {
-                currentMechanism.authenticate(host, xmppServiceDomain, callbackHandler);
+                currentMechanism.authenticate(authzid, host, xmppServiceDomain, callbackHandler);
             }
             else {
-                currentMechanism.authenticate(username, host, xmppServiceDomain, password);
+                currentMechanism.authenticate(authzid, username, host, xmppServiceDomain, password);
             }
             // Wait until SASL negotiation finishes
             wait(connection.getPacketReplyTimeout());

--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
@@ -35,9 +35,9 @@ import javax.security.auth.callback.CallbackHandler;
  *  <li>{@link #getName()} -- returns the common name of the SASL mechanism.</li>
  * </ul>
  * Subclasses will likely want to implement their own versions of these methods:
- *  <li>{@link #authenticate(String, String, DomainBareJid, String)} -- Initiate authentication stanza using the
+ *  <li>{@link #authenticate(BareJid, String, String, DomainBareJid, String)} -- Initiate authentication stanza using the
  *  deprecated method.</li>
- *  <li>{@link #authenticate(String, DomainBareJid, CallbackHandler)} -- Initiate authentication stanza
+ *  <li>{@link #authenticate(BareJid, String, DomainBareJid, CallbackHandler)} -- Initiate authentication stanza
  *  using the CallbackHandler method.</li>
  *  <li>{@link #challengeReceived(String, boolean)} -- Handle a challenge from the server.</li>
  * </ul>
@@ -123,7 +123,7 @@ public abstract class SASLMechanism implements Comparable<SASLMechanism> {
     /**
      * Builds and sends the <tt>auth</tt> stanza to the server. Note that this method of
      * authentication is not recommended, since it is very inflexible. Use
-     * {@link #authenticate(String, DomainBareJid, CallbackHandler)} whenever possible.
+     * {@link #authenticate(BareJid, String, DomainBareJid, CallbackHandler)} whenever possible.
      * 
      * Explanation of auth stanza:
      * 

--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/SCRAMSHA1Mechanism.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/SCRAMSHA1Mechanism.java
@@ -38,7 +38,6 @@ public class SCRAMSHA1Mechanism extends SASLMechanism {
     public static final String NAME = "SCRAM-SHA-1";
 
     private static final int RANDOM_ASCII_BYTE_COUNT = 32;
-    private static final String DEFAULT_GS2_HEADER = "n,";
     private static final byte[] CLIENT_KEY_BYTES = toBytes("Client Key");
     private static final byte[] SERVER_KEY_BYTES = toBytes("Server Key");
     private static final byte[] ONE = new byte[] { 0, 0, 0, 1 };
@@ -71,13 +70,21 @@ public class SCRAMSHA1Mechanism extends SASLMechanism {
     protected void authenticateInternal(CallbackHandler cbh) throws SmackException {
         throw new UnsupportedOperationException("CallbackHandler not (yet) supported");
     }
+    
+    private String getGS2Header() {
+        String authzidPortion = "";
+        if (authorizationId != null) {
+            authzidPortion = "a=" + authorizationId.toString();
+        }
+        return "n," + authzidPortion + ",";
+    }
 
     @Override
     protected byte[] getAuthenticationText() throws SmackException {
         clientRandomAscii = getRandomAscii();
         String saslPrepedAuthcId = saslPrep(authenticationId);
         clientFirstMessageBare = "n=" + escape(saslPrepedAuthcId) + ",r=" + clientRandomAscii;
-        String clientFirstMessage = DEFAULT_GS2_HEADER + clientFirstMessageBare;
+        String clientFirstMessage = getGS2Header() + clientFirstMessageBare;
         state = State.AUTH_TEXT_SENT;
         return toBytes(clientFirstMessage);
     }
@@ -148,7 +155,7 @@ public class SCRAMSHA1Mechanism extends SASLMechanism {
             // Parsing and error checking is done, we can now begin to calculate the values
 
             // First the client-final-message-without-proof
-            String clientFinalMessageWithoutProof = "c=" + Base64.encode(DEFAULT_GS2_HEADER) + ",r=" + rvalue;
+            String clientFinalMessageWithoutProof = "c=" + Base64.encode(getGS2Header()) + ",r=" + rvalue;
 
             // AuthMessage := client-first-message-bare + "," + server-first-message + "," +
             // client-final-message-without-proof

--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/SCRAMSHA1Mechanism.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/SCRAMSHA1Mechanism.java
@@ -38,7 +38,7 @@ public class SCRAMSHA1Mechanism extends SASLMechanism {
     public static final String NAME = "SCRAM-SHA-1";
 
     private static final int RANDOM_ASCII_BYTE_COUNT = 32;
-    private static final String DEFAULT_GS2_HEADER = "n,,";
+    private static final String DEFAULT_GS2_HEADER = "n,";
     private static final byte[] CLIENT_KEY_BYTES = toBytes("Client Key");
     private static final byte[] SERVER_KEY_BYTES = toBytes("Server Key");
     private static final byte[] ONE = new byte[] { 0, 0, 0, 1 };

--- a/smack-core/src/test/java/org/jivesoftware/smack/sasl/DigestMd5SaslTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/sasl/DigestMd5SaslTest.java
@@ -37,8 +37,12 @@ public class DigestMd5SaslTest extends AbstractSaslTest {
         super(saslMechanism);
     }
 
-    protected void runTest() throws NotConnectedException, SmackException, InterruptedException, XmppStringprepException {
-        saslMechanism.authenticate("florian", "irrelevant", JidCreate.domainBareFrom("xmpp.org"), "secret");
+    protected void runTest(boolean useAuthzid) throws NotConnectedException, SmackException, InterruptedException, XmppStringprepException {
+        if (useAuthzid) {
+            saslMechanism.authenticate(JidCreate.bareFrom("shazbat@xmpp.org"), "florian", "irrelevant", JidCreate.domainBareFrom("xmpp.org"), "secret");
+        } else {
+            saslMechanism.authenticate(null, "florian", "irrelevant", JidCreate.domainBareFrom("xmpp.org"), "secret");
+        }
 
         byte[] response = saslMechanism.evaluateChallenge(challengeBytes);
         String responseString = new String(response);
@@ -50,6 +54,11 @@ public class DigestMd5SaslTest extends AbstractSaslTest {
             String key = keyValue[0];
             String value = keyValue[1].replace("\"", "");
             responsePairs.put(key, value);
+        }
+        if (useAuthzid) {
+          assertMapValue("authzid", "shazbat@xmpp.org", responsePairs);
+        } else {
+          assert(!responsePairs.containsKey("authzid"));
         }
         assertMapValue("username", "florian", responsePairs);
         assertMapValue("realm", "xmpp.org", responsePairs);

--- a/smack-core/src/test/java/org/jivesoftware/smack/sasl/DigestMd5SaslTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/sasl/DigestMd5SaslTest.java
@@ -27,6 +27,7 @@ import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.stringprep.XmppStringprepException;
+import org.jxmpp.jid.BareJid;
 
 public class DigestMd5SaslTest extends AbstractSaslTest {
 
@@ -39,7 +40,9 @@ public class DigestMd5SaslTest extends AbstractSaslTest {
 
     protected void runTest(boolean useAuthzid) throws NotConnectedException, SmackException, InterruptedException, XmppStringprepException {
         if (useAuthzid) {
-            saslMechanism.authenticate(JidCreate.bareFrom("shazbat@xmpp.org"), "florian", "irrelevant", JidCreate.domainBareFrom("xmpp.org"), "secret");
+            BareJid authzid = JidCreate.entityBareFrom("shazbat@xmpp.org");
+            assertEquals("shazbat@xmpp.org", authzid.toString());
+            saslMechanism.authenticate(authzid, "florian", "irrelevant", JidCreate.domainBareFrom("xmpp.org"), "secret");
         } else {
             saslMechanism.authenticate(null, "florian", "irrelevant", JidCreate.domainBareFrom("xmpp.org"), "secret");
         }
@@ -67,6 +70,6 @@ public class DigestMd5SaslTest extends AbstractSaslTest {
     }
 
     private static void assertMapValue(String key, String value, Map<String, String> map) {
-        assertEquals(map.get(key), value);
+        assertEquals(value, map.get(key));
     }
 }

--- a/smack-core/src/test/java/org/jivesoftware/smack/sasl/core/SCRAMSHA1MechanismTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/sasl/core/SCRAMSHA1MechanismTest.java
@@ -48,7 +48,7 @@ public class SCRAMSHA1MechanismTest extends SmackTestSuite {
             }
         };
 
-        mech.authenticate(USERNAME, "unusedFoo", JidTestUtil.DOMAIN_BARE_JID_1, PASSWORD);
+        mech.authenticate(null, USERNAME, "unusedFoo", JidTestUtil.DOMAIN_BARE_JID_1, PASSWORD);
         AuthMechanism authMechanism = con.getSentPacket();
         assertEquals(SCRAMSHA1Mechanism.NAME, authMechanism.getMechanism());
         assertEquals(CLIENT_FIRST_MESSAGE, saslLayerString(authMechanism.getAuthenticationText()));

--- a/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLDigestMD5Mechanism.java
+++ b/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLDigestMD5Mechanism.java
@@ -25,6 +25,11 @@ public class SASLDigestMD5Mechanism extends SASLJavaXMechanism {
 
     public static final String NAME = DIGESTMD5;
 
+    @Override
+    public boolean authzidSupported() {
+      return true;
+    }
+
     public String getName() {
         return NAME;
     }

--- a/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLExternalMechanism.java
+++ b/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLExternalMechanism.java
@@ -47,6 +47,11 @@ public class SASLExternalMechanism extends SASLJavaXMechanism  {
     public static final String NAME = EXTERNAL;
 
     @Override
+    public boolean authzidSupported() {
+      return true;
+    }
+
+    @Override
     public String getName() {
         return EXTERNAL;
     }

--- a/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLGSSAPIMechanism.java
+++ b/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLGSSAPIMechanism.java
@@ -35,6 +35,11 @@ public class SASLGSSAPIMechanism extends SASLJavaXMechanism {
     }
 
     @Override
+    public boolean authzidSupported() {
+      return true;
+    }
+
+    @Override
     public String getName() {
         return NAME;
     }

--- a/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLJavaXMechanism.java
+++ b/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLJavaXMechanism.java
@@ -54,7 +54,7 @@ public abstract class SASLJavaXMechanism extends SASLMechanism {
         String[] mechanisms = { getName() };
         Map<String, String> props = getSaslProps();
         try {
-            sc = Sasl.createSaslClient(mechanisms, null, "xmpp", getServerName().toString(), props,
+            sc = Sasl.createSaslClient(mechanisms, authorizationId.toString(), "xmpp", getServerName().toString(), props,
                             new CallbackHandler() {
                                 @Override
                                 public void handle(Callback[] callbacks) throws IOException,

--- a/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLJavaXMechanism.java
+++ b/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLJavaXMechanism.java
@@ -53,8 +53,12 @@ public abstract class SASLJavaXMechanism extends SASLMechanism {
                     throws SmackException {
         String[] mechanisms = { getName() };
         Map<String, String> props = getSaslProps();
+        String authzid = null;
+        if (authorizationId != null) {
+            authzid = authorizationId.toString();
+        }
         try {
-            sc = Sasl.createSaslClient(mechanisms, authorizationId.toString(), "xmpp", getServerName().toString(), props,
+            sc = Sasl.createSaslClient(mechanisms, authzid, "xmpp", getServerName().toString(), props,
                             new CallbackHandler() {
                                 @Override
                                 public void handle(Callback[] callbacks) throws IOException,

--- a/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLPlainMechanism.java
+++ b/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLPlainMechanism.java
@@ -30,6 +30,11 @@ public class SASLPlainMechanism extends SASLJavaXMechanism {
     }
 
     @Override
+    public boolean authzidSupported() {
+      return true;
+    }
+
+    @Override
     public int getPriority() {
         return 400;
     }

--- a/smack-sasl-javax/src/test/java/org/jivesoftware/smack/sasl/javax/SASLDigestMD5Test.java
+++ b/smack-sasl-javax/src/test/java/org/jivesoftware/smack/sasl/javax/SASLDigestMD5Test.java
@@ -30,6 +30,11 @@ public class SASLDigestMD5Test extends DigestMd5SaslTest {
 
     @Test
     public void testDigestMD5() throws NotConnectedException, SmackException, InterruptedException, XmppStringprepException {
-        runTest();
+        runTest(false);
+    }
+
+    @Test
+    public void testDigestMD5Authzid() throws NotConnectedException, SmackException, InterruptedException, XmppStringprepException {
+        runTest(true);
     }
 }

--- a/smack-sasl-provided/src/main/java/org/jivesoftware/smack/sasl/provided/SASLDigestMD5Mechanism.java
+++ b/smack-sasl-provided/src/main/java/org/jivesoftware/smack/sasl/provided/SASLDigestMD5Mechanism.java
@@ -83,6 +83,11 @@ public class SASLDigestMD5Mechanism extends SASLMechanism {
         return new SASLDigestMD5Mechanism();
     }
 
+    @Override
+    public boolean authzidSupported() {
+      return true;
+    }
+
 
     @Override
     public void checkIfSuccessfulOrThrow() throws SmackException {
@@ -141,7 +146,14 @@ public class SASLDigestMD5Mechanism extends SASLMechanism {
             String responseValue = calcResponse(DigestType.ClientResponse);
             // @formatter:off
             // See RFC 2831 2.1.2 digest-response
+            String authzid;
+            if (authorizationId == null) {
+              authzid = "";
+            } else {
+              authzid = ",authzid=\"" + authorizationId.toString() + '"';
+            }
             String saslString = "username=\"" + authenticationId + '"'
+                               + authzid
                                + ",realm=\"" + serviceName + '"'
                                + ",nonce=\"" + nonce + '"'
                                + ",cnonce=\"" + cnonce + '"'

--- a/smack-sasl-provided/src/main/java/org/jivesoftware/smack/sasl/provided/SASLExternalMechanism.java
+++ b/smack-sasl-provided/src/main/java/org/jivesoftware/smack/sasl/provided/SASLExternalMechanism.java
@@ -40,6 +40,10 @@ public class SASLExternalMechanism extends SASLMechanism {
 
     @Override
     protected byte[] getAuthenticationText() throws SmackException {
+        if (authorizationId != null) {
+          return toBytes(authorizationId.toString());
+        }
+
         if (StringUtils.isNullOrEmpty(authenticationId)) {
             return null;
         }
@@ -65,6 +69,11 @@ public class SASLExternalMechanism extends SASLMechanism {
     @Override
     public void checkIfSuccessfulOrThrow() throws SmackException {
         // No check performed
+    }
+
+    @Override
+    public boolean authzidSupported() {
+      return true;
     }
 
 }

--- a/smack-sasl-provided/src/main/java/org/jivesoftware/smack/sasl/provided/SASLPlainMechanism.java
+++ b/smack-sasl-provided/src/main/java/org/jivesoftware/smack/sasl/provided/SASLPlainMechanism.java
@@ -34,7 +34,13 @@ public class SASLPlainMechanism extends SASLMechanism {
     @Override
     protected byte[] getAuthenticationText() throws SmackException {
         // concatenate and encode username (authcid) and password
-        byte[] authcid = toBytes('\u0000' + authenticationId);
+        String authzid;
+        if (authorizationId == null) {
+          authzid = "";
+        } else {
+          authzid = authorizationId.toString();
+        }
+        byte[] authcid = toBytes(authzid + '\u0000' + authenticationId);
         byte[] passw = toBytes('\u0000' + password);
 
         return ByteUtils.concact(authcid, passw);
@@ -58,5 +64,10 @@ public class SASLPlainMechanism extends SASLMechanism {
     @Override
     public void checkIfSuccessfulOrThrow() throws SmackException {
         // No check performed
+    }
+    
+    @Override
+    public boolean authzidSupported() {
+      return true;
     }
 }

--- a/smack-sasl-provided/src/test/java/org/jivesoftware/smack/sasl/provided/SASLDigestMD5Test.java
+++ b/smack-sasl-provided/src/test/java/org/jivesoftware/smack/sasl/provided/SASLDigestMD5Test.java
@@ -29,6 +29,11 @@ public class SASLDigestMD5Test extends DigestMd5SaslTest {
 
     @Test
     public void testDigestMD5() throws NotConnectedException, SmackException, InterruptedException, XmppStringprepException {
-        runTest();
+        runTest(false);
+    }
+
+    @Test
+    public void testDigestMD5Authzid() throws NotConnectedException, SmackException, InterruptedException, XmppStringprepException {
+        runTest(true);
     }
 }


### PR DESCRIPTION
This adds the ability to provide a distinct authorization identifier for use
by SASL mechanisms. Not all SASL mechanisms support this operation, in
particular CRAM-MD5.

Both the javax and provided SASL implementations are extended, and an authzid
parameter added to the authenticate method. Alternate methods are provided to
avoid API change.

The authorization identifier is passed as a BareJid in order to assure the
correct form.