### PR TITLE
Fix typo in MUC documentation example

### DIFF
--- a/documentation/extensions/muc.md
+++ b/documentation/extensions/muc.md
@@ -27,7 +27,7 @@ EntityBareJid mucJid = JidCreate.bareFrom("myroom@conference.jabber.org");
 Resourcepart nickname = Resourcepart.from("testbot");
 
 // A other use (we may invite him to a MUC).
-FullJid otherJid = JidCreate.fullFromm("user3@host.org/Smack");
+FullJid otherJid = JidCreate.fullFrom("user3@host.org/Smack");
 ```
 
 Create a new Room


### PR DESCRIPTION
Fix a typo in the MUC documentation