### PR TITLE
Add Jingle InBandBytestream transports

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/element/JingleIBBTransport.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/element/JingleIBBTransport.java
@@ -1,0 +1,90 @@
+/**
+ *
+ * Copyright 2017 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.jingle.transports.jingle_ibb.element;
+
+import org.jivesoftware.smack.util.StringUtils;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+import org.jivesoftware.smackx.jingle.element.JingleContentTransport;
+
+/**
+ * Transport Element for JingleInBandBytestream transports.
+ */
+public class JingleIBBTransport extends JingleContentTransport {
+    public static final String NAMESPACE_V1 = "urn:xmpp:jingle:transports:ibb:1";
+    public static final String ATTR_BLOCK_SIZE = "block-size";
+    public static final String ATTR_SID = "sid";
+
+    public static final short DEFAULT_BLOCK_SIZE = 4096;
+
+    private final short blockSize;
+    private final String sid;
+
+    public JingleIBBTransport() {
+        this(DEFAULT_BLOCK_SIZE);
+    }
+
+    public JingleIBBTransport(String sid) {
+        this(DEFAULT_BLOCK_SIZE, sid);
+    }
+
+    public JingleIBBTransport(short blockSize) {
+        this(blockSize, StringUtils.randomString(24));
+    }
+
+    public JingleIBBTransport(short blockSize, String sid) {
+        super(null);
+        if (blockSize > 0) {
+            this.blockSize = blockSize;
+        } else {
+            this.blockSize = DEFAULT_BLOCK_SIZE;
+        }
+        this.sid = sid;
+    }
+
+    public String getSessionId() {
+        return sid;
+    }
+
+    public short getBlockSize() {
+        return blockSize;
+    }
+
+    @Override
+    protected void addExtraAttributes(XmlStringBuilder xml) {
+        xml.attribute(ATTR_BLOCK_SIZE, blockSize);
+        xml.attribute(ATTR_SID, sid);
+    }
+
+    @Override
+    public String getNamespace() {
+        return NAMESPACE_V1;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof JingleIBBTransport)) {
+            return false;
+        }
+
+        return this == other || this.hashCode() == other.hashCode();
+    }
+
+    @Override
+    public int hashCode() {
+        return this.toXML().toString().hashCode();
+    }
+}

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/element/package-info.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/element/package-info.java
@@ -1,0 +1,22 @@
+/**
+ *
+ * Copyright 2017 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Smack's API for <a href="https://xmpp.org/extensions/xep-0261.html">XEP-0261: Jingle In-Band Bytestreams</a>.
+ * Element classes.
+ */
+package org.jivesoftware.smackx.jingle.transports.jingle_ibb.element;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/package-info.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/package-info.java
@@ -1,0 +1,21 @@
+/**
+ *
+ * Copyright 2017 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Smack's API for <a href="https://xmpp.org/extensions/xep-0261.html">XEP-0261: Jingle In-Band Bytestreams</a>.
+ */
+package org.jivesoftware.smackx.jingle.transports.jingle_ibb;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/provider/JingleIBBTransportProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/provider/JingleIBBTransportProvider.java
@@ -1,0 +1,39 @@
+/**
+ *
+ * Copyright 2017 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.jingle.transports.jingle_ibb.provider;
+
+import org.jivesoftware.smackx.jingle.provider.JingleContentTransportProvider;
+import org.jivesoftware.smackx.jingle.transports.jingle_ibb.element.JingleIBBTransport;
+import org.xmlpull.v1.XmlPullParser;
+
+/**
+ * Parse JingleByteStreamTransport elements.
+ */
+public class JingleIBBTransportProvider extends JingleContentTransportProvider<JingleIBBTransport> {
+    @Override
+    public JingleIBBTransport parse(XmlPullParser parser, int initialDepth) throws Exception {
+        String blockSizeString = parser.getAttributeValue(null, JingleIBBTransport.ATTR_BLOCK_SIZE);
+        String sid = parser.getAttributeValue(null, JingleIBBTransport.ATTR_SID);
+
+        short blockSize = -1;
+        if (blockSizeString != null) {
+            blockSize = Short.valueOf(blockSizeString);
+        }
+
+        return new JingleIBBTransport(blockSize, sid);
+    }
+}

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/provider/package-info.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/provider/package-info.java
@@ -1,0 +1,22 @@
+/**
+ *
+ * Copyright 2017 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Smack's API for <a href="https://xmpp.org/extensions/xep-0261.html">XEP-0261: Jingle In-Band Bytestreams</a>.
+ * Provider classes.
+ */
+package org.jivesoftware.smackx.jingle.transports.jingle_ibb.provider;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/JingleIBBTransportTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/JingleIBBTransportTest.java
@@ -1,0 +1,71 @@
+/**
+ *
+ * Copyright © 2017 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.jingle.transports.jingle_ibb;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotSame;
+import static junit.framework.TestCase.assertTrue;
+
+import org.jivesoftware.smack.test.util.SmackTestSuite;
+import org.jivesoftware.smack.test.util.TestUtils;
+import org.jivesoftware.smack.util.StringUtils;
+import org.jivesoftware.smackx.jingle.transports.jingle_ibb.element.JingleIBBTransport;
+import org.jivesoftware.smackx.jingle.transports.jingle_ibb.provider.JingleIBBTransportProvider;
+import org.junit.Test;
+
+/**
+ * Test JingleIBBTransport provider and element.
+ */
+public class JingleIBBTransportTest extends SmackTestSuite {
+
+    @Test
+    public void parserTest() throws Exception {
+        String sid = StringUtils.randomString(24);
+        short size = 8192;
+
+        String xml = "<transport xmlns='urn:xmpp:jingle:transports:ibb:1' block-size='8192' sid='" + sid + "'/>";
+
+        JingleIBBTransport transport = new JingleIBBTransport(size, sid);
+        assertEquals(xml, transport.toXML().toString());
+        assertEquals(size, transport.getBlockSize());
+        assertEquals(sid, transport.getSessionId());
+
+        JingleIBBTransport parsed = new JingleIBBTransportProvider()
+                .parse(TestUtils.getParser(xml));
+        assertEquals(transport, parsed);
+        assertTrue(transport.equals(parsed));
+        assertEquals(xml, parsed.toXML().toString());
+
+        JingleIBBTransport transport1 = new JingleIBBTransport((short) 1024);
+        assertEquals((short) 1024, transport1.getBlockSize());
+        assertNotSame(transport, transport1);
+        assertNotSame(transport.getSessionId(), transport1.getSessionId());
+
+        assertFalse(transport.equals(null));
+
+        JingleIBBTransport transport2 = new JingleIBBTransport();
+        assertEquals(JingleIBBTransport.DEFAULT_BLOCK_SIZE, transport2.getBlockSize());
+        assertFalse(transport1.equals(transport2));
+
+        JingleIBBTransport transport3 = new JingleIBBTransport((short) -1024);
+        assertEquals(JingleIBBTransport.DEFAULT_BLOCK_SIZE, transport3.getBlockSize());
+
+        assertEquals(transport3.getNamespace(), JingleIBBTransport.NAMESPACE_V1);
+        assertEquals(transport3.getElementName(), "transport");
+    }
+}


### PR DESCRIPTION
This PR adds elements and providers of the Jingle InBandBytestream transport method (xep-0261)