### PR TITLE
Changes to send service-unavailable for not handled iq.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -1049,9 +1049,9 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
                         return;
                     }
                     // If the IQ stanza is of type "get" or "set" with no registered IQ request handler, then answer an
-                    // IQ of type "error" with code 501 ("feature-not-implemented")
+                    // IQ of type "error" with code 501 ("service_unavailable")
                     ErrorIQ errorIQ = IQ.createErrorResponse(iq, new XMPPError(
-                                    XMPPError.Condition.feature_not_implemented));
+                                    XMPPError.Condition.service_unavailable));
                     try {
                         sendStanza(errorIQ);
                     }


### PR DESCRIPTION
Changes to send service-unavailable for not handled iq as said in RFC6120. https://tools.ietf.org/html/rfc6120#page-128