### PR TITLE
 NullPointerException on JingleManager  

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/time/EntityTimeManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/time/EntityTimeManager.java
@@ -108,6 +108,8 @@ public class EntityTimeManager extends Manager {
             return null;
 
         Time request = new Time();
+        // TODO Add Time(Jid) constructor and use this constructor instead
+        request.setTo(jid);
         Time response = (Time) connection().createPacketCollectorAndSend(request).nextResultOrThrow();
         return response;
     }

--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
@@ -897,6 +897,18 @@ public class Roster extends Manager {
     }
 
     /**
+     * Sets if the roster will be loaded from the server when logging in for newly created instances
+     * of {@link Roster}.
+     *
+     * @param rosterLoadedAtLoginDefault if the roster will be loaded from the server when logging in.
+     * @see #setRosterLoadedAtLogin(boolean)
+     * @since 4.1.7
+     */
+    public static void setRosterLoadedAtLoginDefault(boolean rosterLoadedAtLoginDefault) {
+        Roster.rosterLoadedAtLoginDefault = rosterLoadedAtLoginDefault;
+    }
+
+    /**
      * Sets if the roster will be loaded from the server when logging in. This
      * is the common behaviour for clients but sometimes clients may want to differ this
      * or just never do it if not interested in rosters.

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -751,11 +751,15 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         // Secure the plain connection
         socket = context.getSocketFactory().createSocket(plain,
                 host, plain.getPort(), true);
-        // Initialize the reader and writer with the new secured version
-        initReaderAndWriter();
 
         final SSLSocket sslSocket = (SSLSocket) socket;
+        // Immediately set the enabled SSL protocols and ciphers. See SMACK-712 why this is
+        // important (at least on certain platforms) and it seems to be a good idea anyways to
+        // prevent an accidental implicit handshake.
         TLSUtils.setEnabledProtocolsAndCiphers(sslSocket, config.getEnabledSSLProtocols(), config.getEnabledSSLCiphers());
+
+        // Initialize the reader and writer with the new secured version
+        initReaderAndWriter();
 
         // Proceed to do the handshake
         sslSocket.startHandshake();

--- a/version.gradle
+++ b/version.gradle
@@ -1,7 +1,7 @@
 allprojects {
 	ext {
-		shortVersion = '4.1.6'
-		isSnapshot = false
+		shortVersion = '4.1.7'
+		isSnapshot = true
 		jxmppVersion = '0.4.2'
 		smackMinAndroidSdk = 8
 	}


### PR DESCRIPTION
FATAL EXCEPTION: Smack-Incoming Processor 0 (0)
                                                                        java.lang.NullPointerException
                                                                            at org.jivesoftware.smackx.jingleold.JingleManager$3.accept(JingleManager.java:452)
                                                                            at org.jivesoftware.smack.AbstractXMPPConnection$ListenerWrapper.filterMatches(AbstractXMPPConnection.java:1242)
                                                                            at org.jivesoftware.smack.AbstractXMPPConnection.invokePacketCollectorsAndNotifyRecvListeners(AbstractXMPPConnection.java:1094)
                                                                            at org.jivesoftware.smack.AbstractXMPPConnection$ListenerNotification.run(AbstractXMPPConnection.java:999)
                                                                            at org.jivesoftware.smack.util.BoundedThreadPoolExecutor$1.run(BoundedThreadPoolExecutor.java:48)
                                                                            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1076)
                                                                            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:569)
                                                                            at java.lang.Thread.run(Thread.java:856)
