### PR TITLE
android build fixed

### DIFF
--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -669,7 +669,9 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         KeyManager[] kms = null;
         PasswordCallback pcb = null;
 
-        if (context == null) {
+        if(config.getCallbackHandler() == null) {
+            ks = null;
+        } else if (context == null) {
             if(config.getKeystoreType().equals("PKCS11")) {
                 try {
                     Constructor<?> c = Class.forName("sun.security.pkcs11.SunPKCS11").getConstructor(InputStream.class);


### PR DESCRIPTION
build for android cannot establish TLS connection because lines from
patch were dropped in 640849da. Earlier these changes were added in 7ceb5f09.