### PR TITLE
Avoid adding multiple storage hints to a message

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hints/element/NoCopyHint.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hints/element/NoCopyHint.java
@@ -56,6 +56,6 @@ public final class NoCopyHint extends MessageProcessingHint {
     }
 
     public static void set(Message message) {
-        message.addExtension(INSTANCE);
+        message.overrideExtension(INSTANCE);
     }
 }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hints/element/NoPermanentStoreHint.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hints/element/NoPermanentStoreHint.java
@@ -60,7 +60,7 @@ public final class NoPermanentStoreHint extends MessageProcessingHint {
             // No need to set the no-permanent-store hint when a no-store hint is already set.
             return;
         }
-        setExplicitly(message);
+        message.overrideExtension(INSTANCE);
     }
 
     public static void setExplicitly(Message message) {

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hints/element/NoStoreHint.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hints/element/NoStoreHint.java
@@ -56,6 +56,6 @@ public final class NoStoreHint extends MessageProcessingHint {
     }
 
     public static void set(Message message) {
-        message.addExtension(INSTANCE);
+        message.overrideExtension(INSTANCE);
     }
 }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hints/element/StoreHint.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hints/element/StoreHint.java
@@ -56,6 +56,6 @@ public final class StoreHint extends MessageProcessingHint {
     }
 
     public static void set(Message message) {
-        message.addExtension(INSTANCE);
+        message.overrideExtension(INSTANCE);
     }
 }


### PR DESCRIPTION
Since ExtensionElements are stored in a list in the message, duplicate entries are possible. This commit avoids adding a storage hint to the message in case it already contains one.