### PR TITLE
Token-based reconnection implementation

### DIFF
--- a/documentation/extensions/index.md
+++ b/documentation/extensions/index.md
@@ -15,7 +15,7 @@ Currently supported XEPs of Smack (all subprojects)
 | Name                                        | XEP                                                      | Description |
 |---------------------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | Nonzas  | [XEP-0360](http://xmpp.org/extensions/xep-0360.html) | Defines the term "Nonza", describing every top level stream element that is not a Stanza.                                         |
-| Token-based reconnection  | [XEP-xxxx](http://www.xmpp.org/extensions/inbox/token-reconnection.html) | Defines a token-based session authentication mechanism.                                         |
+| [Token-based reconnection](tokenreconnection.md)  | [XEP-xxxx](http://www.xmpp.org/extensions/inbox/token-reconnection.html) | Defines a token-based session authentication mechanism.                                         |
 
 
 Currently supported XEPs of smack-tcp

--- a/documentation/extensions/index.md
+++ b/documentation/extensions/index.md
@@ -15,6 +15,8 @@ Currently supported XEPs of Smack (all subprojects)
 | Name                                        | XEP                                                      | Description |
 |---------------------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | Nonzas  | [XEP-0360](http://xmpp.org/extensions/xep-0360.html) | Defines the term "Nonza", describing every top level stream element that is not a Stanza.                                         |
+| Token-based reconnection  | [XEP-xxxx](http://www.xmpp.org/extensions/inbox/token-reconnection.html) | Defines a token-based session authentication mechanism.                                         |
+
 
 Currently supported XEPs of smack-tcp
 -------------------------------------

--- a/documentation/extensions/tokenreconnection.md
+++ b/documentation/extensions/tokenreconnection.md
@@ -1,0 +1,50 @@
+Token-based reconnection
+========================
+
+Allows to manage communications blocking.
+
+  * Login with token
+  * Get tokens
+  * Get last refresh token from "success" nonza
+  * Avoid reconnection using token
+
+
+**XEP related:** [XEP-xxxx](http://www.xmpp.org/extensions/inbox/token-reconnection.html)
+
+
+Login with token
+----------------
+
+```
+xmppConnection.login(token, resourcepart);
+```
+*token* is a `String`
+
+*resourcepart* is a `Resourcepart`
+
+
+Get tokens
+----------
+
+```
+TBRManager tbrManager = TBRManager.getInstanceFor(xmppConnection);
+TBRTokens tbrTokens = tbrManager.getTokens();
+String accessToken = tbrTokens.getAccessToken();
+String refreshToken = tbrTokens.getRefreshToken();
+```
+
+
+Get last refresh token from "success" nonza
+-------------------------------------------
+
+```
+String refreshToken = xmppConnection.getXOAUTHLastRefreshToken();
+```
+
+
+Avoid reconnection using token
+------------------------------
+
+```
+xmppConnection.avoidTokenReconnection();
+```

--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -25,26 +25,6 @@ import java.io.Writer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.jivesoftware.smack.AbstractXMPPConnection;
-import org.jivesoftware.smack.SmackException;
-import org.jivesoftware.smack.SmackException.NotConnectedException;
-import org.jivesoftware.smack.SmackException.ConnectionException;
-import org.jivesoftware.smack.XMPPException.StreamErrorException;
-import org.jivesoftware.smack.XMPPConnection;
-import org.jivesoftware.smack.XMPPException;
-import org.jivesoftware.smack.packet.Element;
-import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.Message;
-import org.jivesoftware.smack.packet.Stanza;
-import org.jivesoftware.smack.packet.Nonza;
-import org.jivesoftware.smack.packet.Presence;
-import org.jivesoftware.smack.sasl.packet.SaslStreamElements.SASLFailure;
-import org.jivesoftware.smack.sasl.packet.SaslStreamElements.Success;
-import org.jivesoftware.smack.util.PacketParserUtils;
-import org.jxmpp.jid.DomainBareJid;
-import org.jxmpp.jid.parts.Resourcepart;
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserFactory;
 import org.igniterealtime.jbosh.AbstractBody;
 import org.igniterealtime.jbosh.BOSHClient;
 import org.igniterealtime.jbosh.BOSHClientConfig;
@@ -56,6 +36,27 @@ import org.igniterealtime.jbosh.BOSHException;
 import org.igniterealtime.jbosh.BOSHMessageEvent;
 import org.igniterealtime.jbosh.BodyQName;
 import org.igniterealtime.jbosh.ComposableBody;
+import org.jivesoftware.smack.AbstractXMPPConnection;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.SmackException.ConnectionException;
+import org.jivesoftware.smack.SmackException.NotConnectedException;
+import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.XMPPException.StreamErrorException;
+import org.jivesoftware.smack.XMPPException.XMPPErrorException;
+import org.jivesoftware.smack.packet.Element;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.Nonza;
+import org.jivesoftware.smack.packet.Presence;
+import org.jivesoftware.smack.packet.Stanza;
+import org.jivesoftware.smack.sasl.packet.SaslStreamElements.SASLFailure;
+import org.jivesoftware.smack.sasl.packet.SaslStreamElements.Success;
+import org.jivesoftware.smack.util.PacketParserUtils;
+import org.jxmpp.jid.DomainBareJid;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
 
 /**
  * Creates a connection to an XMPP server via HTTP binding.
@@ -221,6 +222,20 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
         // Authenticate using SASL
         saslAuthentication.authenticate(username, password, config.getAuthzid());
 
+        afterAuth(resource);
+    }
+
+    @Override
+    protected void loginInternal(String token, Resourcepart resource)
+            throws XMPPException, SmackException, IOException, InterruptedException {
+        // Authenticate using SASL
+        saslAuthentication.authenticate(token);
+
+        afterAuth(resource);
+    }
+
+    private void afterAuth(Resourcepart resource)
+            throws XMPPErrorException, SmackException, InterruptedException, NotConnectedException {
         bindResourceAndEstablishSession(resource);
 
         afterSuccessfulLogin(false);

--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackInitialization.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackInitialization.java
@@ -33,8 +33,11 @@ import org.jivesoftware.smack.packet.Bind;
 import org.jivesoftware.smack.provider.BindIQProvider;
 import org.jivesoftware.smack.provider.ProviderManager;
 import org.jivesoftware.smack.sasl.core.SASLAnonymous;
+import org.jivesoftware.smack.sasl.core.SASLXOAUTHMechanism;
 import org.jivesoftware.smack.sasl.core.SASLXOauth2Mechanism;
 import org.jivesoftware.smack.sasl.core.SCRAMSHA1Mechanism;
+import org.jivesoftware.smack.tbr.element.TBRTokensIQ;
+import org.jivesoftware.smack.tbr.provider.TBRTokensProvider;
 import org.jivesoftware.smack.util.FileUtils;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -140,7 +143,10 @@ public final class SmackInitialization {
         SASLAuthentication.registerSASLMechanism(new SASLXOauth2Mechanism());
         SASLAuthentication.registerSASLMechanism(new SASLAnonymous());
 
+        SASLAuthentication.registerXOAUTHSASLMechanism(new SASLXOAUTHMechanism());
+
         ProviderManager.addIQProvider(Bind.ELEMENT, Bind.NAMESPACE, new BindIQProvider());
+        ProviderManager.addIQProvider(TBRTokensIQ.ELEMENT, TBRTokensIQ.NAMESPACE, new TBRTokensProvider());
 
         SmackConfiguration.smackInitialized = true;
     }

--- a/smack-core/src/main/java/org/jivesoftware/smack/XMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/XMPPConnection.java
@@ -22,10 +22,10 @@ import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.filter.IQReplyFilter;
 import org.jivesoftware.smack.filter.StanzaFilter;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler;
-import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Nonza;
+import org.jivesoftware.smack.packet.Stanza;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityFullJid;
 
@@ -624,5 +624,19 @@ public interface XMPPConnection {
      * @return the timestamp in milliseconds
      */
     public long getLastStanzaReceived();
+
+    /**
+     * Set the X-OAUTH last refresh token.
+     * 
+     * @param token
+     */
+    public void setXOAUTHLastRefreshToken(String token);
+
+    /**
+     * Get the X-OAUTH last refresh token.
+     * 
+     * @return the X-OAUTH last refresh token
+     */
+    public String getXOAUTHLastRefreshToken();
 
 }

--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
@@ -16,6 +16,8 @@
  */
 package org.jivesoftware.smack.sasl;
 
+import javax.security.auth.callback.CallbackHandler;
+
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
@@ -26,8 +28,6 @@ import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.util.stringencoder.Base64;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityBareJid;
-
-import javax.security.auth.callback.CallbackHandler;
 
 /**
  * Base class for SASL mechanisms. Subclasses must implement these methods:
@@ -73,6 +73,7 @@ public abstract class SASLMechanism implements Comparable<SASLMechanism> {
     public static final String EXTERNAL = "EXTERNAL";
     public static final String GSSAPI = "GSSAPI";
     public static final String PLAIN = "PLAIN";
+    public static final String XOAUTH = "X-OAUTH";
 
     // TODO Remove once Smack's min Android API is 9, where java.text.Normalizer is available
     private static StringTransformer saslPrepTransformer;
@@ -182,6 +183,19 @@ public abstract class SASLMechanism implements Comparable<SASLMechanism> {
     }
 
     /**
+     * Authenticate with token.
+     * 
+     * @param token
+     * @param cbh
+     * @throws SmackException
+     * @throws InterruptedException
+     */
+    public final void authenticate(String token, CallbackHandler cbh) throws SmackException, InterruptedException {
+        authenticateInternal(cbh);
+        authenticateXOAUTH(token);
+    }
+
+    /**
      * @throws SmackException
      */
     protected void authenticateInternal() throws SmackException {
@@ -227,6 +241,10 @@ public abstract class SASLMechanism implements Comparable<SASLMechanism> {
         }
         // Send the authentication to the server
         connection.sendNonza(new AuthMechanism(getName(), authenticationText));
+    }
+
+    private void authenticateXOAUTH(String token) throws NotConnectedException, InterruptedException {
+        connection.sendNonza(new AuthMechanism(getName(), token));
     }
 
     /**

--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/SASLXOAUTHMechanism.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/SASLXOAUTHMechanism.java
@@ -1,0 +1,71 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.sasl.core;
+
+import javax.security.auth.callback.CallbackHandler;
+
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.sasl.SASLMechanism;
+import org.jivesoftware.smack.util.stringencoder.Base64;
+
+public class SASLXOAUTHMechanism extends SASLMechanism {
+
+    public static final String NAME = XOAUTH;
+
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean authzidSupported() {
+        return true;
+    }
+
+    @Override
+    public int getPriority() {
+        return 600;
+    }
+
+    @Override
+    public SASLXOAUTHMechanism newInstance() {
+        return new SASLXOAUTHMechanism();
+    }
+
+    @Override
+    protected void authenticateInternal(CallbackHandler cbh) throws SmackException {
+        // Nothing to do here
+    }
+
+    @Override
+    protected byte[] getAuthenticationText() throws SmackException {
+        // Nothing to do here
+        return null;
+    }
+
+    @Override
+    public void checkIfSuccessfulOrThrow() throws SmackException {
+        // No check performed
+    }
+
+    @Override
+    protected byte[] evaluateChallenge(byte[] challenge) throws SmackException {
+        String refreshToken = Base64.encodeToString(challenge);
+        connection.setXOAUTHLastRefreshToken(refreshToken);
+        return null;
+    }
+
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/TBRManager.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/TBRManager.java
@@ -26,8 +26,6 @@ import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPConnectionRegistry;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
-import org.jivesoftware.smack.filter.IQReplyFilter;
-import org.jivesoftware.smack.filter.StanzaFilter;
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.tbr.element.TBRGetTokensIQ;
 import org.jivesoftware.smack.tbr.element.TBRTokensIQ;
@@ -87,9 +85,8 @@ public final class TBRManager extends Manager {
     public TBRTokens getTokens()
             throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         TBRGetTokensIQ getTokensIQ = new TBRGetTokensIQ(connection().getUser().asBareJid());
-        StanzaFilter responseFilter = new IQReplyFilter(getTokensIQ, connection());
 
-        IQ responseIq = connection().createPacketCollectorAndSend(responseFilter, getTokensIQ).nextResultOrThrow();
+        IQ responseIq = connection().createPacketCollectorAndSend(getTokensIQ).nextResultOrThrow();
         TBRTokensIQ tokensIQ = (TBRTokensIQ) responseIq;
 
         return new TBRTokens(tokensIQ.getAccessToken(), tokensIQ.getRefreshToken());

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/TBRManager.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/TBRManager.java
@@ -1,0 +1,98 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.tbr;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.jivesoftware.smack.ConnectionCreationListener;
+import org.jivesoftware.smack.Manager;
+import org.jivesoftware.smack.SmackException.NoResponseException;
+import org.jivesoftware.smack.SmackException.NotConnectedException;
+import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.XMPPConnectionRegistry;
+import org.jivesoftware.smack.XMPPException.XMPPErrorException;
+import org.jivesoftware.smack.filter.IQReplyFilter;
+import org.jivesoftware.smack.filter.StanzaFilter;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.tbr.element.TBRGetTokensIQ;
+import org.jivesoftware.smack.tbr.element.TBRTokensIQ;
+
+/**
+ * Token-based reconnection manager class.
+ * 
+ * @author Fernando Ramirez
+ * @see <a href="http://www.xmpp.org/extensions/inbox/token-reconnection.html">
+ *      XEP-xxxx: Token-based reconnection</a>
+ */
+public final class TBRManager extends Manager {
+
+    public static final String AUTH_NAMESPACE = "erlang-solutions.com:xmpp:token-auth:0";
+
+    static {
+        XMPPConnectionRegistry.addConnectionCreationListener(new ConnectionCreationListener() {
+            @Override
+            public void connectionCreated(XMPPConnection connection) {
+                getInstanceFor(connection);
+            }
+        });
+    }
+
+    private static final Map<XMPPConnection, TBRManager> INSTANCES = new WeakHashMap<>();
+
+    /**
+     * Get the singleton instance of TBRManager.
+     *
+     * @param connection
+     * @return the instance of TBRManager
+     */
+    public static synchronized TBRManager getInstanceFor(XMPPConnection connection) {
+        TBRManager tbrManager = INSTANCES.get(connection);
+
+        if (tbrManager == null) {
+            tbrManager = new TBRManager(connection);
+            INSTANCES.put(connection, tbrManager);
+        }
+
+        return tbrManager;
+    }
+
+    private TBRManager(XMPPConnection connection) {
+        super(connection);
+    }
+
+    /**
+     * Get tokens.
+     * 
+     * @return the tokens
+     * @throws NoResponseException
+     * @throws XMPPErrorException
+     * @throws NotConnectedException
+     * @throws InterruptedException
+     */
+    public TBRTokens getTokens()
+            throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
+        TBRGetTokensIQ getTokensIQ = new TBRGetTokensIQ(connection().getUser().asBareJid());
+        StanzaFilter responseFilter = new IQReplyFilter(getTokensIQ, connection());
+
+        IQ responseIq = connection().createPacketCollectorAndSend(responseFilter, getTokensIQ).nextResultOrThrow();
+        TBRTokensIQ tokensIQ = (TBRTokensIQ) responseIq;
+
+        return new TBRTokens(tokensIQ.getAccessToken(), tokensIQ.getRefreshToken());
+    }
+
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/TBRTokens.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/TBRTokens.java
@@ -1,0 +1,54 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.tbr;
+
+/**
+ * Token-based reconnection token model class.
+ * 
+ * @author Fernando Ramirez
+ * @see <a href="http://www.xmpp.org/extensions/inbox/token-reconnection.html">
+ *      XEP-xxxx: Token-based reconnection</a>
+ */
+public class TBRTokens {
+
+    private String accessToken;
+    private String refreshToken;
+
+    public TBRTokens(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    /**
+     * Get the access token.
+     * 
+     * @return the access token
+     */
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    /**
+     * Get the refresh token.
+     * 
+     * @return the refresh token
+     */
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/element/TBRGetTokensIQ.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/element/TBRGetTokensIQ.java
@@ -1,0 +1,52 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.tbr.element;
+
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.tbr.TBRManager;
+import org.jxmpp.jid.Jid;
+
+/**
+ * TBR get tokens IQ class.
+ * 
+ * @author Fernando Ramirez
+ * @see <a href="http://www.xmpp.org/extensions/inbox/token-reconnection.html">
+ *      XEP-xxxx: Token-based reconnection</a>
+ */
+public class TBRGetTokensIQ extends IQ {
+
+    public static final String NAMESPACE = TBRManager.AUTH_NAMESPACE;
+    public static final String ELEMENT = QUERY_ELEMENT;
+
+    /**
+     * TBR get tokens IQ constructor.
+     * 
+     * @param to
+     */
+    public TBRGetTokensIQ(Jid to) {
+        super(ELEMENT, NAMESPACE);
+        this.setType(Type.get);
+        this.setTo(to);
+    }
+
+    @Override
+    protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
+        xml.rightAngleBracket();
+        return xml;
+    }
+
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/element/TBRGetTokensIQ.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/element/TBRGetTokensIQ.java
@@ -45,7 +45,7 @@ public class TBRGetTokensIQ extends IQ {
 
     @Override
     protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
-        xml.rightAngleBracket();
+        xml.setEmptyElement();
         return xml;
     }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/element/TBRTokensIQ.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/element/TBRTokensIQ.java
@@ -1,0 +1,83 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.tbr.element;
+
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.tbr.TBRManager;
+
+/**
+ * TBR tokens IQ class.
+ * 
+ * @author Fernando Ramirez
+ * @see <a href="http://www.xmpp.org/extensions/inbox/token-reconnection.html">
+ *      XEP-xxxx: Token-based reconnection</a>
+ */
+public class TBRTokensIQ extends IQ {
+
+    public static final String NAMESPACE = TBRManager.AUTH_NAMESPACE;
+    public static final String ELEMENT = "items";
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    /**
+     * TBR tokens IQ constructor.
+     * 
+     * @param accessToken
+     * @param refreshToken
+     */
+    public TBRTokensIQ(String accessToken, String refreshToken) {
+        super(ELEMENT, NAMESPACE);
+        this.setType(Type.result);
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    /**
+     * Get the access token.
+     * 
+     * @return the access token
+     */
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    /**
+     * Get the refresh token.
+     * 
+     * @return the refresh token
+     */
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    @Override
+    protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
+        xml.rightAngleBracket();
+
+        if (accessToken != null) {
+            xml.element("access_token", accessToken);
+        }
+
+        if (refreshToken != null) {
+            xml.element("refresh_token", refreshToken);
+        }
+
+        return xml;
+    }
+
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/element/package-info.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/element/package-info.java
@@ -1,0 +1,24 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Token-based reconnection elements.
+ * 
+ * @author Fernando Ramirez
+ * @see <a href="http://www.xmpp.org/extensions/inbox/token-reconnection.html">
+ *      XEP-xxxx: Token-based reconnection</a>
+ */
+package org.jivesoftware.smack.tbr.element;

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/package-info.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/package-info.java
@@ -1,0 +1,24 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Token-based reconnection classes and interfaces.
+ * 
+ * @author Fernando Ramirez
+ * @see <a href="http://www.xmpp.org/extensions/inbox/token-reconnection.html">
+ *      XEP-xxxx: Token-based reconnection</a>
+ */
+package org.jivesoftware.smack.tbr;

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/provider/TBRTokensProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/provider/TBRTokensProvider.java
@@ -1,0 +1,62 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.tbr.provider;
+
+import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.tbr.element.TBRTokensIQ;
+import org.xmlpull.v1.XmlPullParser;
+
+/**
+ * TBR tokens provider class.
+ * 
+ * @author Fernando Ramirez
+ * @see <a href="http://www.xmpp.org/extensions/inbox/token-reconnection.html">
+ *      XEP-xxxx: Token-based reconnection</a>
+ */
+public class TBRTokensProvider extends IQProvider<TBRTokensIQ> {
+
+    @Override
+    public TBRTokensIQ parse(XmlPullParser parser, int initialDepth) throws Exception {
+        String accessToken = null;
+        String refreshToken = null;
+
+        outerloop: while (true) {
+            int eventType = parser.next();
+
+            if (eventType == XmlPullParser.START_TAG) {
+
+                if (parser.getName().equals("access_token")) {
+                    accessToken = parser.nextText();
+                }
+
+                if (parser.getName().equals("refresh_token")) {
+                    refreshToken = parser.nextText();
+                }
+
+            } else if (eventType == XmlPullParser.END_TAG) {
+
+                if (parser.getDepth() == initialDepth) {
+                    break outerloop;
+                }
+
+            }
+        }
+
+        return new TBRTokensIQ(accessToken, refreshToken);
+    }
+
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/tbr/provider/package-info.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/tbr/provider/package-info.java
@@ -1,0 +1,24 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Token-based reconnection providers.
+ * 
+ * @author Fernando Ramirez
+ * @see <a href="http://www.xmpp.org/extensions/inbox/token-reconnection.html">
+ *      XEP-xxxx: Token-based reconnection</a>
+ */
+package org.jivesoftware.smack.tbr.provider;

--- a/smack-core/src/test/java/org/jivesoftware/smack/DummyConnection.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/DummyConnection.java
@@ -231,4 +231,9 @@ public class DummyConnection extends AbstractXMPPConnection {
             }
         }
     }
+
+    @Override
+    protected void loginInternal(String token, Resourcepart resource) throws XMPPException, SmackException, IOException, InterruptedException {
+        // TODO Auto-generated method stub
+    }
 }

--- a/smack-core/src/test/java/org/jivesoftware/smack/tbr/TBRGetTokensIQTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/tbr/TBRGetTokensIQTest.java
@@ -27,7 +27,7 @@ import org.jxmpp.jid.impl.JidCreate;
 public class TBRGetTokensIQTest {
 
     String getTokensIQExample = "<iq to='alice@wonderland.com' id='123' type='get'>"
-            + "<query xmlns='erlang-solutions.com:xmpp:token-auth:0'></query>" + "</iq>";
+            + "<query xmlns='erlang-solutions.com:xmpp:token-auth:0'/>" + "</iq>";
 
     String tokensResponseExample = "<iq to='alice@wonderland.com/resource' from='alice@wonderland.com' id='123' type='result'>"
             + "<items xmlns='erlang-solutions.com:xmpp:token-auth:0'>"

--- a/smack-core/src/test/java/org/jivesoftware/smack/tbr/TBRGetTokensIQTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/tbr/TBRGetTokensIQTest.java
@@ -1,0 +1,61 @@
+/**
+ *
+ * Copyright 2016 Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.tbr;
+
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.tbr.element.TBRGetTokensIQ;
+import org.jivesoftware.smack.tbr.element.TBRTokensIQ;
+import org.jivesoftware.smack.util.PacketParserUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jxmpp.jid.impl.JidCreate;
+
+public class TBRGetTokensIQTest {
+
+    String getTokensIQExample = "<iq to='alice@wonderland.com' id='123' type='get'>"
+            + "<query xmlns='erlang-solutions.com:xmpp:token-auth:0'></query>" + "</iq>";
+
+    String tokensResponseExample = "<iq to='alice@wonderland.com/resource' from='alice@wonderland.com' id='123' type='result'>"
+            + "<items xmlns='erlang-solutions.com:xmpp:token-auth:0'>"
+            + "<access_token>YWNjZXNzAGFsaWNlQHdvbmRlcmxhbmQuY29tL01pY2hhbC1QaW90cm93c2tpcy1NYWNCb29rLVBybwA2MzYyMTg4Mzc2NAA4M2QwNzNiZjBkOGJlYzVjZmNkODgyY2ZlMzkyZWM5NGIzZjA4ODNlNDI4ZjQzYjc5MGYxOWViM2I2ZWJlNDc0ODc3MDkxZTIyN2RhOGMwYTk2ZTc5ODBhNjM5NjE1Zjk=</access_token>"
+            + "<refresh_token>cmVmcmVzaABhbGljZUB3b25kZXJsYW5kLmNvbS9NaWNoYWwtUGlvdHJvd3NraXMtTWFjQm9vay1Qcm8ANjM2MjMwMDYxODQAMQAwZGQxOGJjODhkMGQ0N2MzNTBkYzAwYjcxZjMyZDVmOWIwOTljMmI1ODU5MmNhN2QxZGFmNWFkNGM0NDQ2ZGU2MWYxYzdhNTJjNDUyMGI5YmIxNGIxNTMwMTE4YTM1NTc=</refresh_token>"
+            + "</items>" + "</iq>";
+
+    @Test
+    public void checkGetTokensIQ() throws Exception {
+        TBRGetTokensIQ tbrGetTokensIQ = new TBRGetTokensIQ(JidCreate.from("alice@wonderland.com"));
+        tbrGetTokensIQ.setStanzaId("123");
+
+        Assert.assertEquals(getTokensIQExample, tbrGetTokensIQ.toXML().toString());
+    }
+
+    @Test
+    public void checkTokensResponseParse() throws Exception {
+        IQ iq = (IQ) PacketParserUtils.parseStanza(tokensResponseExample);
+        TBRTokensIQ tokensIQ = (TBRTokensIQ) iq;
+        tokensIQ.setStanzaId("123");
+
+        Assert.assertEquals(
+                "YWNjZXNzAGFsaWNlQHdvbmRlcmxhbmQuY29tL01pY2hhbC1QaW90cm93c2tpcy1NYWNCb29rLVBybwA2MzYyMTg4Mzc2NAA4M2QwNzNiZjBkOGJlYzVjZmNkODgyY2ZlMzkyZWM5NGIzZjA4ODNlNDI4ZjQzYjc5MGYxOWViM2I2ZWJlNDc0ODc3MDkxZTIyN2RhOGMwYTk2ZTc5ODBhNjM5NjE1Zjk=",
+                tokensIQ.getAccessToken());
+        Assert.assertEquals(
+                "cmVmcmVzaABhbGljZUB3b25kZXJsYW5kLmNvbS9NaWNoYWwtUGlvdHJvd3NraXMtTWFjQm9vay1Qcm8ANjM2MjMwMDYxODQAMQAwZGQxOGJjODhkMGQ0N2MzNTBkYzAwYjcxZjMyZDVmOWIwOTljMmI1ODU5MmNhN2QxZGFmNWFkNGM0NDQ2ZGU2MWYxYzdhNTJjNDUyMGI5YmIxNGIxNTMwMTE4YTM1NTc=",
+                tokensIQ.getRefreshToken());
+        Assert.assertEquals(tokensResponseExample, tokensIQ.toXML().toString());
+    }
+
+}

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -16,84 +16,6 @@
  */
 package org.jivesoftware.smack.tcp;
 
-import org.jivesoftware.smack.AbstractConnectionListener;
-import org.jivesoftware.smack.AbstractXMPPConnection;
-import org.jivesoftware.smack.ConnectionConfiguration;
-import org.jivesoftware.smack.ConnectionConfiguration.SecurityMode;
-import org.jivesoftware.smack.StanzaListener;
-import org.jivesoftware.smack.SmackConfiguration;
-import org.jivesoftware.smack.SmackException;
-import org.jivesoftware.smack.SmackException.AlreadyConnectedException;
-import org.jivesoftware.smack.SmackException.AlreadyLoggedInException;
-import org.jivesoftware.smack.SmackException.NoResponseException;
-import org.jivesoftware.smack.SmackException.NotConnectedException;
-import org.jivesoftware.smack.SmackException.ConnectionException;
-import org.jivesoftware.smack.SmackException.SecurityRequiredByClientException;
-import org.jivesoftware.smack.SmackException.SecurityRequiredByServerException;
-import org.jivesoftware.smack.SmackException.SecurityRequiredException;
-import org.jivesoftware.smack.SynchronizationPoint;
-import org.jivesoftware.smack.XMPPException.StreamErrorException;
-import org.jivesoftware.smack.XMPPConnection;
-import org.jivesoftware.smack.XMPPException;
-import org.jivesoftware.smack.XMPPException.XMPPErrorException;
-import org.jivesoftware.smack.compress.packet.Compressed;
-import org.jivesoftware.smack.compression.XMPPInputOutputStream;
-import org.jivesoftware.smack.filter.StanzaFilter;
-import org.jivesoftware.smack.compress.packet.Compress;
-import org.jivesoftware.smack.packet.Element;
-import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.Message;
-import org.jivesoftware.smack.packet.StreamOpen;
-import org.jivesoftware.smack.packet.Stanza;
-import org.jivesoftware.smack.packet.Presence;
-import org.jivesoftware.smack.packet.StartTls;
-import org.jivesoftware.smack.sasl.packet.SaslStreamElements;
-import org.jivesoftware.smack.sasl.packet.SaslStreamElements.Challenge;
-import org.jivesoftware.smack.sasl.packet.SaslStreamElements.SASLFailure;
-import org.jivesoftware.smack.sasl.packet.SaslStreamElements.Success;
-import org.jivesoftware.smack.sm.SMUtils;
-import org.jivesoftware.smack.sm.StreamManagementException;
-import org.jivesoftware.smack.sm.StreamManagementException.StreamIdDoesNotMatchException;
-import org.jivesoftware.smack.sm.StreamManagementException.StreamManagementCounterError;
-import org.jivesoftware.smack.sm.StreamManagementException.StreamManagementNotEnabledException;
-import org.jivesoftware.smack.sm.packet.StreamManagement;
-import org.jivesoftware.smack.sm.packet.StreamManagement.AckAnswer;
-import org.jivesoftware.smack.sm.packet.StreamManagement.AckRequest;
-import org.jivesoftware.smack.sm.packet.StreamManagement.Enable;
-import org.jivesoftware.smack.sm.packet.StreamManagement.Enabled;
-import org.jivesoftware.smack.sm.packet.StreamManagement.Failed;
-import org.jivesoftware.smack.sm.packet.StreamManagement.Resume;
-import org.jivesoftware.smack.sm.packet.StreamManagement.Resumed;
-import org.jivesoftware.smack.sm.packet.StreamManagement.StreamManagementFeature;
-import org.jivesoftware.smack.sm.predicates.Predicate;
-import org.jivesoftware.smack.sm.provider.ParseStreamManagement;
-import org.jivesoftware.smack.packet.Nonza;
-import org.jivesoftware.smack.packet.XMPPError;
-import org.jivesoftware.smack.proxy.ProxyInfo;
-import org.jivesoftware.smack.util.ArrayBlockingQueueWithShutdown;
-import org.jivesoftware.smack.util.Async;
-import org.jivesoftware.smack.util.PacketParserUtils;
-import org.jivesoftware.smack.util.StringUtils;
-import org.jivesoftware.smack.util.TLSUtils;
-import org.jivesoftware.smack.util.XmlStringBuilder;
-import org.jivesoftware.smack.util.dns.HostAddress;
-import org.jxmpp.jid.impl.JidCreate;
-import org.jxmpp.jid.parts.Resourcepart;
-import org.jxmpp.stringprep.XmppStringprepException;
-import org.jxmpp.util.XmppStringUtils;
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
-
-import javax.net.SocketFactory;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.PasswordCallback;
-
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
@@ -135,6 +57,84 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.PasswordCallback;
+
+import org.jivesoftware.smack.AbstractConnectionListener;
+import org.jivesoftware.smack.AbstractXMPPConnection;
+import org.jivesoftware.smack.ConnectionConfiguration;
+import org.jivesoftware.smack.ConnectionConfiguration.SecurityMode;
+import org.jivesoftware.smack.SmackConfiguration;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.SmackException.AlreadyConnectedException;
+import org.jivesoftware.smack.SmackException.AlreadyLoggedInException;
+import org.jivesoftware.smack.SmackException.ConnectionException;
+import org.jivesoftware.smack.SmackException.NoResponseException;
+import org.jivesoftware.smack.SmackException.NotConnectedException;
+import org.jivesoftware.smack.SmackException.SecurityRequiredByClientException;
+import org.jivesoftware.smack.SmackException.SecurityRequiredByServerException;
+import org.jivesoftware.smack.SmackException.SecurityRequiredException;
+import org.jivesoftware.smack.StanzaListener;
+import org.jivesoftware.smack.SynchronizationPoint;
+import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.XMPPException.StreamErrorException;
+import org.jivesoftware.smack.XMPPException.XMPPErrorException;
+import org.jivesoftware.smack.compress.packet.Compress;
+import org.jivesoftware.smack.compress.packet.Compressed;
+import org.jivesoftware.smack.compression.XMPPInputOutputStream;
+import org.jivesoftware.smack.filter.StanzaFilter;
+import org.jivesoftware.smack.packet.Element;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.Nonza;
+import org.jivesoftware.smack.packet.Presence;
+import org.jivesoftware.smack.packet.Stanza;
+import org.jivesoftware.smack.packet.StartTls;
+import org.jivesoftware.smack.packet.StreamOpen;
+import org.jivesoftware.smack.packet.XMPPError;
+import org.jivesoftware.smack.proxy.ProxyInfo;
+import org.jivesoftware.smack.sasl.packet.SaslStreamElements;
+import org.jivesoftware.smack.sasl.packet.SaslStreamElements.Challenge;
+import org.jivesoftware.smack.sasl.packet.SaslStreamElements.SASLFailure;
+import org.jivesoftware.smack.sasl.packet.SaslStreamElements.Success;
+import org.jivesoftware.smack.sm.SMUtils;
+import org.jivesoftware.smack.sm.StreamManagementException;
+import org.jivesoftware.smack.sm.StreamManagementException.StreamIdDoesNotMatchException;
+import org.jivesoftware.smack.sm.StreamManagementException.StreamManagementCounterError;
+import org.jivesoftware.smack.sm.StreamManagementException.StreamManagementNotEnabledException;
+import org.jivesoftware.smack.sm.packet.StreamManagement;
+import org.jivesoftware.smack.sm.packet.StreamManagement.AckAnswer;
+import org.jivesoftware.smack.sm.packet.StreamManagement.AckRequest;
+import org.jivesoftware.smack.sm.packet.StreamManagement.Enable;
+import org.jivesoftware.smack.sm.packet.StreamManagement.Enabled;
+import org.jivesoftware.smack.sm.packet.StreamManagement.Failed;
+import org.jivesoftware.smack.sm.packet.StreamManagement.Resume;
+import org.jivesoftware.smack.sm.packet.StreamManagement.Resumed;
+import org.jivesoftware.smack.sm.packet.StreamManagement.StreamManagementFeature;
+import org.jivesoftware.smack.sm.predicates.Predicate;
+import org.jivesoftware.smack.sm.provider.ParseStreamManagement;
+import org.jivesoftware.smack.util.ArrayBlockingQueueWithShutdown;
+import org.jivesoftware.smack.util.Async;
+import org.jivesoftware.smack.util.PacketParserUtils;
+import org.jivesoftware.smack.util.StringUtils;
+import org.jivesoftware.smack.util.TLSUtils;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+import org.jivesoftware.smack.util.dns.HostAddress;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+import org.jxmpp.util.XmppStringUtils;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
 
 /**
  * Creates a socket connection to an XMPP server. This is the default connection
@@ -380,6 +380,11 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         // Authenticate using SASL
         saslAuthentication.authenticate(username, password, config.getAuthzid());
 
+        afterAuth(resource);
+    }
+
+    private void afterAuth(Resourcepart resource) throws NotConnectedException, NoResponseException, SmackException,
+            InterruptedException, XMPPErrorException, XMPPException {
         // If compression is enabled then request the server to use stream compression. XEP-170
         // recommends to perform stream compression before resource binding.
         maybeEnableCompression();
@@ -436,6 +441,15 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         }
 
         afterSuccessfulLogin(false);
+    }
+
+    @Override
+    protected void loginInternal(String token, Resourcepart resource)
+            throws XMPPException, SmackException, IOException, InterruptedException {
+        // Authenticate using SASL
+        saslAuthentication.authenticate(token);
+
+        afterAuth(resource);
     }
 
     @Override


### PR DESCRIPTION
Docs: http://www.xmpp.org/extensions/inbox/token-reconnection.html

Login with token:
`xmppConnection.login(token, resourcepart);`

Get tokens:
`TBRManager tbrManager = TBRManager.getInstanceFor(xmppConnection);`
`TBRTokens tbrTokens = tbrManager.getTokens();`
`String accessToken = tbrTokens.getAccessToken();`
`String refreshToken = tbrTokens.getRefreshToken();`

Get last refresh token obtained from "success" nonza:
`String refreshToken = xmppConnection.getXOAUTHLastRefreshToken();`

To avoid reconnection using token:
`xmppConnection.avoidTokenReconnection();`
