### PR TITLE
fix from type on EnablePushNotificationsIQ publish_options, cause bad request error

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/push_notifications/element/EnablePushNotificationsIQ.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/push_notifications/element/EnablePushNotificationsIQ.java
@@ -96,7 +96,7 @@ public class EnablePushNotificationsIQ extends IQ {
         xml.rightAngleBracket();
 
         if (publishOptions != null) {
-            DataForm dataForm = new DataForm(DataForm.Type.form);
+            DataForm dataForm = new DataForm(DataForm.Type.submit);
 
             FormField formTypeField = new FormField("FORM_TYPE");
             formTypeField.addValue(PubSub.NAMESPACE + "#publish-options");

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/push_notifications/EnablePushNotificationsIQTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/push_notifications/EnablePushNotificationsIQTest.java
@@ -31,7 +31,7 @@ public class EnablePushNotificationsIQTest {
 
     String exampleEnableIQWithPublishOptions = "<iq id='x42' type='set'>"
             + "<enable xmlns='urn:xmpp:push:0' jid='push-5.client.example' node='yxs32uqsflafdk3iuqo'>"
-            + "<x xmlns='jabber:x:data' type='form'>"
+            + "<x xmlns='jabber:x:data' type='submit'>"
             + "<field var='FORM_TYPE'><value>http://jabber.org/protocol/pubsub#publish-options</value></field>"
             + "<field var='secret'><value>eruio234vzxc2kla-91</value></field>" + "</x>" + "</enable>" + "</iq>";
 


### PR DESCRIPTION
fix form type to 'submit' in EnablePushNotificationsIQ.  
previous type is 'form', it caused error 400 bad-request - modify.
based on https://xmpp.org/extensions/xep-0357.html

```
<iq type='set' id='x43'>
  <enable xmlns='urn:xmpp:push:0' jid='push-5.client.example' node='yxs32uqsflafdk3iuqo'>
    <x xmlns='jabber:x:data' type='submit'>
      <field var='FORM_TYPE'><value>http://jabber.org/protocol/pubsub#publish-options</value></field>
      <field var='secret'><value>eruio234vzxc2kla-91</value></field>
    </x>
  </enable>
</iq>
```