### PR TITLE
Allow parsing of JingleReason.AlternativeSession

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
@@ -156,5 +156,9 @@ public class JingleReason implements NamedElement {
             xml.closeElement(this);
             return xml;
         }
+
+        public String getAlternativeSessionId() {
+            return sessionId;
+        }
     }
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/provider/JingleProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/provider/JingleProvider.java
@@ -69,7 +69,14 @@ public class JingleProvider extends IQProvider<Jingle> {
                 case JingleReason.ELEMENT:
                     parser.next();
                     String reasonString = parser.getName();
-                    Reason reason = Reason.fromString(reasonString);
+                    JingleReason reason;
+                    if (reasonString.equals("alternative-session")) {
+                        parser.next();
+                        String sid = parser.nextText();
+                        reason = new JingleReason.AlternativeSession(sid);
+                    } else {
+                        reason = new JingleReason(Reason.fromString(reasonString));
+                    }
                     builder.setReason(reason);
                     break;
                 default:


### PR DESCRIPTION
The JingleReasonProvider was faulty and ignored the
`<alternative-session>` elements sid.