### PR TITLE
XMPPTCPConnection - setEnabledSSLProtocols/ ciphers can never work

### DIFF
--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -742,12 +742,12 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         // Secure the plain connection
         socket = context.getSocketFactory().createSocket(plain,
                 host, plain.getPort(), true);
-        // Initialize the reader and writer with the new secured version
-        initReaderAndWriter();
 
         final SSLSocket sslSocket = (SSLSocket) socket;
         TLSUtils.setEnabledProtocolsAndCiphers(sslSocket, config.getEnabledSSLProtocols(), config.getEnabledSSLCiphers());
 
+        // Initialize the reader and writer with the new secured version
+        initReaderAndWriter();
         // Proceed to do the handshake
         sslSocket.startHandshake();
 


### PR DESCRIPTION
Hi,
when i was trying to force usage of TLSv1.2, I found out that setting enabledSSLProtocols and enabledSSLCiphers in XMPPTCPConnectionConfiguration can never work.

It is because of opening input/output stream on the socket before setting the parameters - implicit handshake session is created (without the custom params) and used for the handshake.

More info here:
http://stackoverflow.com/questions/13943351/how-to-specify-the-ciphersuite-to-be-used-in-ssl-session
http://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLSocket.html

Thanks!