### PR TITLE
Updated comments to indicate that reject_all is default SubscriptionMode

### DIFF
--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
@@ -215,7 +215,7 @@ public final class Roster extends Manager {
      * Returns the default subscription processing mode to use when a new Roster is created. The
      * subscription processing mode dictates what action Smack will take when subscription
      * requests from other users are made. The default subscription mode
-     * is {@link SubscriptionMode#accept_all}.
+     * is {@link SubscriptionMode#reject_all}.
      *
      * @return the default subscription mode to use for new Rosters
      */
@@ -227,7 +227,7 @@ public final class Roster extends Manager {
      * Sets the default subscription processing mode to use when a new Roster is created. The
      * subscription processing mode dictates what action Smack will take when subscription
      * requests from other users are made. The default subscription mode
-     * is {@link SubscriptionMode#accept_all}.
+     * is {@link SubscriptionMode#reject_all}.
      *
      * @param subscriptionMode the default subscription mode to use for new Rosters.
      */
@@ -385,7 +385,7 @@ public final class Roster extends Manager {
     /**
      * Returns the subscription processing mode, which dictates what action
      * Smack will take when subscription requests from other users are made.
-     * The default subscription mode is {@link SubscriptionMode#accept_all}.
+     * The default subscription mode is {@link SubscriptionMode#reject_all}.
      * <p>
      * If using the manual mode, a PacketListener should be registered that
      * listens for Presence packets that have a type of
@@ -401,7 +401,7 @@ public final class Roster extends Manager {
     /**
      * Sets the subscription processing mode, which dictates what action
      * Smack will take when subscription requests from other users are made.
-     * The default subscription mode is {@link SubscriptionMode#accept_all}.
+     * The default subscription mode is {@link SubscriptionMode#reject_all}.
      * <p>
      * If using the manual mode, a PacketListener should be registered that
      * listens for Presence packets that have a type of
@@ -1409,14 +1409,14 @@ public final class Roster extends Manager {
     public enum SubscriptionMode {
 
         /**
-         * Automatically accept all subscription and unsubscription requests. This is
-         * the default mode and is suitable for simple client. More complex client will
+         * Automatically accept all subscription and unsubscription requests.
+         * This is suitable for simple clients. More complex client will
          * likely wish to handle subscription requests manually.
          */
         accept_all,
 
         /**
-         * Automatically reject all subscription requests.
+         * Automatically reject all subscription requests. This is the default.
          */
         reject_all,
 


### PR DESCRIPTION
Small correction to comments to reflect the change in default SubscriptionMode