### PR TITLE
Chat state manager issue

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/chatstates/ChatStateManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/chatstates/ChatStateManager.java
@@ -176,6 +176,10 @@ public final class ChatStateManager extends Manager {
                 return;
             }
 
+            if (DelayInformation.from(message) != null) {
+               return;
+            }
+
             ChatState state;
             try {
                 state = ChatState.valueOf(extension.getElementName());


### PR DESCRIPTION
Many servers like ejabberd allows messages with empty body to be stored offline. XEP-160 is not correctly implemented since they are also storing chatstates -  https://github.com/processone/ejabberd/issues/842

With customchatlistener there is no way to remove states which are from offline stores since message is not passed to onstatechanged. So in chatstatemanager removing any chatstate which have delay element.
