### PR TITLE
Only ignore our own stale devices

### DIFF
--- a/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/OmemoService.java
+++ b/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/OmemoService.java
@@ -385,8 +385,8 @@ public abstract class OmemoService<T_IdKeyPair, T_IdKey, T_PreKey, T_SigPreKey, 
                 }
             }
 
-            // Ignore stale devices
-            if (OmemoConfiguration.getIgnoreStaleDevices()) {
+            // Ignore own stale devices
+            if (contactsDevice.getJid().equals(userDevice.getJid()) && OmemoConfiguration.getIgnoreStaleDevices()) {
 
                 Date lastMessageDate = getOmemoStoreBackend().getDateOfLastReceivedMessage(userDevice, contactsDevice);
                 if (lastMessageDate == null) {


### PR DESCRIPTION
Should fix ["ignore stale devices option can lock out omemo messaging between devices"](https://discourse.igniterealtime.org/t/smack-omemo-rework-177-ignore-stale-devices-option-can-lock-out-omemo-messaging-between-devices/).

The issue was, that the `encrypt()` method ignored stale devices of contacts. After consulting Daniel Gultsch, I decided to only consider own devices as stale and not taking staleness into account when dealing with contacts devices.This should get rid of deadlock situations as described in the report linked above, as our own stale devices will just re-announce themselves after getting removed from the device list, which will result in them getting active again.