### PR TITLE
fix SlotRequest to use attributes instead of elements

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/httpfileupload/element/SlotRequest.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/httpfileupload/element/SlotRequest.java
@@ -82,10 +82,10 @@ public class SlotRequest extends IQ {
 
     @Override
     protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
+        xml.attribute("filename", filename);
+        xml.attribute("size", String.valueOf(size));
+        xml.optAttribute("content-type", contentType);
         xml.rightAngleBracket();
-        xml.element("filename", filename);
-        xml.element("size", String.valueOf(size));
-        xml.optElement("content-type", contentType);
         return xml;
     }
 }


### PR DESCRIPTION
XEP-363 Spec indicates the values needed for requesting an upload slot should be passed as attributes and not child elements

See: https://xmpp.org/extensions/xep-0363.html#request