### PR TITLE
first commit, add support of manual ACKment of received MESSAGE stanza

### DIFF
--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnectionConfiguration.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnectionConfiguration.java
@@ -48,10 +48,18 @@ public final class XMPPTCPConnectionConfiguration extends ConnectionConfiguratio
      */
     private final int connectTimeout;
 
+    /**
+     * Setting whether to use automatic ACK of received Message stanzas(default behaviour), or
+     * activate manual ACK, that is, all received Message stanzas should be explicitly marked
+     * as handled by application via {@link XMPPTCPConnection#markHandledStanzaId(String)}
+     */
+    private final boolean manualRcvMessageAck;
+
     private XMPPTCPConnectionConfiguration(Builder builder) {
         super(builder);
         compressionEnabled = builder.compressionEnabled;
         connectTimeout = builder.connectTimeout;
+        manualRcvMessageAck = builder.manualRcvMessageAck;
     }
 
     /**
@@ -76,6 +84,17 @@ public final class XMPPTCPConnectionConfiguration extends ConnectionConfiguratio
         return connectTimeout;
     }
 
+    /**
+     * Get whether to use automatic ACK of received Message stanzas(default behaviour), or
+     * activate manual ACK, that is, all received Message stanzas should be explicitly marked
+     * as handled by application via {@link XMPPTCPConnection#markHandledStanzaId(String)}
+     *
+     * * @return boolean false if auto ACK, true if manual ACK
+     */
+    public boolean isManualRcvMessageAck() {
+        return manualRcvMessageAck;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -87,6 +106,7 @@ public final class XMPPTCPConnectionConfiguration extends ConnectionConfiguratio
     public static final class Builder extends ConnectionConfiguration.Builder<Builder, XMPPTCPConnectionConfiguration> {
         private boolean compressionEnabled = false;
         private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+        private boolean manualRcvMessageAck = false;
 
         private Builder() {
         }
@@ -113,6 +133,19 @@ public final class XMPPTCPConnectionConfiguration extends ConnectionConfiguratio
          */
         public Builder setConnectTimeout(int connectTimeout) {
             this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        /**
+         * Setting whether to use automatic ACK of received Message stanzas(default behaviour), or
+         * activate manual ACK, that is, all received Message stanzas should be explicitly marked
+         * as handled by application via {@link XMPPTCPConnection#markHandledStanzaId(String)}
+         *
+         * @param manualAck false if auto ACK for received Message is desired, false for manual ACK
+         * @return a reference to this object.
+         */
+        public Builder setManualRcvAck(boolean manualAck) {
+            this.manualRcvMessageAck = manualAck;
             return this;
         }
 


### PR DESCRIPTION
Hi, I write this PR to add support of manual ACKing of received <message> stanza(requires stream management). This to ensure handshaking/transactional nature in application level so no message will be lost if application is still not completed its message processing(for e.g storing to persistent database/queue, updating UI, etc). This especially true if application defer the handle of message to other module/thread and error/crash/kill is encountered like happened in our application, so maybe this can help other implementation too.

The way handshaking will be done in application is using Smack's **XMPPTcpConnection.markHandledStanzaId()** to explicitly state that the stanza/message is already processed completely. This will trigger the usual Stream Management's receive height counter increment, so the server can now safely remove the message from its offline/retry buffer. 

This **markHandledStanzaId()** can be called regardless order of actual receiption, because under the hood, the modification maintain list of all previously unacknowledged stanzas. Only when first and the consecutives stanzas are already marked as handled, the height counter will be updated and the stanzas will be removed from list. In this modification, <IQ> and <PRESENCE> will always be ACKed automatically regardless configuration.

This behaviour is configurable by mean of XMPPTcpConnectionConfiguration. Unless **Builder.setManualRcvAck(true)** is called, the receive ACK will be done automatically as default/current behaviour.