### PR TITLE
Fixed logsNonFatalExceptionTest on non-english systems

### DIFF
--- a/smack-integration-test/src/test/java/org/igniterealtime/smack/inttest/unittest/SmackIntegrationTestFrameworkUnitTest.java
+++ b/smack-integration-test/src/test/java/org/igniterealtime/smack/inttest/unittest/SmackIntegrationTestFrameworkUnitTest.java
@@ -85,7 +85,7 @@ public class SmackIntegrationTestFrameworkUnitTest {
         assertTrue(failedTest.failureReason instanceof XMPPErrorException);
         XMPPErrorException ex = (XMPPErrorException) failedTest.failureReason;
         assertEquals(XMPPError.Condition.bad_request, ex.getXMPPError().getCondition());
-        assertEquals(ThrowsNonFatalExceptionDummyTest.DESCRIPTIVE_TEXT, ex.getXMPPError().getDescriptiveText());
+        assertEquals(ThrowsNonFatalExceptionDummyTest.DESCRIPTIVE_TEXT, ex.getXMPPError().getDescriptiveText("en"));
     }
 
     public static class ThrowsNonFatalExceptionDummyTest extends AbstractSmackIntegrationTest {


### PR DESCRIPTION
The test failed on my system which has "de" as default locale. Since the descriptiveText was stored in the Exception with key "en", while getDescriptiveText() defaults to systems default locale, the assertEquals test failed.