### PR TITLE
Add and register BodyElementProvider

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/CoreInitializer.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/CoreInitializer.java
@@ -1,0 +1,27 @@
+/**
+ *
+ * Copyright 2018 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack;
+
+import org.jivesoftware.smack.initializer.UrlInitializer;
+
+public class CoreInitializer extends UrlInitializer {
+
+    @Override
+    protected String getProvidersUri() {
+        return "classpath:org.jivesoftware.smack/core.providers";
+    }
+}

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/BodyElementProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/BodyElementProvider.java
@@ -1,0 +1,38 @@
+/**
+ *
+ * Copyright 2018 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.provider;
+
+import static org.jivesoftware.smack.util.PacketParserUtils.parseElementText;
+
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.util.ParserUtils;
+
+import org.xmlpull.v1.XmlPullParser;
+
+public class BodyElementProvider extends ExtensionElementProvider<Message.Body> {
+
+    @Override
+    public Message.Body parse(XmlPullParser parser, int initialDepth) throws Exception {
+        String xmlLang = ParserUtils.getXmlLang(parser);
+        if (xmlLang == null) {
+            xmlLang = "en";
+        }
+
+        String body = parseElementText(parser);
+        return new Message.Body(xmlLang, body);
+    }
+}

--- a/smack-core/src/main/resources/org.jivesoftware.smack/core.providers
+++ b/smack-core/src/main/resources/org.jivesoftware.smack/core.providers
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!-- Providers for core elements -->
+<smackProviders>
+    <extensionProvider>
+      <elementName>body</elementName>
+      <namespace>jabber:client</namespace>
+      <className>org.jivesoftware.smack.provider.BodyElementProvider</className>
+    </extensionProvider>
+</smackProviders>

--- a/smack-core/src/main/resources/org.jivesoftware.smack/smack-config.xml
+++ b/smack-core/src/main/resources/org.jivesoftware.smack/smack-config.xml
@@ -5,6 +5,7 @@
     <startupClasses>
         <className>org.jivesoftware.smack.initializer.VmArgInitializer</className>
         <className>org.jivesoftware.smack.ReconnectionManager</className>
+        <className>org.jivesoftware.smack.CoreInitializer</className>
     </startupClasses>
 
     <optionalStartupClasses>


### PR DESCRIPTION
This PR adds an ExtensionElementProvider for the `Message.Body` element.
It is registered in the new `core.providers` file via the also newly created `CoreInitializer` class, which in turn is registered as a startup class in `smack-config.xml`.

This Provider parses `<body/>` elements with the explicit namespace `jabber:client`.