### PR TITLE
Fix vcard load

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -636,40 +636,39 @@ public class VCard extends IQ {
             xml.element("USERID", emailHome);
             xml.closeElement("EMAIL");
         }
-        
+
         if(!workPhones.isEmpty() || !homePhones.isEmpty()){
-        	if(!workPhones.isEmpty()){
-        		xml.openElement("TEL");
-        		xml.emptyElement("WORK");
-        		for (Entry<String, String> phone : workPhones.entrySet()) {
-        			final String number = phone.getValue();
-        			if (!phone.getKey().equals("WORK") ) {
-						if (number == null || number.equals(""))
-							xml.emptyElement(phone.getKey());
-						else
-							xml.element(phone.getKey(), number);
-					}
-        		}
-        		xml.closeElement("TEL");
-        	}
-        	
-        	if(!homePhones.isEmpty()){
-        		xml.openElement("TEL");
-        		xml.emptyElement("HOME");
-        		for (Entry<String, String> phone : homePhones.entrySet()) {
-        			final String number = phone.getValue();
-        			if (!phone.getKey().equals("HOME")) {
-						if (number == null || number.equals(""))
-							xml.emptyElement(phone.getKey());
-						else
-							xml.element(phone.getKey(), number);
-					}
-        		}
-        		xml.closeElement("TEL");
-        	}
+            if(!workPhones.isEmpty()){
+                xml.openElement("TEL");
+                xml.emptyElement("WORK");
+                for (Entry<String, String> phone : workPhones.entrySet()) {
+                    final String number = phone.getValue();
+                    if (!phone.getKey().equals("WORK") ) {
+                        if (number == null || number.equals(""))
+                            xml.emptyElement(phone.getKey());
+                        else
+                            xml.element(phone.getKey(), number);
+                     }
+                }
+                xml.closeElement("TEL");
+            }
+            if(!homePhones.isEmpty()){
+                xml.openElement("TEL");
+                xml.emptyElement("HOME");
+                for (Entry<String, String> phone : homePhones.entrySet()) {
+                    final String number = phone.getValue();
+                    if (!phone.getKey().equals("HOME")) {
+                        if (number == null || number.equals(""))
+                            xml.emptyElement(phone.getKey());
+                        else
+                            xml.element(phone.getKey(), number);
+                    }
+                }
+                xml.closeElement("TEL");
+            }
         }else
-        	xml.emptyElement("TEL");
-        
+            xml.emptyElement("TEL");
+
         if (!workAddr.isEmpty()) {
             xml.openElement("ADR");
             xml.emptyElement("WORK");

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -643,7 +643,7 @@ public class VCard extends IQ {
         		xml.emptyElement("WORK");
         		for (Entry<String, String> phone : workPhones.entrySet()) {
         			final String number = phone.getValue();
-        			if (phone.getKey() != "WORK" ) {
+        			if (!phone.getKey().equals("WORK") ) {
 						if (number == null || number.equals(""))
 							xml.emptyElement(phone.getKey());
 						else
@@ -658,7 +658,7 @@ public class VCard extends IQ {
         		xml.emptyElement("HOME");
         		for (Entry<String, String> phone : homePhones.entrySet()) {
         			final String number = phone.getValue();
-        			if (phone.getKey() != "HOME") {
+        			if (!phone.getKey().equals("HOME")) {
 						if (number == null || number.equals(""))
 							xml.emptyElement(phone.getKey());
 						else

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -636,28 +636,40 @@ public class VCard extends IQ {
             xml.element("USERID", emailHome);
             xml.closeElement("EMAIL");
         }
-        for (Entry<String, String> phone : workPhones.entrySet()) {
-            final String number = phone.getValue();
-            if (number == null) {
-                continue;
-            }
-            xml.openElement("TEL");
-            xml.emptyElement("WORK");
-            xml.emptyElement(phone.getKey());
-            xml.element("NUMBER", number);
-            xml.closeElement("TEL");
-        }
-        for (Entry<String, String> phone : homePhones.entrySet()) {
-            final String number = phone.getValue();
-            if (number == null) {
-                continue;
-            }
-            xml.openElement("TEL");
-            xml.emptyElement("HOME");
-            xml.emptyElement(phone.getKey());
-            xml.element("NUMBER", number);
-            xml.closeElement("TEL");
-        }
+        
+        if(!workPhones.isEmpty() || !homePhones.isEmpty()){
+        	if(!workPhones.isEmpty()){
+        		xml.openElement("TEL");
+        		xml.emptyElement("WORK");
+        		for (Entry<String, String> phone : workPhones.entrySet()) {
+        			final String number = phone.getValue();
+        			if (phone.getKey() != "WORK" ) {
+						if (number == null || number.equals(""))
+							xml.emptyElement(phone.getKey());
+						else
+							xml.element(phone.getKey(), number);
+					}
+        		}
+        		xml.closeElement("TEL");
+        	}
+        	
+        	if(!homePhones.isEmpty()){
+        		xml.openElement("TEL");
+        		xml.emptyElement("HOME");
+        		for (Entry<String, String> phone : homePhones.entrySet()) {
+        			final String number = phone.getValue();
+        			if (phone.getKey() != "HOME") {
+						if (number == null || number.equals(""))
+							xml.emptyElement(phone.getKey());
+						else
+							xml.element(phone.getKey(), number);
+					}
+        		}
+        		xml.closeElement("TEL");
+        	}
+        }else
+        	xml.emptyElement("TEL");
+        
         if (!workAddr.isEmpty()) {
             xml.openElement("ADR");
             xml.emptyElement("WORK");

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
@@ -18,7 +18,6 @@ package org.jivesoftware.smackx.vcardtemp.provider;
 
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.provider.IQProvider;
-import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smackx.vcardtemp.packet.VCard;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -165,29 +164,26 @@ public class VCardProvider extends IQProvider<VCard> {
     private static void parseTel(XmlPullParser parser, VCard vCard) throws XmlPullParserException, IOException {
         final int initialDepth = parser.getDepth();
         String telType = null;
-        
+
         outerloop: while (true) {
             int eventType = parser.next();
             switch (eventType) {
             case XmlPullParser.START_TAG:
                 String name = parser.getName();
-                
                 for (String t: TEL) {
-                	if (t.equalsIgnoreCase(name)) {
-                		telType = t;
-                		break;
-                	}
+                    if (t.equalsIgnoreCase(name)) {
+                        telType = t;
+                        break;
+                    }
                 }
-                
                 String val = parser.nextText();
                 if (telType != null) {
-	                if ("HOME".equals(telType)) {
-	                	vCard.setPhoneHome(telType, val);
-	                }  else {
-	                    vCard.setPhoneWork(telType, val);
-	                }
+                    if ("HOME".equals(telType)) {
+                        vCard.setPhoneHome(telType, val);
+                        }  else {
+                            vCard.setPhoneWork(telType, val);
+                        }
                 }
-                
                 telType = null;
                 break;
             case XmlPullParser.END_TAG:

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
@@ -63,6 +63,9 @@ public class VCardProvider extends IQProvider<VCard> {
         "ISDN",
         "PCS",
         "PREF",
+        "NUMBER",
+        "WORK",
+        "HOME"
     };
     // @formatter:on
 
@@ -161,39 +164,31 @@ public class VCardProvider extends IQProvider<VCard> {
 
     private static void parseTel(XmlPullParser parser, VCard vCard) throws XmlPullParserException, IOException {
         final int initialDepth = parser.getDepth();
-        boolean isWork = true;
-        String telLabel = null;
-
+        String telType = null;
+        
         outerloop: while (true) {
             int eventType = parser.next();
             switch (eventType) {
             case XmlPullParser.START_TAG:
                 String name = parser.getName();
-                if ("HOME".equals(name)) {
-                    isWork = false;
+                
+                for (String t: TEL) {
+                	if (t.equalsIgnoreCase(name)) {
+                		telType = t;
+                		break;
+                	}
                 }
-                else {
-                    if ("NUMBER".equals(name)) {
-                        if (StringUtils.isNullOrEmpty(telLabel)) {
-                            // RFC 2426 § 3.3.1:
-                            // "The default type is 'voice'"
-                            telLabel = "VOICE";
-                        }
-                        if (isWork) {
-                            vCard.setPhoneWork(telLabel, parser.nextText());
-                        }
-                        else {
-                            vCard.setPhoneHome(telLabel, parser.nextText());
-                        }
-                    }
-                    else {
-                        for (String tel : TEL) {
-                            if (tel.equals(name)) {
-                                telLabel = name;
-                            }
-                        }
-                    }
+                
+                String val = parser.nextText();
+                if (telType != null) {
+	                if ("HOME".equals(telType)) {
+	                	vCard.setPhoneHome(telType, val);
+	                }  else {
+	                    vCard.setPhoneWork(telType, val);
+	                }
                 }
+                
+                telType = null;
                 break;
             case XmlPullParser.END_TAG:
                 if (parser.getDepth() == initialDepth) {


### PR DESCRIPTION
Hi there, we found a bug on the vcard load.

It the user has a vcard like the following:

```
<vCard xmlns="vcard-temp">
  <NICKNAME>uq agent</NICKNAME>
  <TEL>
    <WORK/>
    <VOICE/>
    <NUMBER>4500</NUMBER>
  </TEL>
  <JABBERID>4500@wcs.eudata.biz/wcc</JABBERID>
  <DESC>chat$audio$video</DESC>
</vCard>
```

everything works, if it has something like:

`<vCard xmlns="vcard-temp" version="3.0"><NICKNAME>Edoardo Paronzini</NICKNAME><JABBERID>edoardo.paronzini@wcs.eudata.biz/wcc</JABBERID><NOTE>192.168.0.49</NOTE><DESC>chat$audio$video</DESC><TEL><NUMBER>0</NUMBER><WORK/><VOICE/></TEL></vCard>`

the TEL part of the vcard is ignored. Fix provided