### PR TITLE
Drop stream management state on StreamManagementException

### DIFF
--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -310,7 +310,7 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         addConnectionListener(new AbstractConnectionListener() {
             @Override
             public void connectionClosedOnError(Exception e) {
-                if (e instanceof XMPPException.StreamErrorException) {
+                if (e instanceof XMPPException.StreamErrorException || e instanceof StreamManagementException) {
                     dropSmState();
                 }
             }


### PR DESCRIPTION
Stream management state should be dropped on StreamManagementException. Otherwise client may keep trying to reconnect with a bad SM state.