### PR TITLE
Make XMPPError Condition to Type mapping consistent

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/XMPPError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/XMPPError.java
@@ -70,7 +70,7 @@ public class XMPPError extends AbstractError {
     public static final String ERROR = "error";
 
     private static final Logger LOGGER = Logger.getLogger(XMPPError.class.getName());
-    private static final Map<Condition, Type> CONDITION_TO_TYPE = new HashMap<Condition, Type>();
+    static final Map<Condition, Type> CONDITION_TO_TYPE = new HashMap<Condition, Type>();
 
     static {
         CONDITION_TO_TYPE.put(Condition.bad_request, Type.MODIFY);

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/XMPPError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/XMPPError.java
@@ -39,14 +39,14 @@ import org.jivesoftware.smack.util.XmlStringBuilder;
  *      <tr><td>conflict</td><td>CANCEL</td><td>8.3.3.2</td></tr>
  *      <tr><td>feature-not-implemented</td><td>CANCEL</td><td>8.3.3.3</td></tr>
  *      <tr><td>forbidden</td><td>AUTH</td><td>8.3.3.4</td></tr>
- *      <tr><td>gone</td><td>MODIFY</td><td>8.3.3.5</td></tr>
+ *      <tr><td>gone</td><td>CANCEL</td><td>8.3.3.5</td></tr>
  *      <tr><td>internal-server-error</td><td>WAIT</td><td>8.3.3.6</td></tr>
  *      <tr><td>item-not-found</td><td>CANCEL</td><td>8.3.3.7</td></tr>
  *      <tr><td>jid-malformed</td><td>MODIFY</td><td>8.3.3.8</td></tr>
- *      <tr><td>not-acceptable</td><td> MODIFY</td><td>8.3.3.9</td></tr>
+ *      <tr><td>not-acceptable</td><td>MODIFY</td><td>8.3.3.9</td></tr>
  *      <tr><td>not-allowed</td><td>CANCEL</td><td>8.3.3.10</td></tr>
  *      <tr><td>not-authorized</td><td>AUTH</td><td>8.3.3.11</td></tr>
- *      <tr><td>policy-violation</td><td>AUTH</td><td>8.3.3.12</td></tr>
+ *      <tr><td>policy-violation</td><td>MODIFY</td><td>8.3.3.12</td></tr>
  *      <tr><td>recipient-unavailable</td><td>WAIT</td><td>8.3.3.13</td></tr>
  *      <tr><td>redirect</td><td>MODIFY</td><td>8.3.3.14</td></tr>
  *      <tr><td>registration-required</td><td>AUTH</td><td>8.3.3.15</td></tr>
@@ -55,7 +55,7 @@ import org.jivesoftware.smack.util.XmlStringBuilder;
  *      <tr><td>resource-constraint</td><td>WAIT</td><td>8.3.3.18</td></tr>
  *      <tr><td>service-unavailable</td><td>CANCEL</td><td>8.3.3.19</td></tr>
  *      <tr><td>subscription-required</td><td>AUTH</td><td>8.3.3.20</td></tr>
- *      <tr><td>undefined-condition</td><td>WAIT</td><td>8.3.3.21</td></tr>
+ *      <tr><td>undefined-condition</td><td>MODIFY</td><td>8.3.3.21</td></tr>
  *      <tr><td>unexpected-request</td><td>WAIT</td><td>8.3.3.22</td></tr>
  * </table>
  *
@@ -91,9 +91,10 @@ public class XMPPError extends AbstractError {
         CONDITION_TO_TYPE.put(Condition.remote_server_not_found, Type.CANCEL);
         CONDITION_TO_TYPE.put(Condition.remote_server_timeout, Type.WAIT);
         CONDITION_TO_TYPE.put(Condition.resource_constraint, Type.WAIT);
-        CONDITION_TO_TYPE.put(Condition.service_unavailable, Type.WAIT);
-        CONDITION_TO_TYPE.put(Condition.subscription_required, Type.WAIT);
-        CONDITION_TO_TYPE.put(Condition.unexpected_request, Type.MODIFY);
+        CONDITION_TO_TYPE.put(Condition.service_unavailable, Type.CANCEL);
+        CONDITION_TO_TYPE.put(Condition.subscription_required, Type.AUTH);
+        CONDITION_TO_TYPE.put(Condition.undefined_condition, Type.MODIFY);
+        CONDITION_TO_TYPE.put(Condition.unexpected_request, Type.WAIT);
     }
 
     private final Condition condition;

--- a/smack-core/src/test/java/org/jivesoftware/smack/packet/XMPPErrorTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/packet/XMPPErrorTest.java
@@ -1,0 +1,35 @@
+/**
+ *
+ * Copyright © 2017 Ingo Bauersachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.packet;
+
+import static org.jivesoftware.smack.packet.XMPPError.Condition;
+import static org.jivesoftware.smack.packet.XMPPError.Type;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class XMPPErrorTest {
+    @Test
+    public void testConditionHasDefaultTypeMapping() throws NoSuchFieldException, IllegalAccessException {
+        Map<Condition, Type> conditionToTypeMap = XMPPError.CONDITION_TO_TYPE;
+        assertEquals("CONDITION_TO_TYPE map is likely out of sync with Condition enum",
+                Condition.values().length,
+                conditionToTypeMap.size());
+    }
+}


### PR DESCRIPTION
The Javadoc for several `Condition`s did not match what was actually mapped. Some `Condition`s also had `Type`s that did not match RFC6120. When RFC6120 suggets multiple types, pick the first in the list. In case no type is suggested (`undefined-condition`), use the type in the example stanza.

A new unit test checks that the number of `Condition`s matches the number of entries in the mapping table. For 4.3 it might be better to remove the mapping table and specify the `Type` as a property (constructor parameter+field+getter) in the `Condition` enum. This would make the test obsolete and would gurantee that each `Condition` has a `Type`.