### PR TITLE
if an iq is received and there is no iq handler registered to handle …

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -1133,15 +1133,15 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
                             }
                         }
                     });
-                    // The following returns makes it impossible for packet listeners and collectors to
-                    // filter for IQ request stanzas, i.e. IQs of type 'set' or 'get'. This is the
-                    // desired behavior.
-                    return;
                 }
                 break;
             default:
                 break;
             }
+            // The following returns makes it impossible for packet listeners and collectors to
+            // filter for IQ request stanzas, i.e. IQs of type 'set' or 'get'. This is the
+            // desired behavior.
+            return;
         }
 
         // First handle the async recv listeners. Note that this code is very similar to what follows a few lines below,


### PR DESCRIPTION
…it, an error reply will be sent but the invokeStanzaCollectorsAndNotifyRecvListeners method will still fall through and pass the iq to any stanza listeners.  the docs (and the path where an iq request handler is successfully found) state that iq messages shouldn't be forwarded to the listeners.  this change moves the return statement to the bottom of the 'if (packet instanceof IQ)' block so that iq messages are never forwarded to the listeners.

i'll warn that this code is untested as i don't have the android sdk installed so haven't been able to build.