### PR TITLE
Fix javadoc issues in some packages

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -300,6 +300,7 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
      * Send a HTTP request to the connection manager with the provided body element.
      * 
      * @param body the body which will be sent.
+     * @throws BOSHException
      */
     protected void send(ComposableBody body) throws BOSHException {
         if (!connected) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -1017,6 +1017,11 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
 
     private SmackConfiguration.UnknownIqRequestReplyMode unknownIqRequestReplyMode = SmackConfiguration.getUnknownIqRequestReplyMode();
 
+    /**
+     * Set how Smack behaves when an unknown IQ request has been received.
+     *
+     * @param unknownIqRequestReplyMode reply mode.
+     */
     public void setUnknownIqRequestReplyMode(UnknownIqRequestReplyMode unknownIqRequestReplyMode) {
         this.unknownIqRequestReplyMode = Objects.requireNonNull(unknownIqRequestReplyMode, "Mode must not be null");
     }
@@ -1026,8 +1031,8 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
      * {@link org.jivesoftware.smack.packet.XMPPError.Condition#feature_not_implemented} when a request IQ without a
      * registered {@link IQRequestHandler} is received.
      *
-     * @param replyToUnknownIq
-     * @deprecated use {@link #setUnknownIqRequestReplyMode(UnknownIqRequestReplyMode)} instead.
+     * @param replyToUnknownIq whether Smack should reply to unknown IQs or not.
+     * @deprecated use {@link AbstractXMPPConnection#setUnknownIqRequestReplyMode(UnknownIqRequestReplyMode)} instead.
      */
     @Deprecated
     // TODO Remove in Smack 4.3

--- a/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
@@ -881,6 +881,7 @@ public abstract class ConnectionConfiguration {
          * argument. It also calls {@link #allowEmptyOrNullUsernames()} and {@link #setSecurityMode(ConnectionConfiguration.SecurityMode)} to
          * {@link SecurityMode#required}.
          *
+         * @param sslContext custom SSLContext to be used.
          * @return a reference to this builder.
          */
         public B performSaslExternalAuthentication(SSLContext sslContext) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/SASLAuthentication.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SASLAuthentication.java
@@ -260,6 +260,7 @@ public final class SASLAuthentication {
     /**
      * Notification message saying that SASL authentication was successful. The next step
      * would be to bind the resource.
+     * @param success result of the authentication.
      * @throws SmackException 
      * @throws InterruptedException 
      */

--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
@@ -295,6 +295,8 @@ public final class SmackConfiguration {
      * of a TLS certificate. XMPP connections are able to overwrite this settings by supplying a
      * HostnameVerifier in their ConnectionConfiguration with
      * {@link ConnectionConfiguration.Builder#setHostnameVerifier(HostnameVerifier)}.
+     *
+     * @param verifier HostnameVerifier
      */
     public static void setDefaultHostnameVerifier(HostnameVerifier verifier) {
         defaultHostnameVerififer = verifier;

--- a/smack-core/src/main/java/org/jivesoftware/smack/StanzaCollector.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/StanzaCollector.java
@@ -109,6 +109,7 @@ public class StanzaCollector {
      * immediately returns <tt>null</tt> if no packets are currently in the
      * result queue.
      *
+     * @param <P> type of the result stanza.
      * @return the next stanza(/packet) result, or <tt>null</tt> if there are no more
      *      results.
      */
@@ -124,7 +125,8 @@ public class StanzaCollector {
      * <p>
      * Throws an XMPPErrorException in case the polled stanzas did contain an XMPPError.
      * </p>
-     * 
+     *
+     * @param <P> type of the result stanza.
      * @return the next available packet.
      * @throws XMPPErrorException in case an error response.
      */
@@ -139,7 +141,8 @@ public class StanzaCollector {
     /**
      * Returns the next available packet. The method call will block (not return) until a stanza(/packet) is
      * available.
-     * 
+     *
+     * @param <P> type of the result stanza.
      * @return the next available packet.
      * @throws InterruptedException 
      */
@@ -156,7 +159,8 @@ public class StanzaCollector {
     /**
      * Returns the next available packet. The method call will block until the connection's default
      * timeout has elapsed.
-     * 
+     *
+     * @param <P> type of the result stanza.
      * @return the next available packet.
      * @throws InterruptedException 
      */
@@ -171,6 +175,7 @@ public class StanzaCollector {
      * until a stanza(/packet) is available or the <tt>timeout</tt> has elapsed. If the
      * timeout elapses without a result, <tt>null</tt> will be returned.
      *
+     * @param <P> type of the result stanza.
      * @param timeout the timeout in milliseconds.
      * @return the next available packet.
      * @throws InterruptedException 
@@ -195,7 +200,8 @@ public class StanzaCollector {
      * Returns the next available stanza. The method in equivalent to
      * {@link #nextResultOrThrow(long)} where the timeout argument is the default reply timeout of
      * the connection associated with this collector.
-     * 
+     *
+     * @param <P> type of the result stanza.
      * @return the next available stanza.
      * @throws XMPPErrorException in case an error response was received.
      * @throws NoResponseException if there was no response from the server.
@@ -236,6 +242,7 @@ public class StanzaCollector {
      * </p>
      *
      * @param timeout the amount of time to wait for the next stanza in milliseconds.
+     * @param <P> type of the result stanza.
      * @return the next available stanza.
      * @throws NoResponseException if there was no response from the server.
      * @throws XMPPErrorException in case an error response was received.

--- a/smack-core/src/main/java/org/jivesoftware/smack/SynchronizationPoint.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SynchronizationPoint.java
@@ -68,6 +68,7 @@ public class SynchronizationPoint<E extends Exception> {
      * @param request the plain stream element to send.
      * @throws NoResponseException if no response was received.
      * @throws NotConnectedException if the connection is not connected.
+     * @throws InterruptedException if the connection is interrupted.
      * @return <code>null</code> if synchronization point was successful, or the failure Exception.
      */
     public E sendAndWaitForResponse(TopLevelStreamElement request) throws NoResponseException,
@@ -101,6 +102,7 @@ public class SynchronizationPoint<E extends Exception> {
      * @throws E if an failure was reported.
      * @throws NoResponseException if no response was received.
      * @throws NotConnectedException if the connection is not connected.
+     * @throws InterruptedException if the connection is interrupted.
      */
     public void sendAndWaitForResponseOrThrow(Nonza request) throws E, NoResponseException,
                     NotConnectedException, InterruptedException {
@@ -120,7 +122,7 @@ public class SynchronizationPoint<E extends Exception> {
      * Check if this synchronization point is successful or wait the connections reply timeout.
      * @throws NoResponseException if there was no response marking the synchronization point as success or failed.
      * @throws E if there was a failure
-     * @throws InterruptedException 
+     * @throws InterruptedException if the connection is interrupted.
      */
     public void checkIfSuccessOrWaitOrThrow() throws NoResponseException, E, InterruptedException {
         checkIfSuccessOrWait();

--- a/smack-core/src/main/java/org/jivesoftware/smack/XMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/XMPPConnection.java
@@ -44,13 +44,13 @@ import org.jxmpp.jid.EntityFullJid;
  * // Most servers require you to login before performing other tasks.
  * con.login("jsmith", "mypass");
  * // Start a new conversation with John Doe and send him a message.
- * Chat chat = ChatManager.getInstanceFor(con).createChat(<font color="green">"jdoe@igniterealtime.org"</font>, new MessageListener() {
+ * Chat chat = ChatManager.getInstanceFor(con).createChat("jdoe@igniterealtime.org", new MessageListener() {
  *     public void processMessage(Chat chat, Message message) {
  *         // Print out any messages we get back to standard out.
- *         System.out.println(<font color="green">"Received message: "</font> + message);
+ *         System.out.println("Received message: " + message);
  *     }
  * });
- * chat.sendMessage(<font color="green">"Howdy!"</font>);
+ * chat.sendMessage("Howdy!");
  * // Disconnect from the server
  * con.disconnect();
  * </pre>
@@ -484,7 +484,8 @@ public interface XMPPConnection {
     /**
      * Get the feature stanza(/packet) extensions for a given stream feature of the
      * server, or <code>null</code> if the server doesn't support that feature.
-     * 
+     *
+     * @param <F> {@link ExtensionElement} type of the feature.
      * @param element
      * @param namespace
      * @return a stanza(/packet) extensions of the feature or <code>null</code>

--- a/smack-core/src/main/java/org/jivesoftware/smack/XMPPException.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/XMPPException.java
@@ -90,7 +90,8 @@ public abstract class XMPPException extends Exception {
 
         /**
          * Creates a new XMPPErrorException with the XMPPError that was the root case of the exception.
-         * 
+         *
+         * @param stanza stanza that contained the exception.
          * @param error the root cause of the exception.
          */
         public XMPPErrorException(Stanza stanza, XMPPError error) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/debugger/SmackDebugger.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/debugger/SmackDebugger.java
@@ -64,6 +64,7 @@ public interface SmackDebugger {
      * needs to wrap the new reader and writer to keep being notified of the connection
      * traffic.
      *
+     * @param reader connection reader.
      * @return a new special Reader that wraps the new connection Reader.
      */
     public abstract Reader newConnectionReader(Reader reader);
@@ -74,6 +75,7 @@ public interface SmackDebugger {
      * needs to wrap the new reader and writer to keep being notified of the connection
      * traffic.
      *
+     * @param writer connection writer.
      * @return a new special Writer that wraps the new connection Writer.
      */
     public abstract Writer newConnectionWriter(Writer writer);

--- a/smack-core/src/main/java/org/jivesoftware/smack/debugger/SmackDebuggerFactory.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/debugger/SmackDebuggerFactory.java
@@ -27,6 +27,11 @@ public interface SmackDebuggerFactory {
     /**
      * Initialize the new SmackDebugger instance.
      *
+     * @param connection connection.
+     * @param writer connection writer.
+     * @param reader connection reader.
+     *
+     * @return SmackDebugger.
      * @throws IllegalArgumentException if the SmackDebugger can't be loaded.
      */
     SmackDebugger create(XMPPConnection connection, Writer writer, Reader reader) throws IllegalArgumentException;

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/FromMatchesFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/FromMatchesFilter.java
@@ -52,6 +52,7 @@ public final class FromMatchesFilter extends AbstractFromToMatchesFilter {
      *
      * @param address The address to filter for. If <code>null</code> is given, the stanza must not
      *        have a from address.
+     * @return filter for the "from" address.
      */
     public static FromMatchesFilter create(Jid address) {
         return new FromMatchesFilter(address, address != null ? address.hasNoResource() : false) ;
@@ -63,6 +64,7 @@ public final class FromMatchesFilter extends AbstractFromToMatchesFilter {
      *
      * @param address The address to filter for. If <code>null</code> is given, the stanza must not
      *        have a from address.
+     * @return filter matching the "from" address.
      */
     public static FromMatchesFilter createBare(Jid address) {
         return new FromMatchesFilter(address, true);
@@ -74,6 +76,7 @@ public final class FromMatchesFilter extends AbstractFromToMatchesFilter {
      *
      * @param address The address to filter for. If <code>null</code> is given, the stanza must not
      *        have a from address.
+     * @return filter matching the "from" address.
      */
     public static FromMatchesFilter createFull(Jid address) {
         return new FromMatchesFilter(address, false);

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/IQReplyFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/IQReplyFilter.java
@@ -81,6 +81,7 @@ public class IQReplyFilter implements StanzaFilter {
      * and following discussion in February and March.
      *
      * @param iqPacket An IQ request. Filter for replies to this packet.
+     * @param conn connection.
      */
     public IQReplyFilter(IQ iqPacket, XMPPConnection conn) {
         if (!iqPacket.isRequestIQ()) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/ToMatchesFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/ToMatchesFilter.java
@@ -35,6 +35,7 @@ public final class ToMatchesFilter extends AbstractFromToMatchesFilter {
      *
      * @param address The address to filter for. If <code>null</code> is given, the stanza must not
      *        have a from address.
+     * @return filter matching the "to" address.
      */
     public static ToMatchesFilter create(Jid address) {
         return new ToMatchesFilter(address, address != null ? address.hasNoResource() : false) ;
@@ -46,6 +47,7 @@ public final class ToMatchesFilter extends AbstractFromToMatchesFilter {
      *
      * @param address The address to filter for. If <code>null</code> is given, the stanza must not
      *        have a from address.
+     * @return filter matching the "to" address.
      */
     public static ToMatchesFilter createBare(Jid address) {
         return new ToMatchesFilter(address, true);
@@ -57,6 +59,7 @@ public final class ToMatchesFilter extends AbstractFromToMatchesFilter {
      *
      * @param address The address to filter for. If <code>null</code> is given, the stanza must not
      *        have a from address.
+     * @return filter matching the "to" address.
      */
     public static ToMatchesFilter createFull(Jid address) {
         return new ToMatchesFilter(address, false);

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/AbstractError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/AbstractError.java
@@ -96,6 +96,7 @@ public class AbstractError {
      *
      * @param elementName the XML element name of the stanza(/packet) extension.
      * @param namespace the XML element namespace of the stanza(/packet) extension.
+     * @param <PE> type of the ExtensionElement.
      * @return the extension, or <tt>null</tt> if it doesn't exist.
      */
     public <PE extends ExtensionElement> PE getExtension(String elementName, String namespace) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Packet.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Packet.java
@@ -171,6 +171,7 @@ public interface Packet extends TopLevelStreamElement {
      *
      * @param elementName the XML element name of the stanza(/packet) extension. (May be null)
      * @param namespace the XML element namespace of the stanza(/packet) extension.
+     * @param <PE> type of the ExtensionElement.
      * @return the extension, or <tt>null</tt> if it doesn't exist.
      */
     <PE extends ExtensionElement> PE getExtension(String elementName, String namespace);

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Stanza.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Stanza.java
@@ -351,6 +351,7 @@ public abstract class Stanza implements TopLevelStreamElement {
      *
      * @param elementName the XML element name of the extension. (May be null)
      * @param namespace the XML element namespace of the extension.
+     * @param <PE> type of the ExtensionElement.
      * @return the extension, or <tt>null</tt> if it doesn't exist.
      */
     @SuppressWarnings("unchecked")

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/XMPPError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/XMPPError.java
@@ -109,7 +109,7 @@ public class XMPPError extends AbstractError {
     /**
      * Create a new XMPPError.
      *
-     * @param condition
+     * @param condition error condition.
      * @deprecated use {@link Builder} instead.
      */
     @Deprecated
@@ -120,8 +120,8 @@ public class XMPPError extends AbstractError {
     /**
      * Create a new XMPPError.
      *
-     * @param condition
-     * @param applicationSpecificCondition
+     * @param condition error condition.
+     * @param applicationSpecificCondition application specific condition.
      * @deprecated use {@link Builder} instead.
      */
     @Deprecated
@@ -137,6 +137,8 @@ public class XMPPError extends AbstractError {
      * 
      * @param type the error type.
      * @param condition the error condition.
+     * @param conditionText
+     * @param errorGenerator
      * @param descriptiveTexts 
      * @param extensions list of stanza(/packet) extensions
      * @deprecated use {@link Builder} instead.
@@ -155,6 +157,8 @@ public class XMPPError extends AbstractError {
      * 
      * @param type the error type.
      * @param condition the error condition.
+     * @param conditionText
+     * @param errorGenerator
      * @param descriptiveTexts 
      * @param extensions list of stanza(/packet) extensions
      * @param stanza the stanza carrying this XMPP error.

--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
@@ -236,11 +236,10 @@ public abstract class SASLMechanism implements Comparable<SASLMechanism> {
      *
      * @param challengeString a base64 encoded string representing the challenge.
      * @param finalChallenge true if this is the last challenge send by the server within the success stanza
-     * @throws NotConnectedException
-     * @throws SmackException
-     * @throws InterruptedException 
+     * @throws SmackException exception
+     * @throws InterruptedException if the connection is interrupted
      */
-    public final void challengeReceived(String challengeString, boolean finalChallenge) throws SmackException, NotConnectedException, InterruptedException {
+    public final void challengeReceived(String challengeString, boolean finalChallenge) throws SmackException, InterruptedException {
         byte[] challenge = Base64.decode((challengeString != null && challengeString.equals("=")) ? "" : challengeString);
         byte[] response = evaluateChallenge(challenge);
         if (finalChallenge) {
@@ -260,7 +259,12 @@ public abstract class SASLMechanism implements Comparable<SASLMechanism> {
     }
 
     /**
-     * @throws SmackException
+     * Evaluate the SASL challenge.
+     *
+     * @param challenge challenge to evaluate.
+     *
+     * @return null.
+     * @throws SmackException in case of an error.
      */
     protected byte[] evaluateChallenge(byte[] challenge) throws SmackException {
         return null;

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/DNSUtil.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/DNSUtil.java
@@ -127,6 +127,7 @@ public class DNSUtil {
      *
      * @param domain the domain.
      * @param failedAddresses on optional list that will be populated with host addresses that failed to resolve.
+     * @param dnssecMode DNSSec mode.
      * @return List of HostAddress, which encompasses the hostname and port that the
      *      XMPP server can be reached at for the specified domain.
      */
@@ -147,6 +148,7 @@ public class DNSUtil {
      *
      * @param domain the domain.
      * @param failedAddresses on optional list that will be populated with host addresses that failed to resolve.
+     * @param dnssecMode DNSSec mode.
      * @return List of HostAddress, which encompasses the hostname and port that the
      *      XMPP server can be reached at for the specified domain.
      */

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/FileUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/FileUtils.java
@@ -104,7 +104,7 @@ public final class FileUtils {
      * @throws IOException 
      */
     @SuppressWarnings("DefaultCharset")
-    public static String readFileOrThrow(File file) throws FileNotFoundException, IOException {
+    public static String readFileOrThrow(File file) throws IOException {
         Reader reader = null;
         try {
             reader = new FileReader(file);

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
@@ -709,6 +709,7 @@ public class PacketParserUtils {
      *
      * @param parser the XML parser, positioned at the start of the compression stanza.
      * @return The CompressionFeature stream element
+     * @throws IOException
      * @throws XmlPullParserException if an exception occurs while parsing the stanza.
      */
     public static Compress.Feature parseCompressionFeature(XmlPullParser parser)
@@ -716,7 +717,7 @@ public class PacketParserUtils {
         assert (parser.getEventType() == XmlPullParser.START_TAG);
         String name;
         final int initialDepth = parser.getDepth();
-        List<String> methods = new LinkedList<String>();
+        List<String> methods = new LinkedList<>();
         outerloop: while (true) {
             int eventType = parser.next();
             switch (eventType) {
@@ -899,7 +900,14 @@ public class PacketParserUtils {
     }
 
     /**
-     * Parse an extension element.
+     * Parses an extension element.
+     *
+     * @param elementName the XML element name of the extension element.
+     * @param namespace the XML namespace of the stanza(/packet) extension.
+     * @param parser the XML parser, positioned at the starting element of the extension.
+     *
+     * @return an extension element.
+     * @throws Exception when an error occurs during parsing.
      * @deprecated use {@link #parseExtensionElement(String, String, XmlPullParser)} instead.
      */
     @Deprecated
@@ -914,7 +922,9 @@ public class PacketParserUtils {
      * @param elementName the XML element name of the extension element.
      * @param namespace the XML namespace of the stanza(/packet) extension.
      * @param parser the XML parser, positioned at the starting element of the extension.
+     *
      * @return an extension element.
+     * @throws Exception when an error occurs during parsing.
      */
     public static ExtensionElement parseExtensionElement(String elementName, String namespace,
                     XmlPullParser parser) throws Exception {

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/PacketUtil.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/PacketUtil.java
@@ -25,9 +25,11 @@ public class PacketUtil {
     /**
      * Get a extension element from a collection.
      *
-     * @param collection
-     * @param element
-     * @param namespace
+     * @param collection Collection of ExtensionElements.
+     * @param element name of the targeted ExtensionElement.
+     * @param namespace namespace of the targeted ExtensionElement.
+     * @param <PE> Type of the ExtensionElement
+     *
      * @return the extension element
      * @deprecated use {@link #extensionElementFrom(Collection, String, String)} instead
      */
@@ -41,9 +43,11 @@ public class PacketUtil {
     /**
      * Get a extension element from a collection.
      *
-     * @param collection
-     * @param element
-     * @param namespace
+     * @param collection Collection of ExtensionElements.
+     * @param element name of the targeted ExtensionElement.
+     * @param namespace namespace of the targeted ExtensionElement.
+     * @param <PE> Type of the ExtensionElement
+     *
      * @return the extension element
      */
     @SuppressWarnings("unchecked")

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/TLSUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/TLSUtils.java
@@ -60,6 +60,9 @@ public class TLSUtils {
      * </p>
      * 
      * @param builder the configuration builder to apply this setting to
+     * @param <B> Type of the ConnectionConfiguration builder.
+     *
+     * @return the given builder
      */
     public static <B extends ConnectionConfiguration.Builder<B,?>> B setTLSOnly(B builder) {
         builder.setEnabledSSLProtocols(new String[] { PROTO_TLSV1_2,  PROTO_TLSV1_1, PROTO_TLSV1 });
@@ -77,6 +80,9 @@ public class TLSUtils {
      * </p>
      * 
      * @param builder the configuration builder to apply this setting to
+     * @param <B> Type of the ConnectionConfiguration builder.
+     *
+     * @return the given builder
      */
     public static <B extends ConnectionConfiguration.Builder<B,?>> B setSSLv3AndTLSOnly(B builder) {
         builder.setEnabledSSLProtocols(new String[] { PROTO_TLSV1_2,  PROTO_TLSV1_1, PROTO_TLSV1, PROTO_SSL3 });
@@ -92,6 +98,7 @@ public class TLSUtils {
      * </p>
      * 
      * @param builder a connection configuration builder.
+     * @param <B> Type of the ConnectionConfiguration builder.
      * @throws NoSuchAlgorithmException
      * @throws KeyManagementException
      * @return the given builder.
@@ -120,6 +127,7 @@ public class TLSUtils {
      * </p>
      * 
      * @param builder a connection configuration builder.
+     * @param <B> Type of the ConnectionConfiguration builder.
      * @return the given builder.
      */
     public static <B extends ConnectionConfiguration.Builder<B,?>> B disableHostnameVerificationForTlsCertificates(B builder) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/dns/DNSResolver.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/dns/DNSResolver.java
@@ -42,6 +42,8 @@ public abstract class DNSResolver {
     /**
      * Gets a list of service records for the specified service.
      * @param name The symbolic name of the service.
+     * @param failedAddresses list of failed addresses.
+     * @param dnssecMode security mode.
      * @return The list of SRV records mapped to the service name.
      */
     public final List<SRVRecord> lookupSRVRecords(String name, List<HostAddress> failedAddresses, DnssecMode dnssecMode) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/dns/HostAddress.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/dns/HostAddress.java
@@ -38,6 +38,7 @@ public class HostAddress {
      * 
      * @param fqdn the optional fully qualified domain name (FQDN).
      * @param port The port to connect on.
+     * @param inetAddresses list of addresses.
      * @throws IllegalArgumentException If the port is out of valid range (0 - 65535).
      */
     public HostAddress(String fqdn, int port, List<InetAddress> inetAddresses) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/dns/SRVRecord.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/dns/SRVRecord.java
@@ -41,6 +41,7 @@ public class SRVRecord extends HostAddress implements Comparable<SRVRecord> {
      * @param port The connection port
      * @param priority Priority of the target host
      * @param weight Relative weight for records with same priority
+     * @param inetAddresses list of addresses.
      * @throws IllegalArgumentException fqdn is null or any other field is not in valid range (0-65535).
      */
     public SRVRecord(String fqdn, int port, int priority, int weight, List<InetAddress> inetAddresses) {

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/carbons/CarbonManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/carbons/CarbonManager.java
@@ -336,6 +336,8 @@ public final class CarbonManager extends Manager {
 
     /**
      * Check if carbons are enabled on this connection.
+     *
+     * @return true if carbons are enabled, else false.
      */
     public boolean getCarbonsEnabled() {
         return this.enabled_state;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/packet/AbstractHttpOverXmpp.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/packet/AbstractHttpOverXmpp.java
@@ -56,6 +56,7 @@ public abstract class AbstractHttpOverXmpp extends IQ {
     /**
      * Returns start tag.
      *
+     * @param xml builder.
      * @return start tag
      */
     protected abstract IQChildElementXmlStringBuilder getIQHoxtChildElementBuilder(IQChildElementXmlStringBuilder xml);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/BytestreamManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/BytestreamManager.java
@@ -96,6 +96,7 @@ public interface BytestreamManager {
      * @throws IOException if an IO error occurred while establishing the session
      * @throws InterruptedException if the thread was interrupted while waiting in a blocking
      *         operation
+     * @throws SmackException if an error occurs in Smack.
      */
     public BytestreamSession establishSession(Jid targetJID) throws XMPPException, IOException,
                     InterruptedException, SmackException;
@@ -114,6 +115,7 @@ public interface BytestreamManager {
      * @throws IOException if an IO error occurred while establishing the session
      * @throws InterruptedException if the thread was interrupted while waiting in a blocking
      *         operation
+     * @throws SmackException if an error occurs in Smack.
      */
     public BytestreamSession establishSession(Jid targetJID, String sessionID)
                     throws XMPPException, IOException, InterruptedException, SmackException;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamSession.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamSession.java
@@ -190,7 +190,8 @@ public class InBandBytestreamSession implements BytestreamSession {
     /**
      * This method is invoked if one of the streams has been closed locally, if an error occurred
      * locally or if the whole session should be closed.
-     * 
+     *
+     * @param in do we want to close the Input- or OutputStream?
      * @throws IOException if an error occurs while sending the close request
      */
     protected synchronized void closeByLocal(boolean in) throws IOException {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/packet/Bytestream.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/packet/Bytestream.java
@@ -284,6 +284,7 @@ public class Bytestream extends IQ {
          * 
          * @param JID The JID of the stream host.
          * @param address The internet address of the stream host.
+         * @param port port of the stream host.
          */
         public StreamHost(final Jid JID, final String address, int port) {
             this.JID = Objects.requireNonNull(JID, "StreamHost JID must not be null");

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/caps/cache/EntityCapsPersistentCache.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/caps/cache/EntityCapsPersistentCache.java
@@ -29,6 +29,9 @@ public interface EntityCapsPersistentCache {
 
     /**
      * Lookup DiscoverInfo by a Node string.
+     * @param nodeVer
+     *
+     * @return DiscoverInfo.
      */
     DiscoverInfo lookup(String nodeVer);
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/AdHocCommand.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/AdHocCommand.java
@@ -211,7 +211,8 @@ public abstract class AdHocCommand {
      * Executes the command. This is invoked only on the first stage of the
      * command. It is invoked on every command. If there is a problem executing
      * the command it throws an XMPPException.
-     * 
+     *
+     * @throws NoResponseException
      * @throws XMPPErrorException if there is an error executing the command.
      * @throws NotConnectedException 
      * @throws InterruptedException 
@@ -226,6 +227,7 @@ public abstract class AdHocCommand {
      * XMPPException.
      * 
      * @param response the form answer of the previous stage.
+     * @throws NoResponseException
      * @throws XMPPErrorException if there is a problem executing the command.
      * @throws NotConnectedException 
      * @throws InterruptedException 
@@ -240,6 +242,8 @@ public abstract class AdHocCommand {
      * XMPPException.
      * 
      * @param response the form answer of the previous stage.
+     *
+     * @throws NoResponseException
      * @throws XMPPErrorException if there is a problem executing the command.
      * @throws NotConnectedException 
      * @throws InterruptedException 
@@ -251,7 +255,8 @@ public abstract class AdHocCommand {
      * information of the previous stage. The command must change it state to
      * the previous one. If there is a problem executing the command it throws
      * an XMPPException.
-     * 
+     *
+     * @throws NoResponseException
      * @throws XMPPErrorException if there is a problem executing the command.
      * @throws NotConnectedException 
      * @throws InterruptedException 
@@ -262,7 +267,8 @@ public abstract class AdHocCommand {
      * Cancels the execution of the command. This can be invoked on any stage of
      * the execution. If there is a problem executing the command it throws an
      * XMPPException.
-     * 
+     *
+     * @throws NoResponseException
      * @throws XMPPErrorException if there is a problem executing the command.
      * @throws NotConnectedException 
      * @throws InterruptedException 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/delay/packet/DelayInformation.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/delay/packet/DelayInformation.java
@@ -47,6 +47,8 @@ public class DelayInformation implements ExtensionElement {
     /**
      * Creates a new instance with the specified timestamp. 
      * @param stamp the timestamp
+     * @param from sender
+     * @param reason reason of delay.
      */
     public DelayInformation(Date stamp, String from, String reason) {
         this.stamp = stamp;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqprivate/provider/PrivateDataProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqprivate/provider/PrivateDataProvider.java
@@ -43,6 +43,9 @@ public interface PrivateDataProvider {
      *
      * @param parser an XML parser.
      * @return a new PrivateData instance.
+     * @throws XmlPullParserException
+     * @throws IOException
+     * @throws SmackException
      */
     PrivateData parsePrivateData(XmlPullParser parser) throws XmlPullParserException, IOException, SmackException;
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqregister/AccountManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqregister/AccountManager.java
@@ -293,6 +293,8 @@ public final class AccountManager extends Manager {
      * be performed after a successful login operation has been completed. Not all servers
      * support changing passwords; an XMPPException will be thrown when that is the case.
      *
+     * @param newPassword new password.
+     *
      * @throws IllegalStateException if not currently logged-in to the server.
      * @throws XMPPErrorException if an error occurs when changing the password.
      * @throws NoResponseException if there was no response from the server.

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -240,6 +240,7 @@ public final class MultiUserChatManager extends Manager {
      *
      * @param jid the name of the room in the form "roomName@service", where "service" is the hostname at which the
      *        multi-user chat service is running. Make sure to provide a valid JID.
+     * @return MultiUserChat instance of the room with the given jid.
      */
     public synchronized MultiUserChat getMultiUserChat(EntityBareJid jid) {
         WeakReference<MultiUserChat> weakRefMultiUserChat = multiUserChats.get(jid);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pep/PEPManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pep/PEPManager.java
@@ -115,6 +115,7 @@ public final class PEPManager extends Manager {
      * are received from remote XMPP clients.
      *
      * @param pepListener a roster exchange listener.
+     * @return true if pepListener was added.
      */
     public boolean addPEPListener(PEPListener pepListener) {
         return pepListeners.add(pepListener);
@@ -124,6 +125,7 @@ public final class PEPManager extends Manager {
      * Removes a listener from PEP events.
      *
      * @param pepListener a roster exchange listener.
+     * @return true, if pepListener was removed.
      */
     public boolean removePEPListener(PEPListener pepListener) {
         return pepListeners.remove(pepListener);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/ItemPublishEvent.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/ItemPublishEvent.java
@@ -69,6 +69,7 @@ public class ItemPublishEvent<T extends Item> extends SubscriptionEvent
      * @param nodeId The id of the node the event came from
      * @param eventItems The list of {@link Item} that were published 
      * @param subscriptionIds The list of subscriptionIds
+     * @param publishedDate date of publication.
      */
     public ItemPublishEvent(String nodeId, List<T> eventItems, List<String> subscriptionIds, Date publishedDate)
     {
@@ -107,7 +108,8 @@ public class ItemPublishEvent<T extends Item> extends SubscriptionEvent
     /**
      * Gets the original date the items were published.  This is only 
      * valid if {@link #isDelayed()} is true.
-     * 
+     *
+     * @return date of publication.
      */
     public Date getPublishedDate()
     {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/ItemsExtension.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/ItemsExtension.java
@@ -111,6 +111,7 @@ public class ItemsExtension extends NodeExtension implements EmbeddedPacketExten
      * 
      * @param nodeId The node to which the items are being sent or deleted
      * @param items The list of {@link Item} or {@link RetractItem}
+     * @param notify
      */
     public ItemsExtension(String nodeId, List<? extends ExtensionElement> items, boolean notify)
     {
@@ -140,7 +141,7 @@ public class ItemsExtension extends NodeExtension implements EmbeddedPacketExten
     /**
      * Gets the items related to the type of request or event.
      * 
-     * return List of {@link Item}, {@link RetractItem}, or null
+     * @return List of {@link Item}, {@link RetractItem}, or null
      */
     public List<? extends ExtensionElement> getItems()
     {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/LeafNode.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/LeafNode.java
@@ -64,7 +64,8 @@ public class LeafNode extends Node
 
     /**
      * Get the current items stored in the node.
-     * 
+     *
+     * @param <T> type of the items.
      * @return List of {@link Item} in the node
      * @throws XMPPErrorException
      * @throws NoResponseException if there was no response from the server.
@@ -83,6 +84,8 @@ public class LeafNode extends Node
      * 
      * @param subscriptionId -  The subscription id for the 
      * associated subscription.
+     * @param <T> type of the items.
+     *
      * @return List of {@link Item} in the node
      * @throws XMPPErrorException
      * @throws NoResponseException if there was no response from the server.
@@ -103,7 +106,8 @@ public class LeafNode extends Node
      * event, that did not include the payload.
      * 
      * @param ids Item ids of the items to retrieve
-     * 
+     * @param <T> type of the items.
+     *
      * @return The list of {@link Item} with payload
      * @throws XMPPErrorException 
      * @throws NoResponseException if there was no response from the server.
@@ -126,7 +130,8 @@ public class LeafNode extends Node
      * Get items persisted on the node, limited to the specified number.
      * 
      * @param maxItems Maximum number of items to return
-     * 
+     * @param <T> type of the items.
+     *
      * @return List of {@link Item}
      * @throws XMPPErrorException
      * @throws NoResponseException if there was no response from the server.
@@ -148,6 +153,8 @@ public class LeafNode extends Node
      * on.
      * 
      * @return List of {@link Item}
+     * @param <T> type of the items.
+     *
      * @throws XMPPErrorException
      * @throws NoResponseException if there was no response from the server.
      * @throws NotConnectedException 
@@ -170,6 +177,8 @@ public class LeafNode extends Node
      *        This is an optional argument, if provided as null no extensions will be added.
      * @param returnedExtensions a collection that will be filled with the returned packet
      *        extensions. This is an optional argument, if provided as null it won't be populated.
+     * @param <T> type of the items.
+     *
      * @return List of {@link Item}
      * @throws NoResponseException
      * @throws XMPPErrorException
@@ -236,6 +245,8 @@ public class LeafNode extends Node
      * For synchronous calls use {@link #send(Item) send(Item))}.
      * 
      * @param item - The item being sent
+     * @param <T> type of the items.
+     *
      * @throws NotConnectedException 
      * @throws InterruptedException 
      */
@@ -259,6 +270,8 @@ public class LeafNode extends Node
      * For synchronous calls use {@link #send(Collection) send(Collection))}.
      * 
      * @param items - The collection of items being sent
+     * @param <T> type of the items.
+     *
      * @throws NotConnectedException 
      * @throws InterruptedException 
      */
@@ -311,6 +324,8 @@ public class LeafNode extends Node
      * For asynchronous calls, use {@link #publish(Item) publish(Item)}.
      * 
      * @param item - The item being sent
+     * @param <T> type of the items.
+     *
      * @throws XMPPErrorException 
      * @throws NoResponseException 
      * @throws NotConnectedException 
@@ -337,6 +352,8 @@ public class LeafNode extends Node
      * For asynchronous calls, use {@link #publish(Collection) publish(Collection))}.
      * 
      * @param items - The collection of {@link Item} objects being sent
+     * @param <T> type of the items.
+     *
      * @throws XMPPErrorException 
      * @throws NoResponseException 
      * @throws NotConnectedException 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/Node.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/Node.java
@@ -384,7 +384,10 @@ abstract public class Node
      * {@link Subscription.State#unconfigured} - If the {@link Subscription#isConfigRequired()} is true, 
      * the caller must configure the subscription before messages will be received.  If it is false
      * the caller can configure it but is not required to do so.
+     *
      * @param jid The jid to subscribe as.
+     * @param subForm
+     *
      * @return The subscription
      * @throws XMPPErrorException 
      * @throws NoResponseException 
@@ -434,7 +437,9 @@ abstract public class Node
     /**
      * Returns a SubscribeForm for subscriptions, from which you can create an answer form to be submitted
      * via the {@link #sendConfigurationForm(Form)}.
-     * 
+     *
+     * @param jid
+     *
      * @return A subscription options form
      * @throws XMPPErrorException 
      * @throws NoResponseException 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/PubSubManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/PubSubManager.java
@@ -225,6 +225,8 @@ public final class PubSubManager extends Manager {
      * exception if it does not.
      * 
      * @param id - The unique id of the node
+     * @param <T> type of the node.
+     *
      * @return the node
      * @throws XMPPErrorException The node does not exist
      * @throws NoResponseException if there was no response from the server.
@@ -390,6 +392,8 @@ public final class PubSubManager extends Manager {
      *
      * @param id The unique id of the node.
      * @param item The item to publish.
+     * @param <I> type of the item.
+     *
      * @return the LeafNode on which the item was published.
      * @throws NoResponseException
      * @throws XMPPErrorException

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/search/ReportedData.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/search/ReportedData.java
@@ -43,6 +43,7 @@ public class ReportedData {
      * extension that matches the elementName and namespace "x","jabber:x:data".
      * 
      * @param packet the stanza(/packet) used for reporting data.
+     * @return ReportedData from the packet if present, otherwise null.
      */
     public static ReportedData getReportedDataFrom(Stanza packet) {
         // Check if the packet includes the DataForm extension

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/VCardManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/VCardManager.java
@@ -92,6 +92,8 @@ public final class VCardManager extends Manager {
      * Save this vCard for the user connected by 'connection'. XMPPConnection should be authenticated
      * and not anonymous.
      *
+     * @param vcard VCard.
+     *
      * @throws XMPPErrorException thrown if there was an issue setting the VCard in the server.
      * @throws NoResponseException if there was no response from the server.
      * @throws NotConnectedException 
@@ -110,6 +112,7 @@ public final class VCardManager extends Manager {
     /**
      * Load the VCard of the current user.
      *
+     * @return VCard.
      * @throws XMPPErrorException 
      * @throws NoResponseException 
      * @throws NotConnectedException 
@@ -122,6 +125,9 @@ public final class VCardManager extends Manager {
     /**
      * Load VCard information for a given user.
      *
+     * @param bareJid bareJid of the user.
+     *
+     * @return VCard.
      * @throws XMPPErrorException 
      * @throws NoResponseException if there was no response from the server.
      * @throws NotConnectedException 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -135,10 +135,11 @@ public class VCard extends IQ {
     }
 
     /**
-     * Set generic VCard field.
+     * Get the content of a generic VCard field.
      *
      * @param field value of field. Possible values: NICKNAME, PHOTO, BDAY, JABBERID, MAILER, TZ,
      *              GEO, TITLE, ROLE, LOGO, NOTE, PRODID, REV, SORT-STRING, SOUND, UID, URL, DESC.
+     * @return content of field.
      */
     public String getField(String field) {
         return otherSimpleFields.get(field);
@@ -273,6 +274,7 @@ public class VCard extends IQ {
      *
      * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADR, STREET,
      *                  LOCALITY, REGION, PCODE, CTRY
+     * @return content of home address field.
      */
     public String getAddressFieldHome(String addrField) {
         return homeAddr.get(addrField);
@@ -283,6 +285,7 @@ public class VCard extends IQ {
      *
      * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADR, STREET,
      *                  LOCALITY, REGION, PCODE, CTRY
+     * @param value new value for the field.
      */
     public void setAddressFieldHome(String addrField, String value) {
         homeAddr.put(addrField, value);
@@ -293,6 +296,7 @@ public class VCard extends IQ {
      *
      * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADR, STREET,
      *                  LOCALITY, REGION, PCODE, CTRY
+     * @return content of work address field.
      */
     public String getAddressFieldWork(String addrField) {
         return workAddr.get(addrField);
@@ -303,6 +307,7 @@ public class VCard extends IQ {
      *
      * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADR, STREET,
      *                  LOCALITY, REGION, PCODE, CTRY
+     * @param value new value for the field.
      */
     public void setAddressFieldWork(String addrField, String value) {
         workAddr.put(addrField, value);
@@ -323,6 +328,7 @@ public class VCard extends IQ {
      * Get home phone number.
      *
      * @param phoneType one of VOICE, FAX, PAGER, MSG, CELL, VIDEO, BBS, MODEM, ISDN, PCS, PREF
+     * @return content of home phone number.
      */
     public String getPhoneHome(String phoneType) {
         return homePhones.get(phoneType);
@@ -342,6 +348,7 @@ public class VCard extends IQ {
      * Get work phone number.
      *
      * @param phoneType one of VOICE, FAX, PAGER, MSG, CELL, VIDEO, BBS, MODEM, ISDN, PCS, PREF
+     * @return content of work phone number.
      */
     public String getPhoneWork(String phoneType) {
         return workPhones.get(phoneType);
@@ -470,6 +477,8 @@ public class VCard extends IQ {
      * Common code for getting the bytes of a url.
      *
      * @param url the url to read.
+     * @return bytes of the file pointed to by URL.
+     * @throws IOException if an IOException occurs while reading the file.
      */
     public static byte[] getBytes(URL url) throws IOException {
         final String path = url.getPath();
@@ -557,6 +566,8 @@ public class VCard extends IQ {
     /**
      * Load VCard information for a connected user. XMPPConnection should be authenticated
      * and not anonymous.
+     *
+     * @param connection connection.
      * @throws XMPPErrorException 
      * @throws NoResponseException 
      * @throws NotConnectedException 
@@ -570,6 +581,10 @@ public class VCard extends IQ {
 
     /**
      * Load VCard information for a given user. XMPPConnection should be authenticated and not anonymous.
+     *
+     * @param connection connection.
+     * @param user user whos information we want to load.
+     *
      * @throws XMPPErrorException 
      * @throws NoResponseException if there was no response from the server.
      * @throws NotConnectedException 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdatalayout/packet/DataLayout.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdatalayout/packet/DataLayout.java
@@ -52,6 +52,8 @@ public class DataLayout implements ExtensionElement {
      * <p>
      * Objects of the following type(s) are allowed in the list: {@link String },
      * {@link Section }, {@link Fieldref } and {@link Reportedref }
+     *
+     * @return list of DataFormLayoutElements.
      */
     public List<DataFormLayoutElement> getPageLayout() {
         return this.pageLayout;
@@ -177,6 +179,8 @@ public class DataLayout implements ExtensionElement {
          * <p>
          * Objects of the following type(s) are allowed in the list: {@link String },
          * {@link Section }, {@link Fieldref } and {@link Reportedref }
+         *
+         * @return list of DataFormLayoutElements.
          */
         public List<DataFormLayoutElement> getSectionLayout() {
             return this.sectionLayout;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
@@ -51,6 +51,7 @@ public class XHTMLText {
      * 
      * @param href indicates the URL being linked to
      * @param style the XHTML style of the anchor
+     * @return this.
      */
     public XHTMLText appendOpenAnchorTag(String href, String style) {
         text.halfOpenElement(A);
@@ -62,7 +63,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates that an anchor section ends.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseAnchorTag() {
         text.closeElement(A);
@@ -74,6 +76,7 @@ public class XHTMLText {
      * Appends a tag that indicates that a blockquote section begins.
      * 
      * @param style the XHTML style of the blockquote
+     * @return this.
      */
     public XHTMLText appendOpenBlockQuoteTag(String style) {
         text.halfOpenElement(BLOCKQUOTE);
@@ -84,7 +87,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates that a blockquote section ends.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseBlockQuoteTag() {
         text.closeElement(BLOCKQUOTE);
@@ -96,6 +100,7 @@ public class XHTMLText {
      * 
      * @param style the XHTML style of the body
      * @param lang the language of the body
+     * @return this.
      */
     private XHTMLText appendOpenBodyTag(String style, String lang) {
         text.halfOpenElement(Message.BODY);
@@ -106,6 +111,11 @@ public class XHTMLText {
         return this;
     }
 
+    /**
+     * Appends a tag that indicates that the body section ends.
+     *
+     * @return this.
+     */
     public XHTMLText appendCloseBodyTag() {
         text.closeElement(Message.BODY);
         return this;
@@ -117,7 +127,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that inserts a single carriage return.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendBrTag() {
         text.emptyElement(BR);
@@ -126,7 +137,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates a reference to work, such as a book, report or web site.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendOpenCiteTag() {
         text.openElement(CITE);
@@ -135,7 +147,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates text that is the code for a program.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendOpenCodeTag() {
         text.openElement(CODE);
@@ -144,7 +157,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates end of text that is the code for a program.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseCodeTag() {
         text.closeElement(CODE);
@@ -155,7 +169,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates emphasis.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendOpenEmTag() {
         text.openElement(EM);
@@ -164,7 +179,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates end of emphasis.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseEmTag() {
         text.closeElement(EM);
@@ -178,6 +194,8 @@ public class XHTMLText {
      * 
      * @param level the level of the Header. It must be a value between 1 and 3
      * @param style the XHTML style of the blockquote
+     *
+     * @return this.
      */
     public XHTMLText appendOpenHeaderTag(int level, String style) {
         if (level > 3 || level < 1) {
@@ -193,6 +211,7 @@ public class XHTMLText {
      * Appends a tag that indicates that a header section ends.
      * 
      * @param level the level of the Header. It must be a value between 1 and 3
+     * @return this.
      */
     public XHTMLText appendCloseHeaderTag(int level) {
         if (level > 3 || level < 1) {
@@ -212,6 +231,8 @@ public class XHTMLText {
      * @param height how tall is the picture
      * @param src where to get the picture
      * @param width how wide is the picture
+     *
+     * @return this.
      */
     public XHTMLText appendImageTag(String align, String alt, String height, String src, String width) {
         text.halfOpenElement(IMG);
@@ -231,6 +252,8 @@ public class XHTMLText {
      * Appends a tag that indicates the start of a new line item within a list.
      * 
      * @param style the style of the line item
+     *
+     * @return this.
      */
     public XHTMLText appendLineItemTag(String style) {
         text.halfOpenElement(LI);
@@ -242,6 +265,7 @@ public class XHTMLText {
     /**
      * Appends a tag that indicates that a line item section ends.
      *
+     * @return this.
      */
     public XHTMLText appendCloseLineItemTag() {
         text.closeElement(LI);
@@ -253,6 +277,8 @@ public class XHTMLText {
      * in the list is important. To show this, browsers automatically number the list. 
      * 
      * @param style the style of the ordered list
+     *
+     * @return this.
      */
     public XHTMLText appendOpenOrderedListTag(String style) {
         text.halfOpenElement(OL);
@@ -263,7 +289,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates that an ordered list section ends.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseOrderedListTag() {
         text.closeElement(OL);
@@ -277,6 +304,8 @@ public class XHTMLText {
      * in the list are not in any particular order.
      * 
      * @param style the style of the unordered list
+     *
+     * @return this.
      */
     public XHTMLText appendOpenUnorderedListTag(String style) {
         text.halfOpenElement(UL);
@@ -287,7 +316,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates that an unordered list section ends.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseUnorderedListTag() {
         text.closeElement(UL);
@@ -301,6 +331,8 @@ public class XHTMLText {
      * with two carriage returns, producing a single blank line in between the two paragraphs.
      * 
      * @param style the style of the paragraph
+     *
+     * @return this.
      */
     public XHTMLText appendOpenParagraphTag(String style) {
         text.halfOpenElement(P);
@@ -312,7 +344,8 @@ public class XHTMLText {
     /**
      * Appends a tag that indicates the end of a new paragraph. This is usually rendered 
      * with two carriage returns, producing a single blank line in between the two paragraphs.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseParagraphTag() {
         text.closeElement(P);
@@ -325,6 +358,8 @@ public class XHTMLText {
      * Appends a tag that indicates that an inlined quote section begins.
      * 
      * @param style the style of the inlined quote
+     *
+     * @return this.
      */
     public XHTMLText appendOpenInlinedQuoteTag(String style) {
         text.halfOpenElement(Q);
@@ -335,7 +370,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates that an inlined quote section ends.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseInlinedQuoteTag() {
         text.closeElement(Q);
@@ -348,6 +384,8 @@ public class XHTMLText {
      * Appends a tag that allows to set the fonts for a span of text.
      * 
      * @param style the style for a span of text
+     *
+     * @return this.
      */
     public XHTMLText appendOpenSpanTag(String style) {
         text.halfOpenElement(SPAN);
@@ -358,7 +396,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates that a span section ends.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseSpanTag() {
         text.closeElement(SPAN);
@@ -369,7 +408,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates text which should be more forceful than surrounding text.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendOpenStrongTag() {
         text.openElement(STRONG);
@@ -378,7 +418,8 @@ public class XHTMLText {
 
     /**
      * Appends a tag that indicates that a strong section ends.
-     * 
+     *
+     * @return this.
      */
     public XHTMLText appendCloseStrongTag() {
         text.closeElement(STRONG);
@@ -388,7 +429,9 @@ public class XHTMLText {
     /**
      * Appends a given text to the XHTMLText.
      * 
-     * @param textToAppend the text to append   
+     * @param textToAppend the text to append
+     *
+     * @return this.
      */
     public XHTMLText append(String textToAppend) {
         text.escape(textToAppend);

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/agent/AgentSession.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/agent/AgentSession.java
@@ -885,6 +885,7 @@ public class AgentSession {
      *
      * @param jid the jid of the agent.
      * @param maxSessions the max number of sessions to retrieve.
+     * @param startDate point in time from which on history should get retrieved.
      * @return the chat history associated with a given jid.
      * @throws XMPPException if an error occurs while retrieving the AgentChatHistory.
      * @throws NotConnectedException 


### PR DESCRIPTION
This PR fixes javadoc issues in all packages except smack-integration-test/.../omemo and smack-jingle-old.

Now there are no more warnings popping up when running `gradle javadoc`, except the following:

```
:smack-extensions:javadoc/path/to/Smack/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/packet/MUCInitialPresence.java:183: warning - Tag @link: can't find History(int, int, int, Date) in org.jivesoftware.smackx.muc.packet.MUCInitialPresence.History
```

I'm unable to fix those, as my the syntax is like documented elsewhere. Maybe this is a bug?

```
/**
* Deprecated constructor.
* @deprecated use {@link #History(int, int, int, Date)} instead.
*/
@Deprecated
public History() {
...
}

public History(int maxChars, int maxStanzas, int seconds, Date since) {
...
}
```