### PR TITLE
Create alternative-session JingleReason

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/Jingle.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/Jingle.java
@@ -198,6 +198,11 @@ public final class Jingle extends IQ {
             return this;
         }
 
+        public Builder setReason(JingleReason reason) {
+            this.reason = reason;
+            return this;
+        }
+
         public Jingle build() {
             return new Jingle(sid, action, initiator, responder, reason, contents);
         }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jivesoftware.smack.packet.NamedElement;
+import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.util.XmlStringBuilder;
 
 /**
@@ -31,6 +32,27 @@ import org.jivesoftware.smack.util.XmlStringBuilder;
 public class JingleReason implements NamedElement {
 
     public static final String ELEMENT = "reason";
+
+    public static AlternativeSession AlternativeSession(String sessionId) {
+        return new AlternativeSession(sessionId);
+    }
+
+    public static final JingleReason Busy = new JingleReason(Reason.busy);
+    public static final JingleReason Cancel = new JingleReason(Reason.cancel);
+    public static final JingleReason ConnectivityError = new JingleReason(Reason.connectivity_error);
+    public static final JingleReason Decline = new JingleReason(Reason.decline);
+    public static final JingleReason Expired = new JingleReason(Reason.expired);
+    public static final JingleReason FailedApplication = new JingleReason(Reason.failed_application);
+    public static final JingleReason FailedTransport = new JingleReason(Reason.failed_transport);
+    public static final JingleReason GeneralError = new JingleReason(Reason.general_error);
+    public static final JingleReason Gone = new JingleReason(Reason.gone);
+    public static final JingleReason IncompatibleParameters = new JingleReason(Reason.incompatible_parameters);
+    public static final JingleReason MediaError = new JingleReason(Reason.media_error);
+    public static final JingleReason SecurityError = new JingleReason(Reason.security_error);
+    public static final JingleReason Success = new JingleReason(Reason.success);
+    public static final JingleReason Timeout = new JingleReason(Reason.timeout);
+    public static final JingleReason UnsupportedApplications = new JingleReason(Reason.unsupported_applications);
+    public static final JingleReason UnsupportedTransports = new JingleReason(Reason.unsupported_transports);
 
     public enum Reason {
         alternative_session,
@@ -52,7 +74,7 @@ public class JingleReason implements NamedElement {
         unsupported_transports,
         ;
 
-        private static final Map<String, Reason> LUT = new HashMap<>(Reason.values().length);
+        protected static final Map<String, Reason> LUT = new HashMap<>(Reason.values().length);
 
         static {
             for (Reason reason : Reason.values()) {
@@ -60,9 +82,9 @@ public class JingleReason implements NamedElement {
             }
         }
 
-        private final String asString;
+        protected final String asString;
 
-        private Reason() {
+        Reason() {
             asString = name().replace('_', '-');
         }
 
@@ -80,9 +102,9 @@ public class JingleReason implements NamedElement {
         }
     }
 
-    private final Reason reason;
+    protected final Reason reason;
 
-    public JingleReason(Reason reason) {
+    protected JingleReason(Reason reason) {
         this.reason = reason;
     }
 
@@ -102,4 +124,33 @@ public class JingleReason implements NamedElement {
         return xml;
     }
 
+
+    public static class AlternativeSession extends JingleReason {
+
+        public static final String SID = "sid";
+        private final String sessionId;
+
+        public AlternativeSession(String sessionId) {
+            super(Reason.alternative_session);
+            if (StringUtils.isNullOrEmpty(sessionId)) {
+                throw new NullPointerException("SessionID must not be null or empty.");
+            }
+            this.sessionId = sessionId;
+        }
+
+        @Override
+        public XmlStringBuilder toXML() {
+            XmlStringBuilder xml = new XmlStringBuilder(this);
+            xml.rightAngleBracket();
+
+            xml.openElement(reason.asString);
+            xml.openElement(SID);
+            xml.append(sessionId);
+            xml.closeElement(SID);
+            xml.closeElement(reason.asString);
+
+            xml.closeElement(this);
+            return xml;
+        }
+    }
 }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleReasonTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleReasonTest.java
@@ -31,38 +31,54 @@ public class JingleReasonTest extends SmackTestSuite {
     @Test
     public void parserTest() {
         assertEquals("<reason><success/></reason>",
-                new JingleReason(JingleReason.Reason.success).toXML().toString());
+                JingleReason.Success.toXML().toString());
         assertEquals("<reason><busy/></reason>",
-                new JingleReason(JingleReason.Reason.busy).toXML().toString());
+                JingleReason.Busy.toXML().toString());
         assertEquals("<reason><cancel/></reason>",
-                new JingleReason(JingleReason.Reason.cancel).toXML().toString());
+                JingleReason.Cancel.toXML().toString());
         assertEquals("<reason><connectivity-error/></reason>",
-                new JingleReason(JingleReason.Reason.connectivity_error).toXML().toString());
+                JingleReason.ConnectivityError.toXML().toString());
         assertEquals("<reason><decline/></reason>",
-                new JingleReason(JingleReason.Reason.decline).toXML().toString());
+                JingleReason.Decline.toXML().toString());
         assertEquals("<reason><expired/></reason>",
-                new JingleReason(JingleReason.Reason.expired).toXML().toString());
+                JingleReason.Expired.toXML().toString());
         assertEquals("<reason><unsupported-transports/></reason>",
-                new JingleReason(JingleReason.Reason.unsupported_transports).toXML().toString());
+                JingleReason.UnsupportedTransports.toXML().toString());
         assertEquals("<reason><failed-transport/></reason>",
-                new JingleReason(JingleReason.Reason.failed_transport).toXML().toString());
+                JingleReason.FailedTransport.toXML().toString());
         assertEquals("<reason><general-error/></reason>",
-                new JingleReason(JingleReason.Reason.general_error).toXML().toString());
+                JingleReason.GeneralError.toXML().toString());
         assertEquals("<reason><gone/></reason>",
-                new JingleReason(JingleReason.Reason.gone).toXML().toString());
+                JingleReason.Gone.toXML().toString());
         assertEquals("<reason><media-error/></reason>",
-                new JingleReason(JingleReason.Reason.media_error).toXML().toString());
+                JingleReason.MediaError.toXML().toString());
         assertEquals("<reason><security-error/></reason>",
-                new JingleReason(JingleReason.Reason.security_error).toXML().toString());
+                JingleReason.SecurityError.toXML().toString());
         assertEquals("<reason><unsupported-applications/></reason>",
-                new JingleReason(JingleReason.Reason.unsupported_applications).toXML().toString());
+                JingleReason.UnsupportedApplications.toXML().toString());
         assertEquals("<reason><timeout/></reason>",
-                new JingleReason(JingleReason.Reason.timeout).toXML().toString());
+                JingleReason.Timeout.toXML().toString());
         assertEquals("<reason><failed-application/></reason>",
-                new JingleReason(JingleReason.Reason.failed_application).toXML().toString());
+                JingleReason.FailedApplication.toXML().toString());
         assertEquals("<reason><incompatible-parameters/></reason>",
-                new JingleReason(JingleReason.Reason.incompatible_parameters).toXML().toString());
-        assertEquals(JingleReason.Reason.alternative_session, JingleReason.Reason.fromString("alternative-session"));
+                JingleReason.IncompatibleParameters.toXML().toString());
+        assertEquals("<reason><alternative-session><sid>1234</sid></alternative-session></reason>",
+                JingleReason.AlternativeSession("1234").toXML().toString());
+        // Alternative sessionID must not be empty
+        try {
+            JingleReason.AlternativeSession("");
+            fail();
+        } catch (NullPointerException e) {
+            // Expected
+        }
+        // Alternative sessionID must not be null
+        try {
+            JingleReason.AlternativeSession(null);
+            fail();
+        } catch (NullPointerException e) {
+            // Expected
+        }
+
         try {
             JingleReason.Reason nonExistent = JingleReason.Reason.fromString("illegal-reason");
             fail();

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleReasonTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleReasonTest.java
@@ -16,12 +16,12 @@
  */
 package org.jivesoftware.smackx.jingle;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
+
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smackx.jingle.element.JingleReason;
 import org.junit.Test;
-
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
 
 /**
  * Test JingleReason functionality.


### PR DESCRIPTION
The JingleReason class did not allow proper usage of the Reason `<alternative-session/>` since that had a child element `<sid/>`. This commit fixes the issue by introducing subclasses.