### PR TITLE
Fixes for extra quote in stanzas

### DIFF
--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OccupantsInfo.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OccupantsInfo.java
@@ -81,7 +81,7 @@ public class OccupantsInfo extends IQ {
 
     @Override
     protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder buf) {
-        buf.append("\" roomID=\"").append(roomID).append("\">");
+        buf.append(" roomID=\"").append(roomID).append("\">");
         synchronized (occupants) {
             for (OccupantInfo occupant : occupants) {
                 buf.append("<occupant>");

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/RoomInvitation.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/RoomInvitation.java
@@ -115,7 +115,7 @@ public class RoomInvitation implements ExtensionElement {
     }
 
     public IQ.IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder buf) {
-        buf.append("\" type=\"").append(type.name()).append("\">");
+        buf.append(" type=\"").append(type.name()).append("\">");
         buf.append("<session xmlns=\"http://jivesoftware.com/protocol/workgroup\" id=\"").append(sessionID).append("\"></session>");
         if (invitee != null) {
             buf.append("<invitee>").append(invitee).append("</invitee>");

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/RoomTransfer.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/RoomTransfer.java
@@ -115,7 +115,7 @@ public class RoomTransfer implements ExtensionElement {
     }
 
     public IQ.IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder buf) {
-        buf.append("\" type=\"").append(type.name()).append("\">");
+        buf.append(" type=\"").append(type.name()).append("\">");
         buf.append("<session xmlns=\"http://jivesoftware.com/protocol/workgroup\" id=\"").append(sessionID).append("\"></session>");
         if (invitee != null) {
             buf.append("<invitee>").append(invitee).append("</invitee>");


### PR DESCRIPTION
At some point IQChildElementXmlStringBuilder was modified to add the closing quote around the namespace. this was not reflected in these element extensions