### PR TITLE
This small hack prevent crash on Psi+ online status.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
@@ -417,11 +417,16 @@ public final class Presence extends Stanza implements TypedCloneable<Presence> {
         /**
          * Do not disturb.
          */
-        dnd;
+        dnd,
+
+        /**
+         * Online. At least Psi-plus send it.
+         */
+        online;
 
         /**
          * Converts a String into the corresponding types. Valid String values that can be converted
-         * to types are: "chat", "available", "away", "xa", and "dnd".
+         * to types are: "chat", "available", "away", "xa", "dnd" and "online".
          *
          * @param string the String value to covert.
          * @return the corresponding Type.


### PR DESCRIPTION
Before this commit if roster has at least one user with Psi+ client online the
smack just crash.

Psi+ sends presence likes:
```
<presence from='[user]@jabber.ru/Psi+work' to='catap@catap.ru/34110840091527669849196298' xml:lang='ru'>
<show>online</show>
<priority>50</priority>
<c xmlns='http://jabber.org/protocol/caps' node='http://psi-plus.com' ver='D7clrAb+xAPCSMydA+X+iNO94fI=' hash='sha-1'/>

<x xmlns='vcard-temp:x:update'><photo>b5402fd5a5f7f95f74857688c7e96364d0e0a34c</photo></x><delay xmlns='urn:xmpp:delay' from='[user]@jabber.ru/Psi+work' stamp='2018-05-30T08:33:38Z'/></presence>
```

when smack tried to parse it crashed with trace:
```
12:44:10 XMPPConnection closed due to an exception (XMPPTCPConnection[catap@catap.ru/34110840091527669849196298] (0))java.lang.IllegalArgumentException: No enum constant org.jivesoftware.smack.packet.Presence.Mode.online
	at java.base/java.lang.Enum.valueOf(Enum.java:240)
	at org.jivesoftware.smack.packet.Presence$Mode.valueOf(Presence.java:394)
	at org.jivesoftware.smack.packet.Presence$Mode.fromString(Presence.java:431)
	at org.jivesoftware.smack.util.PacketParserUtils.parsePresence(PacketParserUtils.java:561)
	at org.jivesoftware.smack.util.PacketParserUtils.parseStanza(PacketParserUtils.java:155)
	at org.jivesoftware.smack.AbstractXMPPConnection.parseAndProcessStanza(AbstractXMPPConnection.java:1083)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection.access$500(XMPPTCPConnection.java:151)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1044)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:1000)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:1016)
	at java.base/java.lang.Thread.run(Thread.java:844)
```