### PR TITLE
Bump bcprov-jdk15on to 1.60

### DIFF
--- a/smack-omemo/build.gradle
+++ b/smack-omemo/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 	compile project(":smack-extensions")
 	compile project(":smack-experimental")
 
-	compile "org.bouncycastle:bcprov-jdk15on:1.59"
+	compile "org.bouncycastle:bcprov-jdk15on:1.60"
 
 	testCompile project(path: ":smack-core", configuration: "testRuntime")
 }


### PR DESCRIPTION
Bumping bcprov-jdk15on from 1.59 to 1.60