### PR TITLE
fix: Cleans the multiUserChats map.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/CleaningWeakReferenceMap.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/CleaningWeakReferenceMap.java
@@ -1,0 +1,94 @@
+/**
+ *
+ * Copyright the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.util;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Iterator;
+
+/**
+ * Extends a {@link HashMap} with {@link WeakReference} values, so that
+ * weak references which have been cleared are periodically removed from
+ * the map. The cleaning occurs as part of {@link #put}, after a specific
+ * number ({@link #cleanInterval}) of calls to {@link #put}.
+ *
+ * @param <K> The key type.
+ * @param <V> The value type.
+ *
+ * @author Boris Grozev
+ */
+public class CleaningWeakReferenceMap<K, V>
+    extends HashMap<K, WeakReference<V>> {
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * The number of calls to {@link #put} after which to clean this map
+     * (i.e. remove cleared {@link WeakReference}s from it).
+     */
+    private final int cleanInterval;
+
+    /**
+     * The number of times {@link #put} has been called on this instance
+     * since the last time it was {@link #clean}ed.
+     */
+    private int numberOfInsertsSinceLastClean = 0;
+
+    /**
+     * Initializes a new {@link CleaningWeakReferenceMap} instance with the
+     * default clean interval.
+     */
+    public CleaningWeakReferenceMap() {
+        this(50);
+    }
+
+    /**
+     * Initializes a new {@link CleaningWeakReferenceMap} instance with a given
+     * clean interval.
+     * @param cleanInterval the number of calls to {@link #put} after which the
+     * map will clean itself.
+     */
+    public CleaningWeakReferenceMap(int cleanInterval) {
+        this.cleanInterval = cleanInterval;
+    }
+
+    @Override
+    public WeakReference<V> put(K key, WeakReference<V> value) {
+        WeakReference<V> ret = super.put(key, value);
+
+        if (numberOfInsertsSinceLastClean++ > cleanInterval) {
+            numberOfInsertsSinceLastClean = 0;
+            clean();
+        }
+
+        return ret;
+    }
+
+    /**
+     * Removes all cleared entries from this map (i.e. entries whose value
+     * is a cleared {@link WeakReference}).
+     */
+    private void clean() {
+        Iterator<Entry<K, WeakReference<V>>> iter = entrySet().iterator();
+        while (iter.hasNext()) {
+            Entry<K, WeakReference<V>> e = iter.next();
+            if (e != null && e.getValue() != null
+                && e.getValue().get() == null) {
+                iter.remove();
+            }
+        }
+    }
+}

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -19,7 +19,6 @@ package org.jivesoftware.smackx.muc;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +45,7 @@ import org.jivesoftware.smack.filter.StanzaTypeFilter;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.util.Async;
+import org.jivesoftware.smack.util.CleaningWeakReferenceMap;
 
 import org.jivesoftware.smackx.disco.AbstractNodeInformationProvider;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
@@ -144,7 +144,7 @@ public final class MultiUserChatManager extends Manager {
      * those instances to get garbage collected. Note that MultiUserChat instances can not get garbage collected while
      * the user is joined, because then the MUC will have PacketListeners added to the XMPPConnection.
      */
-    private final Map<EntityBareJid, WeakReference<MultiUserChat>> multiUserChats = new HashMap<>();
+    private final Map<EntityBareJid, WeakReference<MultiUserChat>> multiUserChats = new CleaningWeakReferenceMap<>();
 
     private boolean autoJoinOnReconnect;
 


### PR DESCRIPTION
This is #238  opened against the 4.3 branch.

We use Smack in a server side application, which creates and joins a new MultiUserChat as part of its health check. Health checks run often (every few seconds) and as a result the multiUserChats map in MultiUserChatManager.java fills up with WeakRefereces which are eventually cleared, but never removed from the map. After a long run we've observed >2 million entries, which leads to problems.

This patch solves the problem by cleaning the map by removing all weak references with null referent. The cleaning is run once every 50 calls to put.