### PR TITLE
Suppressing of unknown presence states error and returning 'available'

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
@@ -412,6 +412,7 @@ public final class Presence extends Stanza implements TypedCloneable<Presence> {
          * 
          * @param string the String value to covert.
          * @return the corresponding Type.
+         * @throws NullPointerException if the string is null
          */
         public static Mode fromString(String string) {
             try
@@ -420,7 +421,6 @@ public final class Presence extends Stanza implements TypedCloneable<Presence> {
             }
             catch(IllegalArgumentException e)
             {
-                e.printStackTrace();
                 return Mode.available;
             }
         }

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
@@ -412,11 +412,17 @@ public final class Presence extends Stanza implements TypedCloneable<Presence> {
          * 
          * @param string the String value to covert.
          * @return the corresponding Type.
-         * @throws IllegalArgumentException when not able to parse the string parameter
-         * @throws NullPointerException if the string is null
          */
         public static Mode fromString(String string) {
-            return Mode.valueOf(string.toLowerCase(Locale.US));
+            try
+            {
+                return Mode.valueOf(string.toLowerCase(Locale.US));
+            }
+            catch(IllegalArgumentException e)
+            {
+                e.printStackTrace();
+                return Mode.available;
+            }
         }
     }
 }


### PR DESCRIPTION
 Suppressed illegalArgumentExceptions in Presence.fromString() This is for clients that adopted the "invisible" presence or other states that does not adhere to the standards. instead of closing, it returns an "available" mode.

related to: https://github.com/igniterealtime/Smack/pull/103
