### PR TITLE
fixed AbstractJidTypeFilter.accept()

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/AbstractJidTypeFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/AbstractJidTypeFilter.java
@@ -39,7 +39,7 @@ public abstract class AbstractJidTypeFilter implements StanzaFilter {
 
     @Override
     public final boolean accept(Stanza stanza) {
-        final Jid jid = stanza.getFrom();
+        final Jid jid = getJidToInspect(stanza);
 
         if (jid == null) {
             return false;


### PR DESCRIPTION
With this fix AbstractJidTypeFilter.accept() uses jid from getJidToInspect() instead of always using stanza sender jid (which prevented ToTypeFilter from working properly)