### PR TITLE
Fixes sending pubsub events for empty item.

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/Node.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/Node.java
@@ -740,6 +740,10 @@ abstract public class Node
 				{
 					List<ExtensionElement> secondLevelList = ((EmbeddedPacketExtension)embedEvent).getExtensions();
 
+					// XEP-0060 allows no elements on second level  
+					if(secondLevelList.size() == 0)
+						return true;
+
 					if (secondLevelList.size() > 0 && secondLevelList.get(0).getElementName().equals(secondElement))
 						return true;
 				}


### PR DESCRIPTION
XEP-0060 allows no elements on second level of nodes.