### PR TITLE
Update smack-repl gradle script

### DIFF
--- a/smack-repl/build.gradle
+++ b/smack-repl/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     testCompile project(path: ":smack-core", configuration: "archives")
 }
 
-task printClasspath(dependsOn: assemble) << {
-    println sourceSets.main.runtimeClasspath.asPath
+task printClasspath(dependsOn: assemble) {
+    doLast {
+        println sourceSets.main.runtimeClasspath.asPath
+    }
 }


### PR DESCRIPTION
replace deprecated "<<" semantic with "doLast".

This time target the correct branch