### PR TITLE
Fix getInstanceFor for offline usage.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackException.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackException.java
@@ -131,6 +131,10 @@ public class SmackException extends Exception {
         public NotLoggedInException() {
             super("Client is not logged in");
         }
+
+        public NotLoggedInException(String message) {
+            super("Client is not logged in. " + message);
+        }
     }
 
     public static class AlreadyLoggedInException extends SmackException {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/AbstractOmemoIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/AbstractOmemoIntegrationTest.java
@@ -16,6 +16,8 @@
  */
 package org.jivesoftware.smackx.omemo;
 
+import static junit.framework.TestCase.fail;
+
 import java.io.File;
 import java.util.logging.Level;
 
@@ -65,7 +67,11 @@ public abstract class AbstractOmemoIntegrationTest extends AbstractSmackIntegrat
     public void beforeTest() {
         LOGGER.log(Level.INFO, "START EXECUTION");
         OmemoIntegrationTestHelper.deletePath(storePath);
-        before();
+        try {
+            before();
+        } catch (SmackException.NotLoggedInException e) {
+            fail(e.getMessage());
+        }
     }
 
     @AfterClass
@@ -75,7 +81,7 @@ public abstract class AbstractOmemoIntegrationTest extends AbstractSmackIntegrat
         LOGGER.log(Level.INFO, "END EXECUTION");
     }
 
-    public abstract void before();
+    public abstract void before() throws SmackException.NotLoggedInException;
 
     public abstract void after();
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoInitializationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoInitializationTest.java
@@ -42,7 +42,7 @@ public class OmemoInitializationTest extends AbstractOmemoIntegrationTest {
     private OmemoStore<?,?,?,?,?,?,?,?,?> store;
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne, 666);
         store = OmemoService.getInstance().getOmemoStoreBackend();
     }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoKeyTransportTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoKeyTransportTest.java
@@ -55,7 +55,7 @@ public class OmemoKeyTransportTest extends AbstractOmemoIntegrationTest {
     }
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne, 11111);
         bob = OmemoManager.getInstanceFor(conTwo, 222222);
     }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoMessageSendingTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoMessageSendingTest.java
@@ -61,7 +61,7 @@ public class OmemoMessageSendingTest extends AbstractOmemoIntegrationTest {
     }
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne, 123);
         bob = OmemoManager.getInstanceFor(conTwo, 345);
         store = OmemoService.getInstance().getOmemoStoreBackend();

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoSessionRenegotiationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoSessionRenegotiationTest.java
@@ -52,7 +52,7 @@ public class OmemoSessionRenegotiationTest extends AbstractOmemoIntegrationTest 
     }
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne, 1337);
         bob = OmemoManager.getInstanceFor(conTwo, 1009);
         store = OmemoService.getInstance().getOmemoStoreBackend();
@@ -61,7 +61,6 @@ public class OmemoSessionRenegotiationTest extends AbstractOmemoIntegrationTest 
     @SmackIntegrationTest
     public void sessionRenegotiationTest() throws Exception {
 
-        final boolean[] phaseTwo = new boolean[1];
         final SimpleResultSyncPoint sp1 = new SimpleResultSyncPoint();
         final SimpleResultSyncPoint sp2 = new SimpleResultSyncPoint();
         final SimpleResultSyncPoint sp3 = new SimpleResultSyncPoint();

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoStoreTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoStoreTest.java
@@ -48,7 +48,7 @@ public class OmemoStoreTest extends AbstractOmemoIntegrationTest {
     }
 
     @Override
-    public void before() {
+    public void before() throws SmackException.NotLoggedInException {
         alice = OmemoManager.getInstanceFor(conOne);
         bob = OmemoManager.getInstanceFor(conOne);
     }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoStoreTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoStoreTest.java
@@ -22,6 +22,7 @@ import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertNotSame;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.jivesoftware.smackx.omemo.OmemoIntegrationTestHelper.cleanServerSideTraces;
 import static org.jivesoftware.smackx.omemo.OmemoIntegrationTestHelper.deletePath;
 import static org.jivesoftware.smackx.omemo.OmemoIntegrationTestHelper.setUpOmemoManager;
 
@@ -156,5 +157,7 @@ public class OmemoStoreTest extends AbstractOmemoIntegrationTest {
     public void after() {
         alice.shutdown();
         bob.shutdown();
+        cleanServerSideTraces(alice);
+        cleanServerSideTraces(bob);
     }
 }


### PR DESCRIPTION
This should fix the issue of multiple OmemoStore account identities being generated due to the BareJid not being known before user login.

This PR changes the behaviour of `getInstanceFor(connection)` and `getInstanceFor(connection, deviceId)` by throwing an exception when the jid cannot be retrieved. To allow offline usage, `getInstanceFor(connection, bareJid, deviceId)` is introduced which the client can use to pass the bareJid they expect to smack-omemo.