### PR TITLE
Presence Parser does only accept a valid priority number.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
@@ -552,6 +552,8 @@ public class PacketParserUtils {
                     break;
                 case "priority":
                     int priority = Integer.parseInt(parser.nextText());
+                    if ( priority < -128 || priority > 127 )
+                        priority = 0;
                     presence.setPriority(priority);
                     break;
                 case "show":


### PR DESCRIPTION
When an server or other party is sending a Presence with an invalid priority (e.g. 5225), it will trigger a reconnect of the smack client.

My proposed change adds a check during parsing which sets the priority to the default when the value is not in the correct range.

Receiving a presence with an invalid number does not interrupt the
connection.