### PR TITLE
Remove unused errors and add missing ones

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleError.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleError.java
@@ -28,11 +28,11 @@ public final class JingleError implements ExtensionElement {
 
     public static final JingleError OUT_OF_ORDER = new JingleError("out-of-order");
 
+    public static final JingleError TIE_BREAK = new JingleError("tie-break");
+
     public static final JingleError UNKNOWN_SESSION = new JingleError("unknown-session");
 
-    public static final JingleError UNSUPPORTED_CONTENT = new JingleError("unsupported-content");
-
-    public static final JingleError UNSUPPORTED_TRANSPORTS = new JingleError("unsupported-transports");
+    public static final JingleError UNSUPPORTED_INFO = new JingleError("unsupported-info");
 
     private final String errorName;
 
@@ -71,10 +71,10 @@ public final class JingleError implements ExtensionElement {
             return OUT_OF_ORDER;
         case "unknown-session":
             return UNKNOWN_SESSION;
-        case "unsupported-content":
-            return UNSUPPORTED_CONTENT;
-        case "unsupported-transports":
-            return UNSUPPORTED_TRANSPORTS;
+        case "tie-break":
+            return TIE_BREAK;
+        case "unsupported-info":
+            return UNSUPPORTED_INFO;
         default:
             throw new IllegalArgumentException();
         }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleErrorTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleErrorTest.java
@@ -16,12 +16,12 @@
  */
 package org.jivesoftware.smackx.jingle;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
+
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smackx.jingle.element.JingleError;
 import org.junit.Test;
-
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
 
 /**
  * Test the JingleError class.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleErrorTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleErrorTest.java
@@ -24,7 +24,7 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
 
 /**
- * Test the JingleError class. TODO: Uncomment missing tests once implemented.
+ * Test the JingleError class.
  */
 public class JingleErrorTest extends SmackTestSuite {
 
@@ -32,12 +32,12 @@ public class JingleErrorTest extends SmackTestSuite {
     public void parserTest() {
         assertEquals("<out-of-order xmlns='urn:xmpp:jingle:errors:1'/>",
                 JingleError.fromString("out-of-order").toXML().toString());
-        //assertEquals("<tie-break xmlns='urn:xmpp:jingle:errors:1'/>",
-        //        JingleError.fromString("tie-break").toXML().toString());
+        assertEquals("<tie-break xmlns='urn:xmpp:jingle:errors:1'/>",
+                JingleError.fromString("tie-break").toXML().toString());
         assertEquals("<unknown-session xmlns='urn:xmpp:jingle:errors:1'/>",
                 JingleError.fromString("unknown-session").toXML().toString());
-        //assertEquals("<unsupported-info xmlns='urn:xmpp:jingle:errors:1'/>",
-        //          JingleError.fromString("unsupported-info").toXML().toString());
+        assertEquals("<unsupported-info xmlns='urn:xmpp:jingle:errors:1'/>",
+                  JingleError.fromString("unsupported-info").toXML().toString());
         assertEquals("unknown-session", JingleError.fromString("unknown-session").getMessage());
 
         try {


### PR DESCRIPTION
`<unsupported-content/>´ and ´<unsupported-transports/>` were removed in 2008, while `<tie-break/>` and `<unsupported-info/>` were missing according to XEP-0166.