### PR TITLE
Switch to single transport instead of list

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContent.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContent.java
@@ -16,10 +16,6 @@
  */
 package org.jivesoftware.smackx.jingle.element;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.jivesoftware.smack.packet.NamedElement;
 import org.jivesoftware.smack.util.Objects;
 import org.jivesoftware.smack.util.StringUtils;
@@ -70,24 +66,19 @@ public final class JingleContent implements NamedElement {
 
     private final JingleContentDescription description;
 
-    private final List<JingleContentTransport> transports;
+    private final JingleContentTransport transport;
 
     /**
      * Creates a content description..
      */
     private JingleContent(Creator creator, String disposition, String name, Senders senders,
-                    JingleContentDescription description, List<JingleContentTransport> transports) {
+                    JingleContentDescription description, JingleContentTransport transport) {
         this.creator = Objects.requireNonNull(creator, "Jingle content creator must not be null");
         this.disposition = disposition;
         this.name = StringUtils.requireNotNullOrEmpty(name, "Jingle content name must not be null or empty");
         this.senders = senders;
         this.description = description;
-        if (transports != null) {
-            this.transports = Collections.unmodifiableList(transports);
-        }
-        else {
-            this.transports = Collections.emptyList();
-        }
+        this.transport = transport;
     }
 
     public Creator getCreator() {
@@ -120,17 +111,8 @@ public final class JingleContent implements NamedElement {
      * 
      * @return an Iterator for the JingleTransports in the packet.
      */
-    public List<JingleContentTransport> getJingleTransports() {
-        return transports;
-    }
-
-    /**
-     * Returns a count of the JingleTransports in the Jingle packet.
-     * 
-     * @return the number of the JingleTransports in the Jingle packet.
-     */
-    public int getJingleTransportsCount() {
-        return transports.size();
+    public JingleContentTransport getJingleTransport() {
+        return transport;
     }
 
     @Override
@@ -148,8 +130,7 @@ public final class JingleContent implements NamedElement {
         xml.rightAngleBracket();
 
         xml.optAppend(description);
-
-        xml.append(transports);
+        xml.optElement(transport);
 
         xml.closeElement(this);
         return xml;
@@ -170,7 +151,7 @@ public final class JingleContent implements NamedElement {
 
         private JingleContentDescription description;
 
-        private List<JingleContentTransport> transports;
+        private JingleContentTransport transport;
 
         private Builder() {
         }
@@ -203,16 +184,13 @@ public final class JingleContent implements NamedElement {
             return this;
         }
 
-        public Builder addTransport(JingleContentTransport transport) {
-            if (transports == null) {
-                transports = new ArrayList<>(4);
-            }
-            transports.add(transport);
+        public Builder setTransport(JingleContentTransport transport) {
+            this.transport = transport;
             return this;
         }
 
         public JingleContent build() {
-            return new JingleContent(creator, disposition, name, senders, description, transports);
+            return new JingleContent(creator, disposition, name, senders, description, transport);
         }
     }
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContentTransport.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContentTransport.java
@@ -31,13 +31,13 @@ public abstract class JingleContentTransport implements ExtensionElement {
     public static final String ELEMENT = "transport";
 
     protected final List<JingleContentTransportCandidate> candidates;
-    protected final List<JingleContentTransportInfo> infos;
+    protected final JingleContentTransportInfo info;
 
     protected JingleContentTransport(List<JingleContentTransportCandidate> candidates) {
         this(candidates, null);
     }
 
-    protected JingleContentTransport(List<JingleContentTransportCandidate> candidates, List<JingleContentTransportInfo> infos) {
+    protected JingleContentTransport(List<JingleContentTransportCandidate> candidates, JingleContentTransportInfo info) {
         if (candidates != null) {
             this.candidates = Collections.unmodifiableList(candidates);
         }
@@ -45,19 +45,15 @@ public abstract class JingleContentTransport implements ExtensionElement {
             this.candidates = Collections.emptyList();
         }
 
-        if (infos != null) {
-            this.infos = infos;
-        } else {
-            this.infos = Collections.emptyList();
-        }
+        this.info = info;
     }
 
     public List<JingleContentTransportCandidate> getCandidates() {
         return candidates;
     }
 
-    public List<JingleContentTransportInfo> getInfos() {
-        return infos;
+    public JingleContentTransportInfo getInfo() {
+        return info;
     }
 
     @Override
@@ -81,7 +77,7 @@ public abstract class JingleContentTransport implements ExtensionElement {
 
             xml.rightAngleBracket();
             xml.append(candidates);
-            xml.append(infos);
+            xml.optElement(info);
             xml.closeElement(this);
         }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/provider/JingleProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/provider/JingleProvider.java
@@ -131,7 +131,7 @@ public class JingleProvider extends IQProvider<Jingle> {
                         break;
                     }
                     JingleContentTransport transport = provider.parse(parser);
-                    builder.addTransport(transport);
+                    builder.setTransport(transport);
                     break;
                 }
                 default:

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleActionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleActionTest.java
@@ -40,7 +40,7 @@ public class JingleActionTest extends SmackTestSuite {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void nonExistendEnumTest() {
+    public void nonExistentEnumTest() {
         JingleAction.fromString("inexistent-action");
     }
 }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleContentTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleContentTest.java
@@ -69,9 +69,6 @@ public class JingleContentTest extends SmackTestSuite {
         assertNotSame(content.toXML().toString(), content1.toXML().toString());
         assertEquals(content1.toXML().toString(), builder.build().toXML().toString());
 
-        assertEquals(0, content.getJingleTransportsCount());
-        assertNotNull(content.getJingleTransports());
-
         String xml =
                 "<content creator='initiator' disposition='session' name='A name' senders='both'>" +
                 "</content>";


### PR DESCRIPTION
According to XEPs 0166,0234,0260 and 0261 a content element can only have one single transport child (with multiple candidates). This PR changes the list of transports of the content element to a single transport.