### PR TITLE
XMPP-Connections have to be weak, so the GC can collect them

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FaultTolerantNegotiator.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FaultTolerantNegotiator.java
@@ -18,6 +18,7 @@ package org.jivesoftware.smackx.filetransfer;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.ref.WeakReference;
 
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPConnection;
@@ -40,13 +41,13 @@ public class FaultTolerantNegotiator extends StreamNegotiator {
 
     private final StreamNegotiator primaryNegotiator;
     private final StreamNegotiator secondaryNegotiator;
-    private final XMPPConnection connection;
+    private final WeakReference<XMPPConnection> connection;
 
     public FaultTolerantNegotiator(XMPPConnection connection, StreamNegotiator primary,
             StreamNegotiator secondary) {
         this.primaryNegotiator = primary;
         this.secondaryNegotiator = secondary;
-        this.connection = connection;
+        this.connection = new WeakReference<>(connection);
     }
 
     @Override
@@ -64,7 +65,7 @@ public class FaultTolerantNegotiator extends StreamNegotiator {
     @Override
     public InputStream createIncomingStream(final StreamInitiation initiation) throws SmackException, XMPPErrorException, InterruptedException {
         // This could be either an xep47 ibb 'open' iq or an xep65 streamhost iq
-        IQ initationSet = initiateIncomingStream(connection, initiation);
+        IQ initationSet = initiateIncomingStream(connection.get(), initiation);
 
         StreamNegotiator streamNegotiator = determineNegotiator(initationSet);
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/IBBTransferNegotiator.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/IBBTransferNegotiator.java
@@ -18,6 +18,7 @@ package org.jivesoftware.smackx.filetransfer;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.ref.WeakReference;
 
 import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
@@ -44,7 +45,7 @@ import org.jxmpp.jid.Jid;
  */
 public class IBBTransferNegotiator extends StreamNegotiator {
 
-    private XMPPConnection connection;
+    private WeakReference<XMPPConnection> connection;
 
     private InBandBytestreamManager manager;
 
@@ -54,7 +55,7 @@ public class IBBTransferNegotiator extends StreamNegotiator {
      * @param connection The connection which this negotiator works on.
      */
     protected IBBTransferNegotiator(XMPPConnection connection) {
-        this.connection = connection;
+        this.connection = new WeakReference<>(connection);
         this.manager = InBandBytestreamManager.getByteStreamManager(connection);
     }
 
@@ -75,7 +76,7 @@ public class IBBTransferNegotiator extends StreamNegotiator {
          */
         this.manager.ignoreBytestreamRequestOnce(initiation.getSessionID());
 
-        Stanza streamInitiation = initiateIncomingStream(this.connection, initiation);
+        Stanza streamInitiation = initiateIncomingStream(this.connection.get(), initiation);
         return negotiateIncomingStream(streamInitiation);
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/Socks5TransferNegotiator.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/Socks5TransferNegotiator.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PushbackInputStream;
+import java.lang.ref.WeakReference;
 
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NoResponseException;
@@ -43,13 +44,13 @@ import org.jxmpp.jid.Jid;
  */
 public class Socks5TransferNegotiator extends StreamNegotiator {
 
-    private XMPPConnection connection;
+    private WeakReference<XMPPConnection> connection;
 
     private Socks5BytestreamManager manager;
 
     Socks5TransferNegotiator(XMPPConnection connection) {
-        this.connection = connection;
-        this.manager = Socks5BytestreamManager.getBytestreamManager(this.connection);
+        this.connection = new WeakReference<>(connection);
+        this.manager = Socks5BytestreamManager.getBytestreamManager(connection);
     }
 
     @Override
@@ -75,7 +76,7 @@ public class Socks5TransferNegotiator extends StreamNegotiator {
          */
         this.manager.ignoreBytestreamRequestOnce(initiation.getSessionID());
 
-        Stanza streamInitiation = initiateIncomingStream(this.connection, initiation);
+        Stanza streamInitiation = initiateIncomingStream(this.connection.get(), initiation);
         return negotiateIncomingStream(streamInitiation);
     }
 


### PR DESCRIPTION
If you have more connections / Smack-Clients inside one JVM this fix will take effect in reduced RAM-alloc