### PR TITLE
Uses the host and port from the ConnectionConfiguration object and no…

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -195,7 +195,7 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
         if (!connected && !done) {
             done = true;
             String errorMessage = "Timeout reached for the connection to " 
-                    + getHost() + ":" + getPort() + ".";
+                    + config.getHost() + ":" + config.getPort() + ".";
             throw new SmackException(errorMessage);
         }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
@@ -173,6 +173,22 @@ public abstract class ConnectionConfiguration {
     }
 
     /**
+     * Returns the hostname used by this configuration.
+     * @return the hostname.
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Returns the port number used by this configuration.
+     * @return the port number.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
      * Returns the TLS security mode used when making the connection. By default,
      * the mode is {@link SecurityMode#ifpossible}.
      *


### PR DESCRIPTION
…t from the

XMPPConnection object, because the latter were observed to not be
initialized when the log is printed, resulting in the following log:
"Timeout reached for the connection to null:0."

Note that this was seen in Smack 4.07, the current version was not
tested, as we don't have an easy way to do that.