### PR TITLE
DON'T MERGE: Fix OmemoManager.getInstanceFor()

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackException.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackException.java
@@ -131,6 +131,10 @@ public class SmackException extends Exception {
         public NotLoggedInException() {
             super("Client is not logged in");
         }
+
+        public NotLoggedInException(String message) {
+            super("Client is not logged in. " + message);
+        }
     }
 
     public static class AlreadyLoggedInException extends SmackException {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/AbstractOmemoIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/AbstractOmemoIntegrationTest.java
@@ -16,6 +16,8 @@
  */
 package org.jivesoftware.smackx.omemo;
 
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.util.logging.Level;
 
@@ -65,7 +67,11 @@ public abstract class AbstractOmemoIntegrationTest extends AbstractSmackIntegrat
     public void beforeTest() {
         LOGGER.log(Level.INFO, "START EXECUTION");
         OmemoIntegrationTestHelper.deletePath(storePath);
-        before();
+        try {
+            before();
+        } catch (SmackException.NotLoggedInException e) {
+            fail();
+        }
     }
 
     @AfterClass
@@ -75,7 +81,7 @@ public abstract class AbstractOmemoIntegrationTest extends AbstractSmackIntegrat
         LOGGER.log(Level.INFO, "END EXECUTION");
     }
 
-    public abstract void before();
+    public abstract void before() throws SmackException.NotLoggedInException;
 
     public abstract void after();
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoInitializationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoInitializationTest.java
@@ -41,7 +41,7 @@ public class OmemoInitializationTest extends AbstractOmemoIntegrationTest {
     private OmemoStore<?,?,?,?,?,?,?,?,?> store;
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne, 666);
         store = OmemoService.getInstance().getOmemoStoreBackend();
     }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoKeyTransportTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoKeyTransportTest.java
@@ -55,7 +55,7 @@ public class OmemoKeyTransportTest extends AbstractOmemoIntegrationTest {
     }
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne, 11111);
         bob = OmemoManager.getInstanceFor(conTwo, 222222);
     }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoMessageSendingTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoMessageSendingTest.java
@@ -60,7 +60,7 @@ public class OmemoMessageSendingTest extends AbstractOmemoIntegrationTest {
     }
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne, 123);
         bob = OmemoManager.getInstanceFor(conTwo, 345);
         store = OmemoService.getInstance().getOmemoStoreBackend();

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoSessionRenegotiationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoSessionRenegotiationTest.java
@@ -52,7 +52,7 @@ public class OmemoSessionRenegotiationTest extends AbstractOmemoIntegrationTest 
     }
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne, 1337);
         bob = OmemoManager.getInstanceFor(conTwo, 1009);
         store = OmemoService.getInstance().getOmemoStoreBackend();

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoStoreTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoStoreTest.java
@@ -47,7 +47,7 @@ public class OmemoStoreTest extends AbstractOmemoIntegrationTest {
     }
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne);
         bob = OmemoManager.getInstanceFor(conOne);
     }


### PR DESCRIPTION
getInstanceFor(connection) and getInstanceFor(connection, deviceid)
now throw NotLoggedInExceptions. When such an exception is thrown,
the client should react by using getInstanceFor(connection, jid)
or getInstanceFor(connection, jid, deviceId).

PLEASE DON'T MERGE UNTIL FEEDBACK WAS RECEIVED.