### PR TITLE
Add BodyElement + Provider

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/initializer/SmackCoreInitializer.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/initializer/SmackCoreInitializer.java
@@ -1,0 +1,10 @@
+package org.jivesoftware.smack.initializer;
+
+public final class SmackCoreInitializer extends UrlInitializer {
+
+    @Override
+    protected String getProvidersUri() {
+        return "classpath:org.jivesoftware.smack/smack.providers";
+    }
+
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/BodyElement.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/BodyElement.java
@@ -1,0 +1,43 @@
+/**
+ *
+ * Copyright 2018 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.packet;
+
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+/**
+ * BodyElement that should only be used if the body is used as a child element of an element which is not a message.
+ * The difference of this class to {@link Message.Body} is, that a BodyElement when serialized into xml, will
+ * annotate the namespace "jabber:client".
+ */
+public class BodyElement extends Message.Body {
+
+    public BodyElement(String language, String message) {
+        super(language, message);
+    }
+
+    @Override
+    public XmlStringBuilder toXML() {
+        XmlStringBuilder xml = new XmlStringBuilder();
+        xml.halfOpenElement(getElementName())
+                .xmlnsAttribute(getNamespace())
+                .xmllangAttribute(getLanguage())
+                .rightAngleBracket();
+        xml.escape(getMessage());
+        xml.closeElement(getElementName());
+        return xml;
+    }
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Message.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Message.java
@@ -619,7 +619,7 @@ public final class Message extends Stanza implements TypedCloneable<Message> {
     /**
      * Represents a message body, its language and the content of the message.
      */
-    public static final class Body implements ExtensionElement {
+    public static class Body implements ExtensionElement {
 
         public static final String ELEMENT = "body";
         public static final String NAMESPACE = StreamOpen.CLIENT_NAMESPACE;
@@ -627,7 +627,7 @@ public final class Message extends Stanza implements TypedCloneable<Message> {
         private final String message;
         private final String language;
 
-        private Body(String language, String message) {
+        Body(String language, String message) {
             if (language == null) {
                 throw new NullPointerException("Language cannot be null.");
             }

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/BodyProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/BodyProvider.java
@@ -1,0 +1,39 @@
+/**
+ *
+ * Copyright © 2018 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.provider;
+
+import org.jivesoftware.smack.packet.BodyElement;
+import org.jivesoftware.smack.packet.Stanza;
+import org.jivesoftware.smack.util.ParserUtils;
+
+import org.xmlpull.v1.XmlPullParser;
+
+public class BodyProvider extends ExtensionElementProvider<BodyElement> {
+
+    public static final BodyProvider TEST_INSTANCE = new BodyProvider();
+
+    @Override
+    public BodyElement parse(XmlPullParser parser, int initialDepth) throws Exception {
+        String xmlLang = ParserUtils.getXmlLang(parser);
+        if (xmlLang == null) {
+            xmlLang = Stanza.getDefaultLanguage();
+        }
+
+        String body = parser.nextText();
+        return new BodyElement(xmlLang, body);
+    }
+}

--- a/smack-core/src/main/resources/org.jivesoftware.smack/smack-config.xml
+++ b/smack-core/src/main/resources/org.jivesoftware.smack/smack-config.xml
@@ -5,6 +5,7 @@
     <startupClasses>
         <className>org.jivesoftware.smack.initializer.VmArgInitializer</className>
         <className>org.jivesoftware.smack.ReconnectionManager</className>
+        <className>org.jivesoftware.smack.initializer.SmackCoreInitializer</className>
     </startupClasses>
 
     <optionalStartupClasses>

--- a/smack-core/src/main/resources/org.jivesoftware.smack/smack.providers
+++ b/smack-core/src/main/resources/org.jivesoftware.smack/smack.providers
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!-- Providers for Smack -->
+<smackProviders>
+
+    <extensionProvider>
+      <elementName>body</elementName>
+      <namespace>jabber:client</namespace>
+      <className>org.jivesoftware.smack.provider.BodyProvider</className>
+    </extensionProvider>
+
+</smackProviders>

--- a/smack-core/src/test/java/org/jivesoftware/smack/provider/BodyProviderTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/provider/BodyProviderTest.java
@@ -1,0 +1,38 @@
+/**
+ *
+ * Copyright © 2018 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.provider;
+
+import static junit.framework.TestCase.assertEquals;
+
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.test.util.SmackTestSuite;
+import org.jivesoftware.smack.test.util.TestUtils;
+
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParser;
+
+public class BodyProviderTest extends SmackTestSuite {
+
+    @Test
+    public void bodyProviderTest() throws Exception {
+        String xml = "<body xmlns='jabber:client' xml:lang='en'>This is a message.</body>";
+        XmlPullParser parser = TestUtils.getParser(xml);
+        Message.Body body = BodyProvider.TEST_INSTANCE.parse(parser);
+        assertEquals("This is a message.", body.getMessage());
+        assertEquals("en", body.getLanguage());
+    }
+}


### PR DESCRIPTION
This PR adds a BodyProvider + BodyElement to `smack-core`.
The `BodyElement` extends `Message.Body`, whose constructors visibility had to be changed to `package` instead of `private`. `Message.Body` is also no longer declared as `final`.
The difference between `BodyElement` and `Message.Body` is, that the `.toXML()` method of the latter will never add a namespace of "jabber:client" to the generated XML, while `BodyElement` will. `BodyElement` can therefore be added as a child element to elements other than `Message`.