### PR TITLE
fix for SASL success response improper decoding

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
@@ -250,7 +250,7 @@ public abstract class SASLMechanism implements Comparable<SASLMechanism> {
      * @throws InterruptedException 
      */
     public final void challengeReceived(String challengeString, boolean finalChallenge) throws SmackException, NotConnectedException, InterruptedException {
-        byte[] challenge = Base64.decode(challengeString);
+        byte[] challenge = Base64.decode((challengeString != null && challengeString.equals("=")) ? "" : challengeString);
         byte[] response = evaluateChallenge(challenge);
         if (finalChallenge) {
             return;


### PR DESCRIPTION
Hi fellow smackers.
I've discovered Smack library incompatibility against using SASL auth module with Prosody server.
After [discussing](https://prosody.im/issues/issue/729) the issue with server authors , it has been discovered, that in case of successful response of zero length from SASL provider, "=" sign indicating empty response is mandatory, see RFC for details: http://xmpp.org/rfcs/rfc6120.html#sasl-process-neg-success

> The receiving entity reports success of the handshake by sending a <success/> element qualified by the 'urn:ietf:params:xml:ns:xmpp-sasl' namespace; this element MAY contain XML character data (in SASL terminology, "additional data with success") if the chosen SASL mechanism supports or requires it. If the receiving entity needs to send additional data of zero length, it MUST transmit the data as a single equals sign character ("="). 

Current and all previous version of the lib failing to process such responses.
Proposed fix solves this bug.

Detailed exception log from Smack XMPP client for a reference (tested on fresh 4.1.8):
`
08-25 17:04:10.929 18037-18532/ D/SMACK: SENT (0): <stream:stream xmlns='jabber:client' to='example.com' xmlns:stream='http://etherx.jabber.org/streams' version='1.0' from='user@example.com' xml:lang='en'> 
08-25 17:04:10.958 18037-18533/ D/SMACK: RECV (0): <?xml version='1.0'?><stream:stream xmlns:stream='http://etherx.jabber.org/streams' xml:lang='en' from='example.com' id='150e9ad5-8cb0-4bb3-a6ae-a3d7956fda97' version='1.0' xmlns='jabber:client'><stream:features><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'><required/></starttls></stream:features> 
08-25 17:04:10.958 18037-18532/ D/SMACK: SENT (0): <starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'></starttls> 
08-25 17:04:10.987 18037-18533/ D/SMACK: RECV (0): <proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/> 
08-25 17:04:11.142 18037-18532/ D/SMACK: SENT (0): <stream:stream xmlns='jabber:client' to='example.com' xmlns:stream='http://etherx.jabber.org/streams' version='1.0' from='user@example.com' xml:lang='en'> 
08-25 17:04:11.172 18037-18533/ D/SMACK: RECV (0): <?xml version='1.0'?><stream:stream xmlns:stream='http://etherx.jabber.org/streams' xml:lang='en' from='example.com' id='5fdec49e-eb78-40f7-985e-9852999f30d4' version='1.0' xmlns='jabber:client'><stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>PLAIN</mechanism></mechanisms></stream:features> 
08-25 17:04:11.173 18037-18530/ D/RoosterConnection: Connected Successfully 08-25 17:04:11.174 18037-18532/ D/SMACK: SENT (0): <auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='PLAIN'>cGFzc3dvcmQx</auth> 
08-25 17:04:11.204 18037-18533/ D/SMACK: RECV (0): <success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>=</success> 08-25 17:04:11.204 18037-18532/ D/SMACK: SENT (0): <stream:stream xmlns='jabber:client' to='example.com' xmlns:stream='http://etherx.jabber.org/streams' version='1.0' from='user@example.com' id='5fdec49e-eb78-40f7-985e-9852999f30d4' xml:lang='en'> 
08-25 17:04:16.176 18037-18530/ D/RoosterConnectionService: Something went wrong while connecting ,make sure the credentials are right and try again 
08-25 17:04:16.176 18037-18530/ W/System.err: org.jivesoftware.smack.SmackException$NoResponseException: No response received within reply timeout. Timeout was 5000ms (~5s). Used filter: No filter used or filter was 'null'. 
08-25 17:04:16.176 18037-18530/ W/System.err: at org.jivesoftware.smack.SASLAuthentication.authenticate(SASLAuthentication.java:250) 
08-25 17:04:16.176 18037-18530/ W/System.err: at org.jivesoftware.smack.tcp.XMPPTCPConnection.loginNonAnonymously(XMPPTCPConnection.java:365) 
08-25 17:04:16.176 18037-18530/ W/System.err: at org.jivesoftware.smack.AbstractXMPPConnection.login(AbstractXMPPConnection.java:452) 
08-25 17:04:16.176 18037-18530/ W/System.err: at org.jivesoftware.smack.AbstractXMPPConnection.login(AbstractXMPPConnection.java:410) 
08-25 17:04:16.176 18037-18530/ W/System.err: at java.lang.Thread.run(Thread.java:818) 
08-25 17:04:16.176 18037-18533/ W/art: Long monitor contention event with owner method=void org.jivesoftware.smack.AbstractXMPPConnection.login() from AbstractXMPPConnection.java:400 waiters=0 for 4.972s 
08-25 17:04:16.177 18037-18037/ D/RoosterConnectionService: onDestroy() 08-25 17:04:16.178 18037-18037/ D/RoosterConnectionService: stop() 
08-25 17:04:16.179 18037-18533/ W/AbstractXMPPConnection: Connection closed with error java.lang.IllegalArgumentException: bad base-64 at android.util.Base64.decode(Base64.java:161) 
	at android.util.Base64.decode(Base64.java:136) at android.util.Base64.decode(Base64.java:118) 
	at org.jivesoftware.smack.util.stringencoder.android.AndroidBase64Encoder.decode(AndroidBase64Encoder.java:41) 
	at org.jivesoftware.smack.util.stringencoder.Base64.decode(Base64.java:86) 
	at org.jivesoftware.smack.sasl.SASLMechanism.challengeReceived(SASLMechanism.java:229) 
	at org.jivesoftware.smack.SASLAuthentication.challengeReceived(SASLAuthentication.java:328) 
	at org.jivesoftware.smack.SASLAuthentication.authenticated(SASLAuthentication.java:347) 
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1049) 
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$200(XMPPTCPConnection.java:937) 
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:952) 
	at java.lang.Thread.run(Thread.java:818)
`

