### PR TITLE
Chat state manager issue

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/chatstates/ChatStateManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/chatstates/ChatStateManager.java
@@ -35,6 +35,7 @@ import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smackx.chatstates.packet.ChatStateExtension;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
+import org.jivesoftware.smackx.delay.packet.DelayInformation;
 
 /**
  * Handles chat state for all chats on a particular XMPPConnection. This class manages both the
@@ -174,6 +175,10 @@ public final class ChatStateManager extends Manager {
             ExtensionElement extension = message.getExtension(NAMESPACE);
             if (extension == null) {
                 return;
+            }
+
+            if (DelayInformation.from(message) != null) {
+               return;
             }
 
             ChatState state;


### PR DESCRIPTION
Many servers like ejabberd allows messages with empty body to be stored offline. XEP-160 is not correctly implemented since they are also storing chatstates - processone/ejabberd#842

With customchatlistener there is no way to remove states which are from offline stores since message is not passed to onstatechanged. So in chatstatemanager removing any chatstate which have delay element.
