### PR TITLE
fix: Prevent attempt to construct invalid address

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -756,6 +756,10 @@ public class MultiUserChat {
         // throw.
         userHasLeft();
 
+        if (nickname == null) {
+            return;
+        }
+
         // We leave a room by sending a presence packet where the "to"
         // field is in the form "roomName@service/nickname"
         Presence leavePresence = new Presence(Presence.Type.unavailable);


### PR DESCRIPTION
When no join was properly registered, a nickname will not be defined. In that case, attempting
to construct the from address for the 'leave' presence stanza will result in:

   java.lang.IllegalArgumentException: The Resourcepart must not be null

This commit prevents that, by verifying that the nickname is non-null, before sending that
stanza.