### PR TITLE
Update documentation

### DIFF
--- a/documentation/extensions/blockingcommand.md
+++ b/documentation/extensions/blockingcommand.md
@@ -1,6 +1,8 @@
 Blocking Command
 ================
 
+[Back](index.md)
+
 Allows to manage communications blocking.
 
   * Check push notifications support

--- a/documentation/extensions/caps.md
+++ b/documentation/extensions/caps.md
@@ -1,6 +1,8 @@
 Entity Capabilities
 ===================
 
+[Back](index.md)
+
 This section details the usage of Smacks implementation of Entity
 Capabilities.
 

--- a/documentation/extensions/dataforms.md
+++ b/documentation/extensions/dataforms.md
@@ -1,6 +1,8 @@
 Data Forms
 ==========
 
+[Back](index.md)
+
 Allows to exchange structured data between users and applications for common
 tasks such as registration and searching using Forms.
 

--- a/documentation/extensions/disco.md
+++ b/documentation/extensions/disco.md
@@ -1,6 +1,8 @@
 Service Discovery
 =================
 
+[Back](index.md)
+
 The service discovery extension allows to discover items and information about
 XMPP entities. Follow these links to learn how to use this extension.
 

--- a/documentation/extensions/filetransfer.md
+++ b/documentation/extensions/filetransfer.md
@@ -1,6 +1,8 @@
 File Transfer
 =============
 
+[Back](index.md)
+
 The file transfer extension allows the user to transmit and receive files.
 
   * Send a file to another user

--- a/documentation/extensions/hoxt.md
+++ b/documentation/extensions/hoxt.md
@@ -1,6 +1,8 @@
 HTTP over XMPP transport
 ========================
 
+[Back](index.md)
+
 Allows to transport HTTP communication over XMPP peer-to-peer networks.
 
   * Discover HOXT support

--- a/documentation/extensions/index.md
+++ b/documentation/extensions/index.md
@@ -9,106 +9,107 @@ for many of the protocol extensions.
 This manual provides details about each of the "smackx" extensions, including
 what it is, how to use it, and some simple example code.
 
-Currently supported XEPs of Smack (all subprojects)
+Currently supported XEPs of Smack (all sub-projects)
 ---------------------------------------------------
 
-| Name                                        | XEP                                                      | Description |
-|---------------------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| Nonzas  | [XEP-0360](http://xmpp.org/extensions/xep-0360.html) | Defines the term "Nonza", describing every top level stream element that is not a Stanza.                                         |
+| Name                                        | XEP                                                    | Version   | Description |
+|---------------------------------------------|--------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------|
+| Nonzas                                      | [XEP-0360](https://xmpp.org/extensions/xep-0360.html)  | n/a       | Defines the term "Nonza", describing every top level stream element that is not a Stanza.                                         |
 
 Currently supported XEPs of smack-tcp
 -------------------------------------
 
-| Name                                        | XEP                                                      | Description |
-|---------------------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| [Stream Management](streammanagement.md)  | [XEP-0198](http://xmpp.org/extensions/xep-0198.html) | Allows active management of an XML Stream between two XMPP entities (stanza acknowledgement, stream resumption). |
-
+| Name                                        | XEP                                                    | Version   | Description |
+|---------------------------------------------|--------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------|
+| [Stream Management](streammanagement.md)    | [XEP-0198](https://xmpp.org/extensions/xep-0198.html)  | n/a       | Allows active management of an XML Stream between two XMPP entities (stanza acknowledgement, stream resumption). |
 
 Smack Extensions and currently supported XEPs of smack-extensions
 -----------------------------------------------------------------
 
-| Name                                        | XEP                                                      | Description |
-|---------------------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| [Data Forms](dataforms.md)                | [XEP-0004](http://xmpp.org/extensions/xep-0004.html) | Allows to gather data using Forms. |
-| Last Activity                               | [XEP-0012](http://xmpp.org/extensions/xep-0012.html)     | Communicating information about the last activity associated with an XMPP entity. |
-| Flexible Offline Message Retrieval          | [XEP-0013](http://xmpp.org/extensions/xep-0013.html)  | Extension for flexible, POP3-like handling of offline messages. |
-| [Privacy Lists](privacy.md)               | [XEP-0016](http://xmpp.org/extensions/xep-0016.html) | Enabling or disabling communication with other entities. |
-| [Service Discovery](disco.md)             | [XEP-0030](http://xmpp.org/extensions/xep-0030.html) | Allows to discover services in XMPP entities. |
-| Extended Stanza Addressing                  | [XEP-0033](http://xmpp.org/extensions/xep-0033.html) | Allows to include headers in stanzas in order to specifiy multiple recipients or sub-addresses. |
-| [Multi User Chat](muc.md)                 | [XEP-0045](http://xmpp.org/extensions/xep-0045.html) | Allows configuration of, participation in, and administration of individual text-based conference rooms. |
-| In-Band Bytestreams                         | [XEP-0047](http://xmpp.org/extensions/xep-0047.html) | Enables any two entities to establish a one-to-one bytestream between themselves using plain XMPP. |
-| Bookmarks                                   | [XEP-0048](http://xmpp.org/extensions/xep-0048.html)     | Bookmarks, for e.g. MUC and web pages. |
-| [Private Data](privatedata.md)            | [XEP-0049](http://xmpp.org/extensions/xep-0049.html) | Manages private data. |
-| Ad-Hoc Commands                             | [XEP-0050](http://xmpp.org/extensions/xep-0050.html) | Advertising and executing application-specific commands. |
-| vcard-temp                                  | [XEP-0054](http://xmpp.org/extensions/xep-0054.html) | The vCard-XML format currently in use. |
-| Jabber Search                               | [XEP-0055](http://xmpp.org/extensions/xep-0055.html) | Search information repositories on the XMPP network. |
-| Result Set Management                       | [XEP-0059](http://xmpp.org/extensions/xep-0059.html) | Page through and otherwise manage the receipt of large result sets |
-| [PubSub](pubsub.md)                       | [XEP-0060](http://xmpp.org/extensions/xep-0060.html) | Generic publish and subscribe functionality. |
-| SOCKS5 Bytestrams                           | [XEP-0065](http://xmpp.org/extensions/xep-0065.html) | Out-of-band bytestream between any two XMPP entities. |
-| [XHTML-IM](xhtml.md)                      | [XEP-0071](http://xmpp.org/extensions/xep-0071.html) | Allows send and receiving formatted messages using XHTML. |
-| In-Band Registration                        | [XEP-0077](http://xmpp.org/extensions/xep-0077.html) | In-band registration with XMPP services. |
-| Advanced Message Processing                 | [XEP-0079](http://xmpp.org/extensions/xep-0079.html) | Enables entities to request, and servers to perform, advanced processing of XMPP message stanzas. |
-| User Location                               | [XEP-0080](http://xmpp.org/extensions/xep-0080.html) | Enabled communicating information about the current geographical or physical location of an entity. |
-| XMPP Date Time Profiles                     | [XEP-0082](http://xmpp.org/extensions/xep-0082.html)     | Standardization of Date and Time representation in XMPP. |
-| Chat State Notifications                    | [XEP-0085](http://xmpp.org/extensions/xep-0085.html) | Communicating the status of a user in a chat session. |
-| [Time Exchange](time.md)                  | [XEP-0090](http://xmpp.org/extensions/xep-0090.html) | Allows local time information to be shared between users. |
-| Software Version                            | [XEP-0092](http://xmpp.org/extensions/xep-0092.html)     | Retrieve and announce the software application of an XMPP entity. |
-| Stream Initation                            | [XEP-0095](http://xmpp.org/extensions/xep-0095.html) | Initiating a data stream between any two XMPP entities. |
-| [SI File Transfer](filetransfer.md)       | [XEP-0096](http://xmpp.org/extensions/xep-0096.html) | Transfer files between two users over XMPP. |
-| [Entity Capabilities](caps.md)            | [XEP-0115](http://xmpp.org/extensions/xep-0115.html) | Broadcasting and dynamic discovery of entity capabilities. |
-| Data Forms Validation                       | [XEP-0122](http://xmpp.org/extensions/xep-0122.html) | Enables an application to specify additional validation guidelines . |
-| Service Administration                      | [XEP-0133](http://xmpp.org/extensions/xep-0133.html) | Recommended best practices for service-level administration of servers and components using Ad-Hoc Commands. |
-| Stream Compression                          | [XEP-0138](http://xmpp.org/extensions/xep-0138.html) | Support for optional compression of the XMPP stream.
-| Data Forms Layout                           | [XEP-0141](http://xmpp.org/extensions/xep-0141.html) | Enables an application to specify form layouts. |
-| Personal Eventing Protocol                  | [XEP-0163](http://xmpp.org/extensions/xep-0163.html) | Using the XMPP publish-subscribe protocol to broadcast state change events associated with an XMPP account. |
-| Message Delivery Receipts                   | [XEP-0184](http://xmpp.org/extensions/xep-0184.html) | Extension for message delivery receipts. The sender can request notification that the message has been delivered. |
-| [Blocking Command](blockingcommand.md)      | [XEP-0191](http://xmpp.org/extensions/xep-0191.html) | Communications blocking that is intended to be simpler than privacy lists (XEP-0016). |
-| XMPP Ping                                   | [XEP-0199](http://xmpp.org/extensions/xep-0199.html) | Sending application-level pings over XML streams.
-| Entity Time                                 | [XEP-0202](http://xmpp.org/extensions/xep-0202.html) | Allows entities to communicate their local time |
-| Delayed Delivery                            | [XEP-0203](http://xmpp.org/extensions/xep-0203.html) | Extension for communicating the fact that an XML stanza has been delivered with a delay. |
-| XMPP Over BOSH                              | [XEP-0206](http://xmpp.org/extensions/xep-0206.html) | Use Bidirectional-streams Over Synchronous HTTP (BOSH) to transport XMPP stanzas. |
-| Attention                                   | [XEP-0224](http://xmpp.org/extensions/xep-0224.html) | Getting attention of another user. |
-| Bits of Binary                              | [XEP-0231](http://xmpp.org/extensions/xep-0231.html) | Including or referring to small bits of binary data in an XML stanza. |
-| Best Practices for Resource Locking         | [XEP-0296](https://xmpp.org/extensions/xep-0296.html) | Specifies best practices to be followed by Jabber/XMPP clients about when to lock into, and unlock away from, resources. |
-| Last Message Correction                     | [XEP-0308](http://xmpp.org/extensions/xep-0308.html) | Provides a method for indicating that a message is a correction of the last sent message. |
-| [Group Chat Invitations](invitation.md)   | n/a                                                      | Send invitations to other users to join a group chat room. |
-| [Jive Properties](properties.md)          | n/a                                                      | TODO |
+| Name                                        | XEP                                                    | Version   | Description |
+|---------------------------------------------|--------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------|
+| [Data Forms](dataforms.md)                  | [XEP-0004](https://xmpp.org/extensions/xep-0004.html)  | n/a       | Allows to gather data using Forms. |
+| Last Activity                               | [XEP-0012](https://xmpp.org/extensions/xep-0012.html)  | n/a       | Communicating information about the last activity associated with an XMPP entity. |
+| Flexible Offline Message Retrieval          | [XEP-0013](https://xmpp.org/extensions/xep-0013.html)  | n/a       | Extension for flexible, POP3-like handling of offline messages. |
+| [Privacy Lists](privacy.md)                 | [XEP-0016](https://xmpp.org/extensions/xep-0016.html)  | n/a       | Enabling or disabling communication with other entities. |
+| [Service Discovery](disco.md)               | [XEP-0030](https://xmpp.org/extensions/xep-0030.html)  | n/a       | Allows to discover services in XMPP entities. |
+| Extended Stanza Addressing                  | [XEP-0033](https://xmpp.org/extensions/xep-0033.html)  | n/a       | Allows to include headers in stanzas in order to specifiy multiple recipients or sub-addresses. |
+| [Multi User Chat](muc.md)                   | [XEP-0045](https://xmpp.org/extensions/xep-0045.html)  | n/a       | Allows configuration of, participation in, and administration of individual text-based conference rooms. |
+| In-Band Bytestreams                         | [XEP-0047](https://xmpp.org/extensions/xep-0047.html)  | n/a       | Enables any two entities to establish a one-to-one bytestream between themselves using plain XMPP. |
+| Bookmarks                                   | [XEP-0048](https://xmpp.org/extensions/xep-0048.html)  | n/a       | Bookmarks, for e.g. MUC and web pages. |
+| [Private Data](privatedata.md)              | [XEP-0049](https://xmpp.org/extensions/xep-0049.html)  | n/a       | Manages private data. |
+| Ad-Hoc Commands                             | [XEP-0050](https://xmpp.org/extensions/xep-0050.html)  | n/a       | Advertising and executing application-specific commands. |
+| vcard-temp                                  | [XEP-0054](https://xmpp.org/extensions/xep-0054.html)  | n/a       | The vCard-XML format currently in use. |
+| Jabber Search                               | [XEP-0055](https://xmpp.org/extensions/xep-0055.html)  | n/a       | Search information repositories on the XMPP network. |
+| Result Set Management                       | [XEP-0059](https://xmpp.org/extensions/xep-0059.html)  | n/a       | Page through and otherwise manage the receipt of large result sets |
+| [PubSub](pubsub.md)                         | [XEP-0060](https://xmpp.org/extensions/xep-0060.html)  | n/a       | Generic publish and subscribe functionality. |
+| SOCKS5 Bytestreams                          | [XEP-0065](https://xmpp.org/extensions/xep-0065.html)  | n/a       | Out-of-band bytestream between any two XMPP entities. |
+| [XHTML-IM](xhtml.md)                        | [XEP-0071](https://xmpp.org/extensions/xep-0071.html)  | n/a       | Allows send and receiving formatted messages using XHTML. |
+| In-Band Registration                        | [XEP-0077](https://xmpp.org/extensions/xep-0077.html)  | n/a       | In-band registration with XMPP services. |
+| Advanced Message Processing                 | [XEP-0079](https://xmpp.org/extensions/xep-0079.html)  | n/a       | Enables entities to request, and servers to perform, advanced processing of XMPP message stanzas. |
+| User Location                               | [XEP-0080](https://xmpp.org/extensions/xep-0080.html)  | n/a       | Enabled communicating information about the current geographical or physical location of an entity. |
+| XMPP Date Time Profiles                     | [XEP-0082](https://xmpp.org/extensions/xep-0082.html)  | n/a       | Standardization of Date and Time representation in XMPP. |
+| Chat State Notifications                    | [XEP-0085](https://xmpp.org/extensions/xep-0085.html)  | n/a       | Communicating the status of a user in a chat session. |
+| [Time Exchange](time.md)                    | [XEP-0090](https://xmpp.org/extensions/xep-0090.html)  | n/a       | Allows local time information to be shared between users. |
+| Software Version                            | [XEP-0092](https://xmpp.org/extensions/xep-0092.html)  | n/a       | Retrieve and announce the software application of an XMPP entity. |
+| Stream Initation                            | [XEP-0095](https://xmpp.org/extensions/xep-0095.html)  | n/a       | Initiating a data stream between any two XMPP entities. |
+| [SI File Transfer](filetransfer.md)         | [XEP-0096](https://xmpp.org/extensions/xep-0096.html)  | n/a       | Transfer files between two users over XMPP. |
+| [Entity Capabilities](caps.md)              | [XEP-0115](https://xmpp.org/extensions/xep-0115.html)  | n/a       | Broadcasting and dynamic discovery of entity capabilities. |
+| Data Forms Validation                       | [XEP-0122](https://xmpp.org/extensions/xep-0122.html)  | n/a       | Enables an application to specify additional validation guidelines . |
+| Service Administration                      | [XEP-0133](https://xmpp.org/extensions/xep-0133.html)  | n/a       | Recommended best practices for service-level administration of servers and components using Ad-Hoc Commands. |
+| Stream Compression                          | [XEP-0138](https://xmpp.org/extensions/xep-0138.html)  | n/a       | Support for optional compression of the XMPP stream.
+| Data Forms Layout                           | [XEP-0141](https://xmpp.org/extensions/xep-0141.html)  | n/a       | Enables an application to specify form layouts. |
+| Personal Eventing Protocol                  | [XEP-0163](https://xmpp.org/extensions/xep-0163.html)  | n/a       | Using the XMPP publish-subscribe protocol to broadcast state change events associated with an XMPP account. |
+| Message Delivery Receipts                   | [XEP-0184](https://xmpp.org/extensions/xep-0184.html)  | n/a       | Extension for message delivery receipts. The sender can request notification that the message has been delivered. |
+| [Blocking Command](blockingcommand.md)      | [XEP-0191](https://xmpp.org/extensions/xep-0191.html)  | n/a       | Communications blocking that is intended to be simpler than privacy lists (XEP-0016). |
+| XMPP Ping                                   | [XEP-0199](https://xmpp.org/extensions/xep-0199.html)  | n/a       | Sending application-level pings over XML streams.
+| Entity Time                                 | [XEP-0202](https://xmpp.org/extensions/xep-0202.html)  | n/a       | Allows entities to communicate their local time |
+| Delayed Delivery                            | [XEP-0203](https://xmpp.org/extensions/xep-0203.html)  | n/a       | Extension for communicating the fact that an XML stanza has been delivered with a delay. |
+| XMPP Over BOSH                              | [XEP-0206](https://xmpp.org/extensions/xep-0206.html)  | n/a       | Use Bidirectional-streams Over Synchronous HTTP (BOSH) to transport XMPP stanzas. |
+| Attention                                   | [XEP-0224](https://xmpp.org/extensions/xep-0224.html)  | n/a       | Getting attention of another user. |
+| Bits of Binary                              | [XEP-0231](https://xmpp.org/extensions/xep-0231.html)  | n/a       | Including or referring to small bits of binary data in an XML stanza. |
+| Best Practices for Resource Locking         | [XEP-0296](https://xmpp.org/extensions/xep-0296.html)  | n/a       | Specifies best practices to be followed by Jabber/XMPP clients about when to lock into, and unlock away from, resources. |
+| Last Message Correction                     | [XEP-0308](https://xmpp.org/extensions/xep-0308.html)  | n/a       | Provides a method for indicating that a message is a correction of the last sent message. |
+| [Group Chat Invitations](invitation.md)     | n/a                                                    | n/a       | Send invitations to other users to join a group chat room. |
+| [Jive Properties](properties.md)            | n/a                                                    | n/a       | TODO |
 
 
 Experimental Smack Extensions and currently supported XEPs of smack-experimental
 --------------------------------------------------------------------------------
+| Message Carbons                             | [XEP-0280](https://xmpp.org/extensions/xep-0280.html)  | n/a       | Keep all IM clients for a user engaged in a conversation, by carbon-copy outbound messages to all interested resources. |
+| [Message Archive Management](mam.md)        | [XEP-0313](https://xmpp.org/extensions/xep-0313.html)  | n/a       | Query and control an archive of messages stored on a server. |
+| [Internet of Things - Sensor Data](iot.md)  | [XEP-0323](https://xmpp.org/extensions/xep-0323.html)  | n/a       | Sensor data interchange over XMPP. |
+| [Internet of Things - Provisioning](iot.md) | [XEP-0324](https://xmpp.org/extensions/xep-0324.html)  | n/a       | Provisioning, access rights and user priviliges for the Internet of Things. |
+| [Internet of Things - Control](iot.md)      | [XEP-0325](https://xmpp.org/extensions/xep-0325.html)  | n/a       | Describes how to control devices or actuators in an XMPP-based sensor network. |
+| [HTTP over XMPP transport](hoxt.md)         | [XEP-0332](https://xmpp.org/extensions/xep-0332.html)  | n/a       | Allows to transport HTTP communication over XMPP peer-to-peer networks. |
+| Chat Markers         			  			  | [XEP-0333](https://xmpp.org/extensions/xep-0333.html)  | n/a       | A solution of marking the last received, displayed and acknowledged message in a chat. |
+| Message Processing Hints                    | [XEP-0334](https://xmpp.org/extensions/xep-0334.html)  | n/a       | Hints to entities routing or receiving a message. |
+| JSON Containers                             | [XEP-0335](https://xmpp.org/extensions/xep-0335.html)  | n/a       | Encapsulation of JSON data within XMPP Stanzas. |
+| [Internet of Things - Discovery](iot.md)    | [XEP-0347](https://xmpp.org/extensions/xep-0347.html)  | n/a       | Describes how Things can be installed and discovered by their owners. |
+| Client State Indication                     | [XEP-0352](https://xmpp.org/extensions/xep-0352.html)  | n/a       | A way for the client to indicate its active/inactive state. |
+| [Push Notifications](pushnotifications.md)  | [XEP-0357](https://xmpp.org/extensions/xep-0357.html)  | n/a       | Defines a way to manage push notifications from an XMPP Server. |
+| Stable and Unique Stanza IDs                | [XEP-0359](https://xmpp.org/extensions/xep-0359.html)  | 0.5.0     | This specification describes unique and stable IDs for messages. |
+| HTTP File Upload                            | [XEP-0363](https://xmpp.org/extensions/xep-0363.html)  | 0.3.1     | Protocol to request permissions to upload a file to an HTTP server and get a shareable URL. |
+| References                                  | [XEP-0372](https://xmpp.org/extensions/xep-0363.html)  | 0.2.0     | Add references like mentions or external data to stanzas. |
+| [Spoiler Messages](spoiler.md)              | [XEP-0382](https://xmpp.org/extensions/xep-0382.html)  | 0.2.0     | Indicate that the body of a message should be treated as a spoiler |
+| [OMEMO Multi End Message and Object Encryption](omemo.md) | [XEP-0384](https://xmpp.org/extensions/xep-0384.html) | n/a     | Encrypt messages using OMEMO encryption (currently only with smack-omemo-signal -> GPLv3). |
+| [Consistent Color Generation](consistent_colors.md) | [XEP-0392](https://xmpp.org/extensions/xep-0392.html)  | 0.4.0     | Generate consistent colors for identifiers like usernames to provide a consistent user experience. |
+| [Message Markup](messagemarkup.md)          | [XEP-0394](https://xmpp.org/extensions/xep-0394.html)  | 0.1.0     | Style message bodies while keeping body and markup information separated. |
 
-| Name                                        | XEP                                                      | Description |
-|---------------------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| Message Carbons                             | [XEP-0280](http://xmpp.org/extensions/xep-0280.html) | Keep all IM clients for a user engaged in a conversation, by carbon-copy outbound messages to all interested resources. |
-| [Message Archive Management](mam.md)        | [XEP-0313](http://xmpp.org/extensions/xep-0313.html) | Query and control an archive of messages stored on a server. |
-| [Internet of Things - Sensor Data](iot.md)  | [XEP-0323](http://xmpp.org/extensions/xep-0323.html) | Sensor data interchange over XMPP. |
-| [Internet of Things - Provisioning](iot.md) | [XEP-0324](http://xmpp.org/extensions/xep-0324.html) | Provisioning, access rights and user priviliges for the Internet of Things. |
-| [Internet of Things - Control](iot.md)      | [XEP-0325](http://xmpp.org/extensions/xep-0325.html) | Describes how to control devices or actuators in an XMPP-based sensor netowrk. |
-| [HTTP over XMPP transport](hoxt.md)         | [XEP-0332](http://xmpp.org/extensions/xep-0332.html) | Allows to transport HTTP communication over XMPP peer-to-peer networks. |
-| Chat Markers         			  			  | [XEP-0333](http://xmpp.org/extensions/xep-0333.html) | A solution of marking the last received, displayed and acknowledged message in a chat. |
-| Message Processing Hints                    | [XEP-0334](http://xmpp.org/extensions/xep-0334.html) | Hints to entities routing or receiving a message. |
-| JSON Containers                             | [XEP-0335](http://xmpp.org/extensions/xep-0335.html) | Encapsulation of JSON data within XMPP Stanzas. |
-| [Internet of Things - Discovery](iot.md)    | [XEP-0347](http://xmpp.org/extensions/xep-0347.html) | Describes how Things can be installed and discovered by their owners. |
-| Client State Indication                     | [XEP-0352](http://xmpp.org/extensions/xep-0352.html) | A way for the client to indicate its active/inactive state. |
-| [Push Notifications](pushnotifications.md)  | [XEP-0357](http://xmpp.org/extensions/xep-0357.html) | Defines a way to manage push notifications from an XMPP Server. |
-| Stable and Unique Stanza IDs                | [XEP-0359](http://xmpp.org/extensions/xep-0359.html) | This specification describes unique and stable IDs for messages. |
-| HTTP File Upload                            | [XEP-0363](http://xmpp.org/extensions/xep-0363.html) | Protocol to request permissions to upload a file to an HTTP server and get a shareable URL. |
-| References                                  | [XEP-0372](http://xmpp.org/extensions/xep-0363.html) | Add references like mentions or external data to stanzas. |
-| [Spoiler Messages](spoiler.md)              | [XEP-0382](http://xmpp.org/extensions/xep-0382.html) | Indicate that the body of a message should be treated as a spoiler |
-| [Multi-User Chat Light](muclight.md)        | [XEP-xxxx](http://mongooseim.readthedocs.io/en/latest/open-extensions/xeps/xep-muc-light.html) | Multi-User Chats for mobile XMPP applications and specific enviroment. |
-| [OMEMO Multi End Message and Object Encryption](omemo.md)            | [XEP-XXXX](https://conversations.im/omemo/xep-omemo.html) | Encrypt messages using OMEMO encryption (currently only with smack-omemo-signal -> GPLv3). |
-| [Consistent Color Generation](consistent_colors.md) | [XEP-0392](http://xmpp.org/extensions/xep-0392.html) | Generate consistent colors for identifiers like usernames to provide a consistent user experience. |
-| Google GCM JSON payload                     | n/a                                                  | Semantically the same as XEP-0335: JSON Containers |
-| [Message Markup](messagemarkup.md)          | [XEP-0394](http://xmpp.org/extensions/xep-0394.html)| Style message bodies while keeping body and markup information separated. |
+Unofficial XMPP Extensions
+--------------------------
 
+| Name                                        | XEP                                                    | Version   | Description |
+|---------------------------------------------|--------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------|
+| [Multi-User Chat Light](muclight.md)        | [XEP-xxxx](https://mongooseim.readthedocs.io/en/latest/open-extensions/xeps/xep-muc-light.html) | n/a     | Multi-User Chats for mobile XMPP applications and specific environment. |
+| Google GCM JSON payload                     | n/a                                                    | n/a       | Semantically the same as XEP-0335: JSON Containers. |
 
 Legacy Smack Extensions and currently supported XEPs of smack-legacy
 --------------------------------------------------------------------
 
 If a XEP becomes 'Deprecated' or 'Obsolete' the code will be moved to the *smack-legacy* subproject.
 
-| Name                                        | XEP                                                      | Description |
-|---------------------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| [Message Events](messageevents.md)        | [XEP-0022](http://xmpp.org/extensions/xep-0022.html) | Requests and responds to message events. |
-| [Roster Item Exchange](rosterexchange.md) | [XEP-0093](http://xmpp.org/extensions/xep-0093.html) | Allows roster data to be shared between users. |
+| Name                                        | XEP                                                    | Version   | Description |
+|---------------------------------------------|--------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------|
+| [Message Events](messageevents.md)          | [XEP-0022](https://xmpp.org/extensions/xep-0022.html)  | n/a       | Requests and responds to message events. |
+| [Roster Item Exchange](rosterexchange.md)   | [XEP-0093](https://xmpp.org/extensions/xep-0093.html)  | n/a       | Allows roster data to be shared between users. |

--- a/documentation/extensions/invitation.md
+++ b/documentation/extensions/invitation.md
@@ -1,6 +1,8 @@
 Group Chat Invitations
 ======================
 
+[Back](index.md)
+
 The group chat invitation extension is used to invite other users to a
 group chat room.
 

--- a/documentation/extensions/iot.md
+++ b/documentation/extensions/iot.md
@@ -1,6 +1,8 @@
 Internet of Things (XEP-0323, -0324, -0325, -0347)
 ==================================================
 
+[Back](index.md)
+
 The Internet of Things (IoT) XEPs are an experimental open standard how XMPP can be used for IoT. They currently consists of
 - XEP-0323 Sensor Data
 - XEP-0324 Provisioning

--- a/documentation/extensions/mam.md
+++ b/documentation/extensions/mam.md
@@ -1,6 +1,8 @@
 Message Archive Management
 ==========================
 
+[Back](index.md)
+
 Query and control an archive of messages stored on a server.
 
   * Check MAM support

--- a/documentation/extensions/muc.md
+++ b/documentation/extensions/muc.md
@@ -1,6 +1,8 @@
 Multi User Chat
 ===============
 
+[Back](index.md)
+
 Allows configuration of, participation in, and administration of individual
 text-based conference rooms.
 

--- a/documentation/extensions/muclight.md
+++ b/documentation/extensions/muclight.md
@@ -1,6 +1,8 @@
 Multi-User Chat Light
 =====================
 
+[Back](index.md)
+
 Allows configuration of, participation in, and administration of presence­less  Multi­-User Chats. 
 Its feature set is a response to mobile XMPP applications needs and specific environment.
 

--- a/documentation/extensions/privacy.md
+++ b/documentation/extensions/privacy.md
@@ -1,10 +1,12 @@
 Privacy Lists
 ============
 
+[Back](index.md)
+
 [XEP-0016: Privacy Lists](http://xmpp.org/extensions/xep-0016.html)
 
-What is?
---------
+What is it?
+-----------
 
 `Privacy` is a method for users to block communications from particular other
 users. In XMPP this is done by managing one's privacy lists.

--- a/documentation/extensions/privatedata.md
+++ b/documentation/extensions/privatedata.md
@@ -1,6 +1,8 @@
 Private Data
 ============
 
+[Back](index.md)
+
 Manages private data, which is a mechanism to allow users to store arbitrary
 XML data on an XMPP server. Each private data chunk is defined by a element
 name and XML namespace. Example private data:

--- a/documentation/extensions/properties.md
+++ b/documentation/extensions/properties.md
@@ -1,6 +1,8 @@
 Stanza Properties
 =================
 
+[Back](index.md)
+
 Smack provides an easy mechanism for attaching arbitrary properties to
 packets. Each property has a String name, and a value that is a Java primitive
 (int, long, float, double, boolean) or any Serializable object (a Java object

--- a/documentation/extensions/pubsub.md
+++ b/documentation/extensions/pubsub.md
@@ -1,6 +1,8 @@
 Pubsub
 ======
 
+[Back](index.md)
+
 This section details the usage of an API designed for accessing an XMPP based
 implementation of a [publish and
 subscribe](http://en.wikipedia.org/wiki/Publish/subscribe) based messaging

--- a/documentation/extensions/pushnotifications.md
+++ b/documentation/extensions/pushnotifications.md
@@ -1,6 +1,8 @@
 Push Notifications
 ==================
 
+[Back](index.md)
+
 Allows to manage how XMPP servers deliver information for use in push notifications to mobile and other devices.
 
   * Check push notifications support

--- a/documentation/extensions/rosterexchange.md
+++ b/documentation/extensions/rosterexchange.md
@@ -1,6 +1,8 @@
 Roster Item Exchange
 ====================
 
+[Back](index.md)
+
 This extension is used to send rosters, roster groups and roster entries from
 one XMPP Entity to another. It also provides an easy way to hook up custom
 logic when entries are received from other XMPP clients.

--- a/documentation/extensions/streammanagement.md
+++ b/documentation/extensions/streammanagement.md
@@ -1,6 +1,8 @@
 Stream Management
 =================
 
+[Back](index.md)
+
 XMPPTCPConnection comes with support for Stream Management (SM).
 
 **XEP related:** [XEP-0198](http://xmpp.org/extensions/xep-0198.html)

--- a/documentation/extensions/time.md
+++ b/documentation/extensions/time.md
@@ -1,6 +1,8 @@
 Entity Time Exchange
 ====================
 
+[Back](index.md)
+
 Supports a protocol that XMPP clients use to exchange their respective local
 times and time zones.
 

--- a/documentation/extensions/xhtml.md
+++ b/documentation/extensions/xhtml.md
@@ -1,6 +1,8 @@
 XHTML Messages
 ==============
 
+[Back](index.md)
+
 Provides the ability to send and receive formatted messages using XHTML.
 
 Follow these links to learn how to compose, send, receive and discover support


### PR DESCRIPTION
This PR contains the following changes:

* update the links in `index.md` to https
* add a new column "Version" to specify which version of the XEP an implementation is based on (currently not populated)
* Reformat the table in `index.md`
* Fix some typos
* Add "back to index" links to all documentation files in `/extensions/`.