### PR TITLE
updated connect method for BOSH connection

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 // The name of the root project.
 // If we would not set the name, then gradle would use the directory
 // name of the root directory
-rootProject.name = 'Smack'
+rootProject.name = 'Smack-forked'
 
 include 'smack-core',
 		'smack-im',
@@ -9,16 +9,16 @@ include 'smack-core',
 		'smack-extensions',
 		'smack-experimental',
 		'smack-debug',
-		'smack-debug-slf4j',
+		//'smack-debug-slf4j',
 		'smack-resolver-dnsjava',
 		'smack-resolver-minidns',
-		'smack-resolver-javax',
+		//'smack-resolver-javax',
 		'smack-sasl-javax',
 		'smack-sasl-provided',
-		'smack-compression-jzlib',
-		'smack-legacy',
-		'smack-jingle-old',
-		'smack-bosh',
-		'smack-android',
+		//'smack-compression-jzlib',
+		//'smack-legacy',
+		//'smack-jingle-old',
+		'smack-bosh'
+		/*'smack-android',
 		'smack-android-extensions',
 		'smack-java7'

--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -132,7 +132,7 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
     }
 
     @Override
-    protected void connectInternal() throws SmackException {
+    protected void connectInternal() throws SmackException, XMPPException, IOException  {
         done = false;
         try {
             // Ensure a clean starting state
@@ -197,6 +197,18 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
         saslFeatureReceived.checkIfSuccessOrWaitOrThrow();
 
         callConnectionConnectedListener();
+
+        // Automatically makes the login if the user was previously connected successfully
+        // to the server and the connection was terminated abruptly
+
+        // in cases for reconnect:
+        // if do this asynchronously in BOSHConnectionListener saslFeatureReceived.check
+        // method doesn't pass
+        // and login flow becomes not clear and complicated.
+        if (wasAuthenticated) {
+            login();
+            notifyReconnection();
+        }
     }
 
     public boolean isSecureConnection() {
@@ -438,17 +450,6 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
                             listener.connectionCreated(XMPPBOSHConnection.this);
                         }
                     }
-                    else {
-                            if (wasAuthenticated) {
-                                try {
-                                    login();
-                                }
-                                catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
-                            notifyReconnection();
-                    }
                 }
                 else {
                     if (connEvent.isError()) {
@@ -537,7 +538,12 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
                                 }
                                 break;
                             case "error":
-                                throw new StreamErrorException(PacketParserUtils.parseStreamError(parser));
+                                //Some bosh error isn't stream error
+                                if ("urn:ietf:params:xml:ns:xmpp-streams".equals(parser.getNamespace(null))) {
+                                    throw new StreamErrorException(PacketParserUtils.parseStreamError(parser));
+                                } else {
+                                    throw new XMPPException.XMPPErrorException(PacketParserUtils.parseError(parser));
+                                }
                             }
                             break;
                         }


### PR DESCRIPTION
Now in case when user was previously connected successfully and connection was closed on error if we  call "connect" method from ReconnectionManager as usual for tcp, connection won't be reestablished.
saslFeatureReceived checking doesn't pass if we try login outside "connect" method but in BOSHConnectionListener.
Besides login flow in this way becomes not clear and complicated. 
So moving login to one place like in tcp resolves issue.

Another issue - parsing bosh errors. Some error received from server isn't actually stream error. For example error with code 404.  
