### PR TITLE
Fix typos in filetransfer package

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FaultTolerantNegotiator.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FaultTolerantNegotiator.java
@@ -35,7 +35,7 @@ import org.jxmpp.jid.Jid;
 
 /**
  * The fault tolerant negotiator takes two stream negotiators, the primary and the secondary
- * negotiator. If the primary negotiator fails during the stream negotiaton process, the second
+ * negotiator. If the primary negotiator fails during the stream negotiation process, the second
  * negotiator is used.
  */
 public class FaultTolerantNegotiator extends StreamNegotiator {
@@ -78,7 +78,7 @@ public class FaultTolerantNegotiator extends StreamNegotiator {
         } else if (streamInitiation instanceof Open) {
             return secondaryNegotiator;
         } else {
-            throw new IllegalStateException("Unknown stream initation type");
+            throw new IllegalStateException("Unknown stream initiation type");
         }
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransfer.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransfer.java
@@ -77,18 +77,18 @@ public abstract class FileTransfer {
     }
 
     /**
-     * Returns the size of the file being transfered.
+     * Returns the size of the file being transferred.
      *
-     * @return Returns the size of the file being transfered.
+     * @return Returns the size of the file being transferred.
      */
     public long getFileSize() {
         return fileSize;
     }
 
     /**
-     * Returns the name of the file being transfered.
+     * Returns the name of the file being transferred.
      *
-     * @return Returns the name of the file being transfered.
+     * @return Returns the name of the file being transferred.
      */
     public String getFileName() {
         return fileName;
@@ -247,7 +247,7 @@ public abstract class FileTransfer {
          * The file transfer is being negotiated with the peer. The party
          * Receiving the file has the option to accept or refuse a file transfer
          * request. If they accept, then the process of stream negotiation will
-         * begin. If they refuse the file will not be transfered.
+         * begin. If they refuse the file will not be transferred.
          *
          * @see #negotiating_stream
          */
@@ -294,7 +294,7 @@ public abstract class FileTransfer {
 
         private final String status;
 
-        private Status(String status) {
+        Status(String status) {
             this.status = status;
         }
 
@@ -337,16 +337,16 @@ public abstract class FileTransfer {
         /**
          * An error occurred over the socket connected to send the file.
          */
-        connection("An error occured over the socket connected to send the file."),
+        connection("An error occurred over the socket connected to send the file."),
 
         /**
          * An error occurred while sending or receiving the file.
          */
-        stream("An error occured while sending or recieving the file.");
+        stream("An error occurred while sending or receiving the file.");
 
         private final String msg;
 
-        private Error(String msg) {
+        Error(String msg) {
             this.msg = msg;
         }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferListener.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferListener.java
@@ -24,10 +24,10 @@ package org.jivesoftware.smackx.filetransfer;
  */
 public interface FileTransferListener {
     /**
-     * A request to send a file has been recieved from another user.
+     * A request to send a file has been received from another user.
      * 
      * @param request
      *            The request from the other user.
      */
-    public void fileTransferRequest(final FileTransferRequest request);
+    void fileTransferRequest(final FileTransferRequest request);
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferManager.java
@@ -34,10 +34,10 @@ import org.jivesoftware.smackx.si.packet.StreamInitiation;
 import org.jxmpp.jid.EntityFullJid;
 
 /**
- * The file transfer manager class handles the sending and recieving of files.
+ * The file transfer manager class handles the sending and receiving of files.
  * To send a file invoke the {@link #createOutgoingFileTransfer(EntityFullJid)} method.
  * <p>
- * And to recieve a file add a file transfer listener to the manager. The
+ * And to receive a file add a file transfer listener to the manager. The
  * listener will notify you when there is a new file transfer request. To create
  * the {@link IncomingFileTransfer} object accept the transfer, or, if the
  * transfer is not desirable reject it.
@@ -135,7 +135,7 @@ public final class FileTransferManager extends Manager {
     /**
      * When the file transfer request is acceptable, this method should be
      * invoked. It will create an IncomingFileTransfer which allows the
-     * transmission of the file to procede.
+     * transmission of the file to proceed.
      * 
      * @param request
      *            The remote request that is being accepted.
@@ -145,7 +145,7 @@ public final class FileTransferManager extends Manager {
     protected IncomingFileTransfer createIncomingFileTransfer(
             FileTransferRequest request) {
         if (request == null) {
-            throw new NullPointerException("RecieveRequest cannot be null");
+            throw new NullPointerException("ReceiveRequest cannot be null");
         }
 
         IncomingFileTransfer transfer = new IncomingFileTransfer(request,

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferRequest.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferRequest.java
@@ -23,7 +23,7 @@ import org.jivesoftware.smackx.si.packet.StreamInitiation;
 import org.jxmpp.jid.Jid;
 
 /**
- * A request to send a file recieved from another user.
+ * A request to send a file received from another user.
  * 
  * @author Alexander Wenckus
  * 
@@ -34,14 +34,14 @@ public class FileTransferRequest {
     private final FileTransferManager manager;
 
     /**
-     * A recieve request is constructed from the Stream Initiation request
-     * received from the initator.
+     * A receive request is constructed from the Stream Initiation request
+     * received from the initiator.
      * 
      * @param manager
      *            The manager handling this file transfer
      * 
      * @param si
-     *            The Stream initiaton recieved from the initiator.
+     *            The Stream initiation received from the initiator.
      */
     public FileTransferRequest(FileTransferManager manager, StreamInitiation si) {
         this.streamInitiation = si;
@@ -67,9 +67,9 @@ public class FileTransferRequest {
     }
 
     /**
-     * Returns the description of the file provided by the requestor.
+     * Returns the description of the file provided by the requester.
      * 
-     * @return Returns the description of the file provided by the requestor.
+     * @return Returns the description of the file provided by the requester.
      */
     public String getDescription() {
         return streamInitiation.getFile().getDesc();
@@ -106,12 +106,12 @@ public class FileTransferRequest {
     }
 
     /**
-     * Returns the stream initiation stanza(/packet) that was sent by the requestor which
+     * Returns the stream initiation stanza(/packet) that was sent by the requester which
      * contains the parameters of the file transfer being transfer and also the
      * methods available to transfer the file.
      * 
      * @return Returns the stream initiation stanza(/packet) that was sent by the
-     *         requestor which contains the parameters of the file transfer
+     *         requester which contains the parameters of the file transfer
      *         being transfer and also the methods available to transfer the
      *         file.
      */

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/IncomingFileTransfer.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/IncomingFileTransfer.java
@@ -43,13 +43,13 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
  * concerned with and they can be handled in different ways depending upon the
  * method that is invoked on this class.
  * <p/>
- * The first way that a file is recieved is by calling the
- * {@link #recieveFile()} method. This method, negotiates the appropriate stream
+ * The first way that a file is received is by calling the
+ * {@link #receiveFile()} method. This method, negotiates the appropriate stream
  * method and then returns the <b><i>InputStream</b></i> to read the file
  * data from.
  * <p/>
- * The second way that a file can be recieved through this class is by invoking
- * the {@link #recieveFile(File)} method. This method returns immediatly and
+ * The second way that a file can be received through this class is by invoking
+ * the {@link #receiveFile(File)} method. This method returns immediately and
  * takes as its parameter a file on the local file system where the file
  * recieved from the transfer will be put.
  *
@@ -59,14 +59,14 @@ public class IncomingFileTransfer extends FileTransfer {
 
     private static final Logger LOGGER = Logger.getLogger(IncomingFileTransfer.class.getName());
 
-    private FileTransferRequest recieveRequest;
+    private FileTransferRequest receiveRequest;
 
     private InputStream inputStream;
 
     protected IncomingFileTransfer(FileTransferRequest request,
             FileTransferNegotiator transferNegotiator) {
         super(request.getRequestor(), request.getStreamID(), transferNegotiator);
-        this.recieveRequest = request;
+        this.receiveRequest = request;
     }
 
     /**
@@ -79,7 +79,7 @@ public class IncomingFileTransfer extends FileTransfer {
      *                       is thrown.
      * @throws InterruptedException 
      */
-    public InputStream recieveFile() throws SmackException, XMPPErrorException, InterruptedException {
+    public InputStream receiveFile() throws SmackException, XMPPErrorException, InterruptedException {
         if (inputStream != null) {
             throw new IllegalStateException("Transfer already negotiated!");
         }
@@ -96,10 +96,10 @@ public class IncomingFileTransfer extends FileTransfer {
     }
 
     /**
-     * This method negotitates the stream and then transfer's the file over the negotiated stream.
-     * The transfered file will be saved at the provided location.
+     * This method negotiates the stream and then transfer's the file over the negotiated stream.
+     * The transferred file will be saved at the provided location.
      * <p/>
-     * This method will return immedialtly, file transfer progress can be monitored through several
+     * This method will return immediately, file transfer progress can be monitored through several
      * methods:
      * <p/>
      * <UL>
@@ -114,7 +114,7 @@ public class IncomingFileTransfer extends FileTransfer {
      * @throws IllegalArgumentException This exception is thrown when the the provided file is
      *         either null, or cannot be written to.
      */
-    public void recieveFile(final File file) throws SmackException, IOException {
+    public void receiveFile(final File file) throws SmackException, IOException {
         if (file == null) {
             throw new IllegalArgumentException("File cannot be null");
         }
@@ -180,7 +180,7 @@ public class IncomingFileTransfer extends FileTransfer {
     private InputStream negotiateStream() throws SmackException, XMPPErrorException, InterruptedException {
         setStatus(Status.negotiating_transfer);
         final StreamNegotiator streamNegotiator = negotiator
-                .selectStreamNegotiator(recieveRequest);
+                .selectStreamNegotiator(receiveRequest);
         setStatus(Status.negotiating_stream);
         FutureTask<InputStream> streamNegotiatorTask = new FutureTask<InputStream>(
                 new Callable<InputStream>() {
@@ -188,7 +188,7 @@ public class IncomingFileTransfer extends FileTransfer {
                     @Override
                     public InputStream call() throws Exception {
                         return streamNegotiator
-                                .createIncomingStream(recieveRequest.getStreamInitiation());
+                                .createIncomingStream(receiveRequest.getStreamInitiation());
                     }
                 });
         streamNegotiatorTask.run();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/OutgoingFileTransfer.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/OutgoingFileTransfer.java
@@ -128,7 +128,7 @@ public class OutgoingFileTransfer extends FileTransfer {
             String description) throws XMPPException, SmackException, InterruptedException {
         if (isDone() || outputStream != null) {
             throw new IllegalStateException(
-                    "The negotation process has already"
+                    "The negotiation process has already"
                             + " been attempted on this file transfer");
         }
         try {
@@ -169,7 +169,7 @@ public class OutgoingFileTransfer extends FileTransfer {
         checkTransferThread();
         if (isDone() || outputStream != null) {
             throw new IllegalStateException(
-                    "The negotation process has already"
+                    "The negotiation process has already"
                             + " been attempted for this file transfer");
         }
         setFileInfo(fileName, fileSize);

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferIntegrationTest.java
@@ -76,7 +76,7 @@ public class FileTransferIntegrationTest extends AbstractSmackIntegrationTest {
                 byte[] dataReceived = null;
                 IncomingFileTransfer ift = request.accept();
                 try {
-                    InputStream is = ift.recieveFile();
+                    InputStream is = ift.receiveFile();
                     ByteArrayOutputStream os = new ByteArrayOutputStream();
                     int nRead;
                     byte[] buf = new byte[1024];


### PR DESCRIPTION
While studying the filetransfer code, I found some typos.
My corrections involve mostly comments, but also one method (`IncomingFileTransfer.recieveFile()` -> `IncomingFileTransfer.receiveFile()`).