### PR TITLE
fix: Cleans the multiUserChats map.

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -491,8 +491,7 @@ public final class MultiUserChatManager extends Manager {
      * @param <V> The value type.
      */
     private static class CleaningWeakReferenceMap<K, V>
-        extends HashMap<K, WeakReference<V>>
-    {
+        extends HashMap<K, WeakReference<V>> {
         private static final long serialVersionUID = 0L;
 
         /**
@@ -508,12 +507,10 @@ public final class MultiUserChatManager extends Manager {
         private int numberOfInsertsSinceLastClean = 0;
 
         @Override
-        public WeakReference<V> put(K key, WeakReference<V> value)
-        {
+        public WeakReference<V> put(K key, WeakReference<V> value) {
             WeakReference<V> ret = super.put(key, value);
 
-            if (numberOfInsertsSinceLastClean++ > CLEAN_INTERVAL)
-            {
+            if (numberOfInsertsSinceLastClean++ > CLEAN_INTERVAL) {
                 numberOfInsertsSinceLastClean = 0;
                 clean();
             }
@@ -525,15 +522,12 @@ public final class MultiUserChatManager extends Manager {
          * Removes all cleared entries from this map (i.e. entries whose value
          * is a cleared {@link WeakReference}).
          */
-        private void clean()
-        {
+        private void clean() {
             Iterator<Entry<K, WeakReference<V>>> iter = entrySet().iterator();
-            while (iter.hasNext())
-            {
+            while (iter.hasNext()) {
                 Entry<K, WeakReference<V>> e = iter.next();
                 if (e != null && e.getValue() != null
-                    && e.getValue().get() == null)
-                {
+                    && e.getValue().get() == null) {
                     iter.remove();
                 }
             }


### PR DESCRIPTION
We use Smack in a server side application, which creates and joins a new `MultiUserChat` as part of its health check. Health checks run often (every few seconds) and as a result the `multiUserChats` map in `MultiUserChatManager.java` fills up with `WeakReferece`s which are eventually cleared, but never removed from the map. After a long run we've observed >2 million entries, which leads to problems.

This patch solves the problem by cleaning the map by removing all weak references with `null` referent. The cleaning is run once every 50 calls to `put`.