### PR TITLE
Prevent race condition in ecaps test

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/caps/EntityCapsTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/caps/EntityCapsTest.java
@@ -158,7 +158,7 @@ public class EntityCapsTest extends AbstractSmackIntegrationTest {
         sdmTwo.addFeature(dummyFeature);
 
         // wait for the dummy feature to get sent via presence
-        presenceReceivedSyncPoint.waitForResult(10 * 1000);
+        presenceReceivedSyncPoint.waitForResult(timeout);
 
         dropCapsCache();
         // discover that


### PR DESCRIPTION
The EntityCapsTest.testPreventDiscoInfo() integration test was sometimes failing because of a race condition where the presence sent by ServiceDiscoveryManager.addFeature() was received *after* the caps cache had been dropped. This PR adds a presence listener to wait for presence before dropping the cache.