### PR TITLE
Add JingleContentTransportInfo class

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContentTransport.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContentTransport.java
@@ -31,18 +31,33 @@ public abstract class JingleContentTransport implements ExtensionElement {
     public static final String ELEMENT = "transport";
 
     protected final List<JingleContentTransportCandidate> candidates;
+    protected final List<JingleContentTransportInfo> infos;
 
     protected JingleContentTransport(List<JingleContentTransportCandidate> candidates) {
+        this(candidates, null);
+    }
+
+    protected JingleContentTransport(List<JingleContentTransportCandidate> candidates, List<JingleContentTransportInfo> infos) {
         if (candidates != null) {
             this.candidates = Collections.unmodifiableList(candidates);
         }
         else {
             this.candidates = Collections.emptyList();
         }
+
+        if (infos != null) {
+            this.infos = infos;
+        } else {
+            this.infos = Collections.emptyList();
+        }
     }
 
     public List<JingleContentTransportCandidate> getCandidates() {
         return candidates;
+    }
+
+    public List<JingleContentTransportInfo> getInfos() {
+        return infos;
     }
 
     @Override
@@ -66,6 +81,7 @@ public abstract class JingleContentTransport implements ExtensionElement {
 
             xml.rightAngleBracket();
             xml.append(candidates);
+            xml.append(infos);
             xml.closeElement(this);
         }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContentTransportInfo.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContentTransportInfo.java
@@ -1,0 +1,26 @@
+/**
+ *
+ * Copyright 2017 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.jingle.element;
+
+import org.jivesoftware.smack.packet.NamedElement;
+
+/**
+ * Abstract JingleContentTransportInfo element.
+ */
+public abstract class JingleContentTransportInfo implements NamedElement {
+
+}


### PR DESCRIPTION
This class is used to enable representation of jingleTransportInfo messages (eg. 0260 Example 5).