### PR TITLE
Rename and deprecate XMPPConnection methods

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -168,7 +168,7 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
                         addAsyncStanzaListener(debugger.getReaderListener(), null);
                     }
                     if (debugger.getWriterListener() != null) {
-                        addPacketSendingListener(debugger.getWriterListener(), null);
+                        addStanzaSendingListener(debugger.getWriterListener(), null);
                     }
                 }
             }

--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -840,8 +840,14 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         }
     }
 
+    @Deprecated
     @Override
     public void addPacketSendingListener(StanzaListener packetListener, StanzaFilter packetFilter) {
+        addStanzaSendingListener(packetListener, packetFilter);
+    }
+
+    @Override
+    public void addStanzaSendingListener(StanzaListener packetListener, StanzaFilter packetFilter) {
         if (packetListener == null) {
             throw new NullPointerException("Packet listener is null.");
         }
@@ -851,8 +857,14 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         }
     }
 
+    @Deprecated
     @Override
     public void removePacketSendingListener(StanzaListener packetListener) {
+        removeStanzaSendingListener(packetListener);
+    }
+
+    @Override
+    public void removeStanzaSendingListener(StanzaListener packetListener) {
         synchronized (sendListeners) {
             sendListeners.remove(packetListener);
         }
@@ -896,8 +908,15 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         });
     }
 
+    @Deprecated
     @Override
     public void addPacketInterceptor(StanzaListener packetInterceptor,
+                                     StanzaFilter packetFilter) {
+        addStanzaInterceptor(packetInterceptor, packetFilter);
+    }
+
+    @Override
+    public void addStanzaInterceptor(StanzaListener packetInterceptor,
             StanzaFilter packetFilter) {
         if (packetInterceptor == null) {
             throw new NullPointerException("Packet interceptor is null.");
@@ -908,8 +927,14 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         }
     }
 
+    @Deprecated
     @Override
     public void removePacketInterceptor(StanzaListener packetInterceptor) {
+        removeStanzaInterceptor(packetInterceptor);
+    }
+
+    @Override
+    public void removeStanzaInterceptor(StanzaListener packetInterceptor) {
         synchronized (interceptors) {
             interceptors.remove(packetInterceptor);
         }

--- a/smack-core/src/main/java/org/jivesoftware/smack/StanzaListener.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/StanzaListener.java
@@ -30,7 +30,7 @@ import org.jivesoftware.smack.packet.Stanza;
  * <p>
  * Additionally you are able to intercept Packets that are going to be send and
  * make modifications to them. You can register a PacketListener as interceptor
- * by using {@link XMPPConnection#addPacketInterceptor(StanzaListener,
+ * by using {@link XMPPConnection#addStanzaInterceptor(StanzaListener,
  * org.jivesoftware.smack.filter.StanzaFilter)}
  * </p>
  *

--- a/smack-core/src/main/java/org/jivesoftware/smack/XMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/XMPPConnection.java
@@ -319,7 +319,7 @@ public interface XMPPConnection {
      *
      * @param packetListener the stanza(/packet) listener to notify of new received packets.
      * @param packetFilter the stanza(/packet) filter to use.
-     * @see #addPacketInterceptor(StanzaListener, StanzaFilter)
+     * @see #addStanzaInterceptor(StanzaListener, StanzaFilter)
      * @since 4.1
      */
     public void addSyncStanzaListener(StanzaListener packetListener, StanzaFilter packetFilter);
@@ -345,7 +345,7 @@ public interface XMPPConnection {
      * 
      * @param packetListener the stanza(/packet) listener to notify of new received packets.
      * @param packetFilter the stanza(/packet) filter to use.
-     * @see #addPacketInterceptor(StanzaListener, StanzaFilter)
+     * @see #addStanzaInterceptor(StanzaListener, StanzaFilter)
      * @since 4.1
     */
     public void addAsyncStanzaListener(StanzaListener packetListener, StanzaFilter packetFilter);
@@ -369,15 +369,41 @@ public interface XMPPConnection {
      * 
      * @param packetListener the stanza(/packet) listener to notify of sent packets.
      * @param packetFilter   the stanza(/packet) filter to use.
+     * @deprecated use {@link #addStanzaSendingListener} instead
      */
+    // TODO Remove in Smack 4.4
+    @Deprecated
     public void addPacketSendingListener(StanzaListener packetListener, StanzaFilter packetFilter);
+
+    /**
+     * Registers a stanza(/packet) listener with this connection. The listener will be
+     * notified of every stanza(/packet) that this connection sends. A stanza(/packet) filter determines
+     * which packets will be delivered to the listener. Note that the thread
+     * that writes packets will be used to invoke the listeners. Therefore, each
+     * stanza(/packet) listener should complete all operations quickly or use a different
+     * thread for processing.
+     *
+     * @param packetListener the stanza(/packet) listener to notify of sent packets.
+     * @param packetFilter   the stanza(/packet) filter to use.
+     */
+    public void addStanzaSendingListener(StanzaListener packetListener, StanzaFilter packetFilter);
 
     /**
      * Removes a stanza(/packet) listener for sending packets from this connection.
      * 
      * @param packetListener the stanza(/packet) listener to remove.
+     * @deprecated use {@link #removeStanzaSendingListener} instead
      */
+    // TODO Remove in Smack 4.4
+    @Deprecated
     public void removePacketSendingListener(StanzaListener packetListener);
+
+    /**
+     * Removes a stanza(/packet) listener for sending packets from this connection.
+     *
+     * @param packetListener the stanza(/packet) listener to remove.
+     */
+    public void removeStanzaSendingListener(StanzaListener packetListener);
 
     /**
      * Registers a stanza(/packet) interceptor with this connection. The interceptor will be
@@ -387,18 +413,47 @@ public interface XMPPConnection {
      * 
      * <p>
      * NOTE: For a similar functionality on incoming packets, see {@link #addAsyncStanzaListener(StanzaListener, StanzaFilter)}.
+     * </p>
+     *
+     * @param packetInterceptor the stanza(/packet) interceptor to notify of packets about to be sent.
+     * @param packetFilter      the stanza(/packet) filter to use.
+     * @deprecated use {@link #addStanzaInterceptor} instead
+     */
+    // TODO Remove in Smack 4.4
+    @Deprecated
+    public void addPacketInterceptor(StanzaListener packetInterceptor, StanzaFilter packetFilter);
+
+    /**
+     * Registers a stanza(/packet) interceptor with this connection. The interceptor will be
+     * invoked every time a stanza(/packet) is about to be sent by this connection. Interceptors
+     * may modify the stanza(/packet) to be sent. A stanza(/packet) filter determines which packets
+     * will be delivered to the interceptor.
+     *
+     * <p>
+     * NOTE: For a similar functionality on incoming packets, see {@link #addAsyncStanzaListener(StanzaListener, StanzaFilter)}.
+     * </p>
      *
      * @param packetInterceptor the stanza(/packet) interceptor to notify of packets about to be sent.
      * @param packetFilter      the stanza(/packet) filter to use.
      */
-    public void addPacketInterceptor(StanzaListener packetInterceptor, StanzaFilter packetFilter);
+    public void addStanzaInterceptor(StanzaListener packetInterceptor, StanzaFilter packetFilter);
+
+    /**
+     * Removes a stanza(/packet) interceptor.
+     *
+     * @param packetInterceptor the stanza(/packet) interceptor to remove.
+     * @deprecated user {@link #removeStanzaInterceptor} instead
+     */
+    // TODO Remove in Smack 4.4
+    @Deprecated
+    public void removePacketInterceptor(StanzaListener packetInterceptor);
 
     /**
      * Removes a stanza(/packet) interceptor.
      *
      * @param packetInterceptor the stanza(/packet) interceptor to remove.
      */
-    public void removePacketInterceptor(StanzaListener packetInterceptor);
+    public void removeStanzaInterceptor(StanzaListener packetInterceptor);
 
     /**
      * Returns the current value of the reply timeout in milliseconds for request for this

--- a/smack-debug/src/main/java/org/jivesoftware/smackx/debugger/EnhancedDebugger.java
+++ b/smack-debug/src/main/java/org/jivesoftware/smackx/debugger/EnhancedDebugger.java
@@ -1013,7 +1013,7 @@ public class EnhancedDebugger implements SmackDebugger {
     void cancel() {
         connection.removeConnectionListener(connListener);
         connection.removeAsyncStanzaListener(packetReaderListener);
-        connection.removePacketSendingListener(packetWriterListener);
+        connection.removeStanzaSendingListener(packetWriterListener);
         ((ObservableReader) reader).removeReaderListener(readerListener);
         ((ObservableWriter) writer).removeWriterListener(writerListener);
         messagesTable = null;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/sid/StableUniqueStanzaIdManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/sid/StableUniqueStanzaIdManager.java
@@ -95,7 +95,7 @@ public final class StableUniqueStanzaIdManager extends Manager {
     public synchronized void enable() {
         ServiceDiscoveryManager.getInstanceFor(connection()).addFeature(NAMESPACE);
         StanzaFilter filter = new AndFilter(OUTGOING_FILTER, new NotFilter(OUTGOING_FILTER));
-        connection().addPacketInterceptor(stanzaListener, filter);
+        connection().addStanzaInterceptor(stanzaListener, filter);
     }
 
     /**
@@ -103,7 +103,7 @@ public final class StableUniqueStanzaIdManager extends Manager {
      */
     public synchronized void disable() {
         ServiceDiscoveryManager.getInstanceFor(connection()).removeFeature(NAMESPACE);
-        connection().removePacketInterceptor(stanzaListener);
+        connection().removeStanzaInterceptor(stanzaListener);
     }
 
     /**

--- a/smack-extensions/src/main/java/org/jivesoftware/smack/chat2/ChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smack/chat2/ChatManager.java
@@ -116,7 +116,7 @@ public final class ChatManager extends Manager {
             }
         }, INCOMING_MESSAGE_FILTER);
 
-        connection.addPacketInterceptor(new StanzaListener() {
+        connection.addStanzaInterceptor(new StanzaListener() {
             @Override
             public void processStanza(Stanza stanza) throws NotConnectedException, InterruptedException {
                 Message message = (Message) stanza;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/caps/EntityCapsManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/caps/EntityCapsManager.java
@@ -339,7 +339,7 @@ public final class EntityCapsManager extends Manager {
             }
         });
 
-        connection.addPacketSendingListener(new StanzaListener() {
+        connection.addStanzaSendingListener(new StanzaListener() {
             @Override
             public void processStanza(Stanza packet) {
                 presenceSend = (Presence) packet;
@@ -362,7 +362,7 @@ public final class EntityCapsManager extends Manager {
                 packet.overrideExtension(caps);
             }
         };
-        connection.addPacketInterceptor(packetInterceptor, PresenceTypeFilter.AVAILABLE);
+        connection.addStanzaInterceptor(packetInterceptor, PresenceTypeFilter.AVAILABLE);
         // It's important to do this as last action. Since it changes the
         // behavior of the SDM in some ways
         sdm.setEntityCapsManager(this);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqlast/LastActivityManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqlast/LastActivityManager.java
@@ -134,7 +134,7 @@ public final class LastActivityManager extends Manager {
         super(connection);
 
         // Listen to all the sent messages to reset the idle time on each one
-        connection.addPacketSendingListener(new StanzaListener() {
+        connection.addStanzaSendingListener(new StanzaListener() {
             @Override
             public void processStanza(Stanza packet) {
                 Presence presence = (Presence) packet;
@@ -153,7 +153,7 @@ public final class LastActivityManager extends Manager {
             }
         }, StanzaTypeFilter.PRESENCE);
 
-        connection.addPacketSendingListener(new StanzaListener() {
+        connection.addStanzaSendingListener(new StanzaListener() {
             @Override
             public void processStanza(Stanza packet) {
                 Message message = (Message) packet;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -334,7 +334,7 @@ public class MultiUserChat {
                         );
         // @formatter:on
         connection.addSyncStanzaListener(declinesListener, new AndFilter(fromRoomFilter, DECLINE_FILTER));
-        connection.addPacketInterceptor(presenceInterceptor, new AndFilter(ToMatchesFilter.create(room),
+        connection.addStanzaInterceptor(presenceInterceptor, new AndFilter(ToMatchesFilter.create(room),
                         StanzaTypeFilter.PRESENCE));
         messageCollector = connection.createStanzaCollector(fromRoomGroupchatFilter);
 
@@ -2021,7 +2021,7 @@ public class MultiUserChat {
         connection.removeSyncStanzaListener(presenceListener);
         connection.removeSyncStanzaListener(subjectListener);
         connection.removeSyncStanzaListener(declinesListener);
-        connection.removePacketInterceptor(presenceInterceptor);
+        connection.removeStanzaInterceptor(presenceInterceptor);
         if (messageCollector != null) {
             messageCollector.cancel();
             messageCollector = null;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/PrivacyListManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/PrivacyListManager.java
@@ -126,7 +126,7 @@ public final class PrivacyListManager extends Manager {
         });
 
         // cached(Active|Default)ListName handling
-        connection.addPacketSendingListener(new StanzaListener() {
+        connection.addStanzaSendingListener(new StanzaListener() {
             @Override
             public void processStanza(Stanza packet) throws NotConnectedException {
                 XMPPConnection connection = connection();
@@ -148,7 +148,7 @@ public final class PrivacyListManager extends Manager {
                 }, iqResultReplyFilter);
             }
         }, SetActiveListFilter.INSTANCE);
-        connection.addPacketSendingListener(new StanzaListener() {
+        connection.addStanzaSendingListener(new StanzaListener() {
             @Override
             public void processStanza(Stanza packet) throws NotConnectedException {
                 XMPPConnection connection = connection();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/receipts/DeliveryReceiptManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/receipts/DeliveryReceiptManager.java
@@ -279,7 +279,7 @@ public final class DeliveryReceiptManager extends Manager {
      * @see #dontAutoAddDeliveryReceiptRequests()
      */
     public void autoAddDeliveryReceiptRequests() {
-        connection().addPacketInterceptor(AUTO_ADD_DELIVERY_RECEIPT_REQUESTS_LISTENER,
+        connection().addStanzaInterceptor(AUTO_ADD_DELIVERY_RECEIPT_REQUESTS_LISTENER,
                         MESSAGES_TO_REQUEST_RECEIPTS_FOR);
     }
 
@@ -290,7 +290,7 @@ public final class DeliveryReceiptManager extends Manager {
      * @see #autoAddDeliveryReceiptRequests()
      */
     public void dontAutoAddDeliveryReceiptRequests() {
-        connection().removePacketInterceptor(AUTO_ADD_DELIVERY_RECEIPT_REQUESTS_LISTENER);
+        connection().removeStanzaInterceptor(AUTO_ADD_DELIVERY_RECEIPT_REQUESTS_LISTENER);
     }
 
     /**

--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
@@ -335,7 +335,7 @@ public final class Roster extends Manager {
 
         });
 
-        connection.addPacketSendingListener(new StanzaListener() {
+        connection.addStanzaSendingListener(new StanzaListener() {
             @Override
             public void processStanza(Stanza stanzav) throws NotConnectedException, InterruptedException {
                 // Once we send an unavailable presence, the server is allowed to suppress sending presence status

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/caps/EntityCapsTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/caps/EntityCapsTest.java
@@ -134,7 +134,7 @@ public class EntityCapsTest extends AbstractSmackIntegrationTest {
     @SmackIntegrationTest
     public void testPreventDiscoInfo() throws Exception {
         final String dummyFeature = getNewDummyFeature();
-        conOne.addPacketSendingListener(new StanzaListener() {
+        conOne.addStanzaSendingListener(new StanzaListener() {
 
             @Override
             public void processStanza(Stanza stanza) {

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -643,7 +643,7 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
             if (config.isDebuggerEnabled()) {
                 addAsyncStanzaListener(debugger.getReaderListener(), null);
                 if (debugger.getWriterListener() != null) {
-                    addPacketSendingListener(debugger.getWriterListener(), null);
+                    addStanzaSendingListener(debugger.getWriterListener(), null);
                 }
             }
         }


### PR DESCRIPTION
Rename and deprecate XMPPConnections methods as described in SMACK-802