### PR TITLE
Make UnknownIqRequestReplyMode public

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
@@ -371,7 +371,7 @@ public final class SmackConfiguration {
         return defaultHostnameVerififer;
     }
 
-    enum UnknownIqRequestReplyMode {
+    public enum UnknownIqRequestReplyMode {
         doNotReply,
         replyFeatureNotImplemented,
         replyServiceUnavailable,


### PR DESCRIPTION
If it is not made public, then SmackConfiguration.(g|s)etUnknownIqRequestReplyMode cannot
be used.