### PR TITLE
Implementation of XEP-0308: Last Message Correction

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/MessageCorrectExtension.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/MessageCorrectExtension.java
@@ -1,0 +1,105 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.message_correct;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+/**
+ * An Extension that implements XEP-0308: Last Message Correction
+ * 
+ * This extension is expected to be added to message stanzas. Please refer to
+ * the XEP for more implementation guidelines.
+ * 
+ * @author Fernando Ramirez, f.e.ramirez94@gmail.com
+ * @see <a href="http://xmpp.org/extensions/xep-0308.html">XEP-0308:&nbsp;Last&
+ *      nbsp;Message&nbsp;Correction</a>
+ */
+public class MessageCorrectExtension implements ExtensionElement {
+
+    /**
+     * The XML element name of a 'message correct' extension.
+     */
+    public static final String ELEMENT = "replace";
+
+    /**
+     * The namespace that qualifies the XML element of a 'message correct'
+     * extension.
+     */
+    public static final String NAMESPACE = "urn:xmpp:message-correct:0";
+
+    /**
+     * The id tag of a 'message correct' extension.
+     */
+    public static final String ID_TAG = "id";
+
+    /**
+     * The id of the message to correct.
+     */
+    private String idInitialMessage;
+
+    public MessageCorrectExtension(String idInitialMessage) {
+        this.setIdInitialMessage(idInitialMessage);
+    }
+
+    public String getIdInitialMessage() {
+        return idInitialMessage;
+    }
+
+    public void setIdInitialMessage(String idInitialMessage) {
+        this.idInitialMessage = idInitialMessage;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jivesoftware.smack.packet.PacketExtension#getElementName()
+     */
+    @Override
+    public String getElementName() {
+        return ELEMENT;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jivesoftware.smack.packet.PacketExtension#toXML()
+     */
+    @Override
+    public XmlStringBuilder toXML() {
+        XmlStringBuilder xml = new XmlStringBuilder(this);
+        xml.attribute(ID_TAG, getIdInitialMessage());
+        xml.closeEmptyElement();
+        return xml;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jivesoftware.smack.packet.PacketExtension#getNamespace()
+     */
+    @Override
+    public String getNamespace() {
+        return NAMESPACE;
+    }
+
+    public static MessageCorrectExtension from(Message message) {
+        return message.getExtension(ELEMENT, NAMESPACE);
+    }
+
+}

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/package-info.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/package-info.java
@@ -1,0 +1,21 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes and Interfaces that implement Last Message Correction as defined in XEP-0308.
+ */
+package org.jivesoftware.smackx.message_correct;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/provider/MessageCorrectProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/provider/MessageCorrectProvider.java
@@ -1,0 +1,42 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.message_correct.provider;
+
+import java.io.IOException;
+
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smackx.message_correct.MessageCorrectExtension;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+/**
+ * A ExtensionElementProvider for the MessageCorrectExtension. As
+ * MessageCorrection elements have only the ID of the message to replace.
+ * 
+ * @author Fernando Ramirez, f.e.ramirez94@gmail.com
+ */
+public class MessageCorrectProvider extends ExtensionElementProvider<MessageCorrectExtension> {
+
+    @Override
+    public MessageCorrectExtension parse(XmlPullParser parser, int initialDepth)
+            throws XmlPullParserException, IOException, SmackException {
+        String idMessageToReplace = parser.getAttributeValue("", MessageCorrectExtension.ID_TAG);
+        return new MessageCorrectExtension(idMessageToReplace);
+    }
+
+}

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/provider/package-info.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/provider/package-info.java
@@ -1,0 +1,17 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.message_correct.provider;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/message_correct/MessageCorrectExtensionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/message_correct/MessageCorrectExtensionTest.java
@@ -1,0 +1,51 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.message_correct;
+
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.util.PacketParserUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MessageCorrectExtensionTest {
+
+    private Message initialMessage;
+
+    private final String idInitialMessage = "bad1";
+
+    private final String initialMessageXml = "<message to='juliet@capulet.net/balcony' id='good1'>"
+            + "<body>But soft, what light through yonder window breaks?</body>" + "</message>";
+
+    private final CharSequence messageCorrectionXml = "<replace xmlns='urn:xmpp:message-correct:0' id='bad1'/>";
+
+    private final CharSequence expectedXml = "<message to='juliet@capulet.net/balcony' id='good1'>"
+            + "<body>But soft, what light through yonder window breaks?</body>"
+            + "<replace xmlns='urn:xmpp:message-correct:0' id='bad1'/>" + "</message>";
+
+    @Test
+    public void checkStanzas() throws Exception {
+        initialMessage = (Message) PacketParserUtils.parseStanza(initialMessageXml);
+        MessageCorrectExtension messageCorrectExtension = new MessageCorrectExtension(idInitialMessage);
+
+        Assert.assertEquals(messageCorrectExtension.toXML().toString(), messageCorrectionXml);
+
+        initialMessage.addExtension(messageCorrectExtension);
+
+        Assert.assertEquals(initialMessage.toXML(), expectedXml);
+    }
+
+}


### PR DESCRIPTION
## **Fixes SMACK-714**
Documentation: https://xmpp.org/extensions/xep-0308.html

**How to use it**

Send: 
`message.addExtension(new MessageCorrectExtension(idInitialMessage));`

Receive:
`ProviderManager.addExtensionProvider(MessageCorrectExtension.ELEMENT_NAME, MessageCorrectExtension.NAMESPACE, new MessageCorrectProvider());`

`MessageCorrectExtension messageCorrectExtension = MessageCorrectExtension.from(message)`