### PR TITLE
Fixed IntegrationTest

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/AbstractError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/AbstractError.java
@@ -67,7 +67,10 @@ public class AbstractError {
         String defaultLocale = Locale.getDefault().getLanguage();
         String descriptiveText = getDescriptiveText(defaultLocale);
         if (descriptiveText == null) {
-            descriptiveText = getDescriptiveText("");
+            descriptiveText = getDescriptiveText("en");
+            if(descriptiveText == null) {
+                descriptiveText = getDescriptiveText("");
+            }
         }
         return descriptiveText;
     }


### PR DESCRIPTION
SmackIntegrationTestFrameworkUnitTest.logsNonFatalException test case failed on systems with a system language other than english. The test created an Exception with an English descriptiveText ("en"), but when comparing the text with the input, the method AbstractError.getDescriptiveText() was used, which tried to get the text in system language ("de" in my case), before falling back to "" as language. Thats why the test failed.

I fixed it by modifying getDescriptiveText(): Try system language, if that string is null, try "en" and if the string is still null, try "".