### PR TITLE
Retain old API

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
@@ -280,6 +280,16 @@ public final class SmackConfiguration {
         compressionHandlers.add(xmppInputOutputStream);
     }
 
+    /**
+     * Get compression handlers.
+     *
+     * @deprecated use {@link #getCompressionHandlers()} instead.
+     */
+    @Deprecated
+    public static List<XMPPInputOutputStream> getCompresionHandlers() {
+        return getCompressionHandlers();
+    }
+
     public static List<XMPPInputOutputStream> getCompressionHandlers() {
         List<XMPPInputOutputStream> res = new ArrayList<>(compressionHandlers.size());
         for (XMPPInputOutputStream ios : compressionHandlers) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/IQ.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/IQ.java
@@ -215,6 +215,14 @@ public abstract class IQ extends Stanza {
      */
     protected abstract IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml);
 
+    /**
+     * @deprecated use {@link #initializeAsResultFor(IQ)} instead.
+     */
+    @Deprecated
+    protected final void initialzeAsResultFor(IQ request) {
+        initializeAsResultFor(request);
+    }
+
     protected final void initializeAsResultFor(IQ request) {
         if (!(request.getType() == Type.get || request.getType() == Type.set)) {
             throw new IllegalArgumentException(

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/ByteUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/ByteUtils.java
@@ -17,6 +17,17 @@
 package org.jivesoftware.smack.util;
 
 public class ByteUtils {
+
+    /**
+     * Concatenate two byte arrays.
+     *
+     * @deprecated use {@link #concat(byte[], byte[])} instead.
+     */
+    @Deprecated
+    public static byte[] concact(byte[] arrayOne, byte[] arrayTwo) {
+        return concat(arrayOne, arrayTwo);
+    }
+
     public static byte[] concat(byte[] arrayOne, byte[] arrayTwo) {
         int combinedLength = arrayOne.length + arrayTwo.length;
         byte[] res = new byte[combinedLength];

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/PacketUtil.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/PacketUtil.java
@@ -24,6 +24,22 @@ public class PacketUtil {
 
     /**
      * Get a extension element from a collection.
+     * @param collection
+     * @param element
+     * @param namespace
+     * @param <PE>
+     * @return the extension element
+     * @deprecated use {@link #extensionElementFrom(Collection, String, String)} instead.
+     */
+    @Deprecated
+    public static <PE extends ExtensionElement> PE packetExtensionfromCollection(
+            Collection<ExtensionElement> collection, String element,
+            String namespace) {
+        return extensionElementFrom(collection, element, namespace);
+    }
+
+    /**
+     * Get a extension element from a collection.
      *
      * @param collection
      * @param element

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/jmf/AudioMediaSession.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/jmf/AudioMediaSession.java
@@ -90,6 +90,16 @@ public class AudioMediaSession extends JingleMediaSession {
 
     /**
      * Starts transmission and for NAT Traversal reasons start receiving also.
+     *
+     * @deprecated use {@link #startTransmit()} instead.
+     */
+    @Deprecated
+    public void startTrasmit() {
+        startTransmit();
+    }
+
+    /**
+     * Starts transmission and for NAT Traversal reasons start receiving also.
      */
     @Override
     public void startTransmit() {
@@ -97,7 +107,19 @@ public class AudioMediaSession extends JingleMediaSession {
     }
 
     /**
-     * Set transmit activity. If the active is true, the instance should trasmit.
+     * Set transmit activity. If the active is true, the instance should transmit.
+     * If it is set to false, the instance should pause transmit.
+     *
+     * @param active active state
+     * @deprecated use {@link #setTransmit(boolean)} instead.
+     */
+    @Deprecated
+    public void setTrasmit(boolean active) {
+        setTransmit(active);
+    }
+
+    /**
+     * Set transmit activity. If the active is true, the instance should transmit.
      * If it is set to false, the instance should pause transmit.
      *
      * @param active active state
@@ -113,6 +135,16 @@ public class AudioMediaSession extends JingleMediaSession {
     @Override
     public void startReceive() {
         // Do nothing
+    }
+
+    /**
+     * Stops transmission and for NAT Traversal reasons stop receiving also.
+     *
+     * @deprecated use {@link #stopTransmit()} instead.
+     */
+    @Deprecated
+    public void stopTrasmit() {
+        stopTransmit();
     }
 
     /**

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/jspeex/AudioMediaSession.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/jspeex/AudioMediaSession.java
@@ -155,6 +155,16 @@ public class AudioMediaSession extends JingleMediaSession implements MediaSessio
 
     /**
      * Starts transmission and for NAT Traversal reasons start receiving also.
+     *
+     * @deprecated use {@link #startTransmit()} instead.
+     */
+    @Deprecated
+    public void startTrasmit() {
+        startTransmit();
+    }
+
+    /**
+     * Starts transmission and for NAT Traversal reasons start receiving also.
      */
     @Override
     public void startTransmit() {
@@ -166,6 +176,18 @@ public class AudioMediaSession extends JingleMediaSession implements MediaSessio
         catch (IOException e) {
             LOGGER.log(Level.WARNING, "exception", e);
         }
+    }
+
+    /**
+     * Set transmit activity. If the active is true, the instance should transmit.
+     * If it is set to false, the instance should pause transmit.
+     *
+     * @param active active state
+     * @deprecated use {@link #setTransmit(boolean)} instead.
+     */
+    @Deprecated
+    public void setTrasmit(boolean active) {
+        setTransmit(active);
     }
 
     /**
@@ -185,6 +207,16 @@ public class AudioMediaSession extends JingleMediaSession implements MediaSessio
     @Override
     public void startReceive() {
         // Do nothing
+    }
+
+    /**
+     * Stops transmission and for NAT Traversal reasons stop receiving also.
+     *
+     * @deprecated use {@link #stopTransmit()} instead.
+     */
+    @Deprecated
+    public void stopTrasmit() {
+        stopTransmit();
     }
 
     /**

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/sshare/ScreenShareSession.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/sshare/ScreenShareSession.java
@@ -121,10 +121,32 @@ public class ScreenShareSession extends JingleMediaSession {
 
     /**
      * Starts transmission and for NAT Traversal reasons start receiving also.
+     *
+     * @deprecated use {@link #startTransmit()} instead.
+     */
+    @Deprecated
+    public void startTrasmit() {
+        startTransmit();
+    }
+
+    /**
+     * Starts transmission and for NAT Traversal reasons start receiving also.
      */
     @Override
     public void startTransmit() {
         new Thread(transmitter).start();
+    }
+
+    /**
+     * Set transmit activity. If the active is true, the instance should transmit.
+     * If it is set to false, the instance should pause transmit.
+     *
+     * @param active active state
+     * @deprecated use {@link #setTransmit(boolean)} instead.
+     */
+    @Deprecated
+    public void setTrasmit(boolean active) {
+        setTransmit(active);
     }
 
     /**
@@ -144,6 +166,16 @@ public class ScreenShareSession extends JingleMediaSession {
     @Override
     public void startReceive() {
         // Do nothing
+    }
+
+    /**
+     * Stops transmission and for NAT Traversal reasons stop receiving also.
+     *
+     * @deprecated use {@link #stopTransmit()} instead.
+     */
+    @Deprecated
+    public void stopTrasmit() {
+        stopTransmit();
     }
 
     /**


### PR DESCRIPTION
PR #188 changed the signatures of some methods in order to fix typos.
This PR restores the old API, by adding back the old signatures annotated as deprecated.