### PR TITLE
Attribute Support On ExtensionElement Added

### DIFF
--- a/smack-android/src/main/java/org/jivesoftware/smack/android/AndroidSmackInitializer.java
+++ b/smack-android/src/main/java/org/jivesoftware/smack/android/AndroidSmackInitializer.java
@@ -16,8 +16,6 @@
  */
 package org.jivesoftware.smack.android;
 
-import java.util.List;
-
 import org.apache.http.conn.ssl.StrictHostnameVerifier;
 import org.jivesoftware.smack.SmackConfiguration;
 import org.jivesoftware.smack.initializer.SmackInitializer;
@@ -25,6 +23,8 @@ import org.jivesoftware.smack.util.stringencoder.Base64;
 import org.jivesoftware.smack.util.stringencoder.Base64UrlSafeEncoder;
 import org.jivesoftware.smack.util.stringencoder.android.AndroidBase64Encoder;
 import org.jivesoftware.smack.util.stringencoder.android.AndroidBase64UrlSafeEncoder;
+
+import java.util.List;
 
 public class AndroidSmackInitializer implements SmackInitializer {
 

--- a/smack-android/src/main/java/org/jivesoftware/smack/util/stringencoder/android/AndroidBase64Encoder.java
+++ b/smack-android/src/main/java/org/jivesoftware/smack/util/stringencoder/android/AndroidBase64Encoder.java
@@ -1,13 +1,12 @@
 /**
- *
  * Copyright © 2014 Florian Schmaus
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +19,10 @@ import android.util.Base64;
 
 /**
  * A Base 64 encoding implementation based on android.util.Base64.
+ *
  * @author Florian Schmaus
  */
+
 public final class AndroidBase64Encoder implements org.jivesoftware.smack.util.stringencoder.Base64.Encoder {
 
     private static AndroidBase64Encoder instance = new AndroidBase64Encoder();

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/SimpleExtensionElement.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/SimpleExtensionElement.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 /**
  * Created by Sakib Sami on 5/19/16.
- * <p>
+ * <p/>
  * SimpleExtensionElement provides support
  * to add custom attribute to extension
  * alone with custom element support
@@ -20,13 +20,9 @@ public class SimpleExtensionElement implements ExtensionElement {
     private Map<String, String> attributes = new LinkedHashMap<>();
     private Map<String, String> elements = new LinkedHashMap<>();
 
-    private SimpleExtensionElement(String ELEMENT_NAME, String NAMESPACE) {
+    public SimpleExtensionElement(String ELEMENT_NAME, String NAMESPACE) {
         this.ELEMENT_NAME = ELEMENT_NAME;
         this.NAMESPACE = NAMESPACE;
-    }
-
-    public static SimpleExtensionElement getInstance(String ELEMENT_NAME, String NAMESPACE) {
-        return new SimpleExtensionElement(ELEMENT_NAME, NAMESPACE);
     }
 
     public void setAttribute(String name, String value) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/SimpleExtensionElement.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/SimpleExtensionElement.java
@@ -1,6 +1,5 @@
 package org.jivesoftware.smack.packet;
 
-import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.util.XmlStringBuilder;
 
 import java.util.LinkedHashMap;

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/SimpleExtensionElement.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/SimpleExtensionElement.java
@@ -1,0 +1,93 @@
+package org.jivesoftware.smack.packet;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created by Sakib Sami on 5/19/16.
+ * <p>
+ * SimpleExtensionElement provides support
+ * to add custom attribute to extension
+ * alone with custom element support
+ */
+
+public class SimpleExtensionElement implements ExtensionElement {
+    private String NAMESPACE;
+    private String ELEMENT_NAME;
+    private Map<String, String> attributes = new LinkedHashMap<>();
+    private Map<String, String> elements = new LinkedHashMap<>();
+
+    private SimpleExtensionElement(String ELEMENT_NAME, String NAMESPACE) {
+        this.ELEMENT_NAME = ELEMENT_NAME;
+        this.NAMESPACE = NAMESPACE;
+    }
+
+    public static SimpleExtensionElement getInstance(String ELEMENT_NAME, String NAMESPACE) {
+        return new SimpleExtensionElement(ELEMENT_NAME, NAMESPACE);
+    }
+
+    public void setAttribute(String name, String value) {
+        attributes.put(name, value);
+    }
+
+    public String getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    public void removeAttribute(String name) {
+        attributes.remove(name);
+    }
+
+    public void setElement(String name, String value) {
+        elements.put(name, value);
+    }
+
+    public String getElement(String name) {
+        return elements.get(name);
+    }
+
+    public void removeElement(String name) {
+        elements.remove(name);
+    }
+
+    public Set<String> getAttributeNames() {
+        return attributes.keySet();
+    }
+
+    public Set<String> getElementNames() {
+        return elements.keySet();
+    }
+
+    @Override
+    public CharSequence toXML() {
+        XmlStringBuilder builder = new XmlStringBuilder();
+        builder.halfOpenElement(ELEMENT_NAME);
+        if (getNamespace() != null)
+            builder.xmlnsAttribute(NAMESPACE);
+
+        for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+            builder.optAttribute(attribute.getKey(), attribute.getValue());
+        }
+        builder.rightAngleBracket();
+
+        for (Map.Entry<String, String> element : elements.entrySet()) {
+            builder.element(element.getKey(), element.getValue());
+        }
+        builder.closeElement(ELEMENT_NAME);
+        return builder;
+    }
+
+    @Override
+    public String getNamespace() {
+        return NAMESPACE;
+    }
+
+    @Override
+    public String getElementName() {
+        return ELEMENT_NAME;
+    }
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/SimpleExtensionElementProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/SimpleExtensionElementProvider.java
@@ -2,10 +2,9 @@ package org.jivesoftware.smack.provider;
 
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.packet.Element;
-import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smack.packet.SimpleExtensionElement;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
-import thegrunetwork.extensions.SimpleExtensionElement;
 
 import java.io.IOException;
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/SimpleExtensionElementProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/SimpleExtensionElementProvider.java
@@ -20,7 +20,7 @@ public class SimpleExtensionElementProvider extends ExtensionElementProvider {
 
     @Override
     public Element parse(XmlPullParser xmlPullParser, int i) throws XmlPullParserException, IOException, SmackException {
-        SimpleExtensionElement element = SimpleExtensionElement.getInstance(xmlPullParser.getName(), xmlPullParser.getNamespace());
+        SimpleExtensionElement element = new SimpleExtensionElement(xmlPullParser.getName(), xmlPullParser.getNamespace());
         for (int x = 0; x < xmlPullParser.getAttributeCount(); x++) {
             element.setAttribute(xmlPullParser.getAttributeName(x), xmlPullParser.getAttributeValue(x));
         }

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/SimpleExtensionElementProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/SimpleExtensionElementProvider.java
@@ -1,0 +1,55 @@
+package org.jivesoftware.smack.provider;
+
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.packet.Element;
+import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import thegrunetwork.extensions.SimpleExtensionElement;
+
+import java.io.IOException;
+
+/**
+ * Created by Sakib Sami on 5/19/16.
+ * <p>
+ * SimpleExtensionElementProvider provides support
+ * to add custom attribute to extension
+ * alone with custom element support
+ */
+
+public class SimpleExtensionElementProvider extends ExtensionElementProvider {
+
+    @Override
+    public Element parse(XmlPullParser xmlPullParser, int i) throws XmlPullParserException, IOException, SmackException {
+        SimpleExtensionElement element = SimpleExtensionElement.getInstance(xmlPullParser.getName(), xmlPullParser.getNamespace());
+        for (int x = 0; x < xmlPullParser.getAttributeCount(); x++) {
+            element.setAttribute(xmlPullParser.getAttributeName(x), xmlPullParser.getAttributeValue(x));
+        }
+        
+        int initialDepth = xmlPullParser.getDepth();
+        label29:
+        do {
+            while (true) {
+                int eventType = xmlPullParser.next();
+                switch (eventType) {
+                    case 2:
+                        String name = xmlPullParser.getName();
+                        if (xmlPullParser.isEmptyElementTag()) {
+                            element.setElement(name, "");
+                        } else {
+                            eventType = xmlPullParser.next();
+                            if (eventType == 4) {
+                                String value = xmlPullParser.getText();
+                                element.setElement(name, value);
+                            }
+                        }
+                        break;
+                    case 3:
+                        continue label29;
+                }
+            }
+        } while (xmlPullParser.getDepth() != initialDepth);
+
+        return element;
+    }
+}


### PR DESCRIPTION
There was no support for adding attribute on extension which is added.
Two new class added SimpleExtensionElement and SimpleExtensionElementProvider
To escape confusion I have created different classes.Also it will be flexible to use. No need to write parser in ExtensionElementProvider.

Uses : 
```
SimpleExtensionElement see = new SimpleExtensionElement("elementName", "nameSpace");
see.setAttribute("key", "value"); // to add attribute
see.setElement("key", "value"); // to add element
```

and in ProviderManager just add
`ProviderManager.addExtensionProvider("elementName", "nameSpace", new SimpleExtensionElementProvider();`

thats all. 