### PR TITLE
Keep 4.1.9 chat.sendMessage(String) behavior

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smack/chat2/Chat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smack/chat2/Chat.java
@@ -42,6 +42,7 @@ public final class Chat extends Manager {
     public void send(CharSequence message) throws NotConnectedException, InterruptedException {
         Message stanza = new Message();
         stanza.setBody(message);
+        stanza.setType(Message.Type.chat);
         send(stanza);
     }
 


### PR DESCRIPTION
chat2.Chat.send(String) should have the same behavior as chat.Chat.sendMessage(String)