### PR TITLE
Invalid presence priority should not crash connection

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
@@ -185,15 +185,15 @@ public final class Presence extends Stanza implements TypedCloneable<Presence> {
     }
 
     /**
-     * Sets the priority of the presence. The valid range is -128 through 128.
+     * Sets the priority of the presence. The valid range is -128 through 127.
      *
      * @param priority the priority of the presence.
      * @throws IllegalArgumentException if the priority is outside the valid range.
      */
     public void setPriority(int priority) {
-        if (priority < -128 || priority > 128) {
+        if (priority < -128 || priority > 127) {
             throw new IllegalArgumentException("Priority value " + priority +
-                    " is not valid. Valid range is -128 through 128.");
+                    " is not valid. Valid range is -128 through 127.");
         }
         this.priority = priority;
     }

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
@@ -550,8 +550,15 @@ public class PacketParserUtils {
                     presence.setStatus(parser.nextText());
                     break;
                 case "priority":
-                    int priority = Integer.parseInt(parser.nextText());
-                    presence.setPriority(priority);
+                    String value = parser.nextText();
+                    try {
+                        int priority = Integer.parseInt(value);
+                        presence.setPriority(priority);
+                    } catch (Exception e) {
+                        LOGGER.warning("Invalid priority value '" + value + "' in Presence stanza from '"
+                                        + presence.getFrom() + "' id: '" + presence.getStanzaId()
+                                        + "': \"" + e + "\"");
+                    }
                     break;
                 case "show":
                     String modeText = parser.nextText();


### PR DESCRIPTION
Packet parsing causes the connection to be disconnected when a presence stanza is parsed that contains an invalid priority value. Instead, the invalid value should be handled in a non-fatal way (similar as to how other problems are handled).