### PR TITLE
requireNotNullOrEmpty: Obey the rules of grammar

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -497,7 +497,7 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
     public synchronized void login(CharSequence username, String password, Resourcepart resource) throws XMPPException,
                     SmackException, IOException, InterruptedException {
         if (!config.allowNullOrEmptyUsername) {
-            StringUtils.requireNotNullOrEmpty(username, "Username must not be null or empty");
+            StringUtils.requireNotNullNorEmpty(username, "Username must not be null nor empty");
         }
         throwNotConnectedExceptionIfAppropriate("Did you call connect() before login()?");
         throwAlreadyLoggedInExceptionIfAppropriate();

--- a/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
@@ -894,8 +894,8 @@ public abstract class ConnectionConfiguration {
          * @return a reference to this builder.
          */
         public B addEnabledSaslMechanism(String saslMechanism) {
-            return addEnabledSaslMechanism(Arrays.asList(StringUtils.requireNotNullOrEmpty(saslMechanism,
-                            "saslMechanism must not be null or empty")));
+            return addEnabledSaslMechanism(Arrays.asList(StringUtils.requireNotNullNorEmpty(saslMechanism,
+                            "saslMechanism must not be null nor empty")));
         }
 
         /**

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/PacketExtensionFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/PacketExtensionFilter.java
@@ -42,7 +42,7 @@ public class PacketExtensionFilter implements StanzaFilter {
      * @param namespace the XML namespace of the stanza extension.
      */
     public PacketExtensionFilter(String elementName, String namespace) {
-        StringUtils.requireNotNullOrEmpty(namespace, "namespace must not be null or empty");
+        StringUtils.requireNotNullNorEmpty(namespace, "namespace must not be null nor empty");
 
         this.elementName = elementName;
         this.namespace = namespace;

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/PacketIDFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/PacketIDFilter.java
@@ -50,7 +50,7 @@ public class PacketIDFilter implements StanzaFilter {
      */
     @Deprecated
     public PacketIDFilter(String packetID) {
-        StringUtils.requireNotNullOrEmpty(packetID, "Packet ID must not be null or empty.");
+        StringUtils.requireNotNullNorEmpty(packetID, "Packet ID must not be null nor empty.");
         this.packetID = packetID;
     }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/StanzaExtensionFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/StanzaExtensionFilter.java
@@ -40,7 +40,7 @@ public class StanzaExtensionFilter implements StanzaFilter {
      * @param namespace the XML namespace of the stanza extension.
      */
     public StanzaExtensionFilter(String elementName, String namespace) {
-        StringUtils.requireNotNullOrEmpty(namespace, "namespace must not be null or empty");
+        StringUtils.requireNotNullNorEmpty(namespace, "namespace must not be null nor empty");
 
         this.elementName = elementName;
         this.namespace = namespace;

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/StanzaIdFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/StanzaIdFilter.java
@@ -44,7 +44,7 @@ public class StanzaIdFilter implements StanzaFilter {
      * @param stanzaID the stanza ID to filter for.
      */
     public StanzaIdFilter(String stanzaID) {
-        this.stanzaId = StringUtils.requireNotNullOrEmpty(stanzaID, "Stanza ID must not be null or empty.");
+        this.stanzaId = StringUtils.requireNotNullNorEmpty(stanzaID, "Stanza ID must not be null nor empty.");
     }
 
     @Override

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/ThreadFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/ThreadFilter.java
@@ -35,7 +35,7 @@ public class ThreadFilter extends FlexibleStanzaTypeFilter<Message> implements S
      * @param thread the thread value to filter for.
      */
     public ThreadFilter(String thread) {
-        StringUtils.requireNotNullOrEmpty(thread, "Thread must not be null or empty.");
+        StringUtils.requireNotNullNorEmpty(thread, "Thread must not be null nor empty.");
         this.thread = thread;
     }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/AbstractTextElement.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/AbstractTextElement.java
@@ -27,7 +27,7 @@ public abstract class AbstractTextElement implements ExtensionElement {
     private final String lang;
 
     protected AbstractTextElement(String text, String lang) {
-        this.text = StringUtils.requireNotNullOrEmpty(text, "Text must not be null or empty");
+        this.text = StringUtils.requireNotNullNorEmpty(text, "Text must not be null nor empty");
         this.lang = lang;
     }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/StandardExtensionElement.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/StandardExtensionElement.java
@@ -66,8 +66,8 @@ public final class StandardExtensionElement implements ExtensionElement {
 
     private StandardExtensionElement(String name, String namespace, Map<String, String> attributes, String text,
                     MultiMap<String, StandardExtensionElement> elements) {
-        this.name = StringUtils.requireNotNullOrEmpty(name, "Name must not be null or empty");
-        this.namespace = StringUtils.requireNotNullOrEmpty(namespace, "Namespace must not be null or empty");
+        this.name = StringUtils.requireNotNullNorEmpty(name, "Name must not be null nor empty");
+        this.namespace = StringUtils.requireNotNullNorEmpty(namespace, "Namespace must not be null nor empty");
         if (attributes == null) {
             this.attributes = Collections.emptyMap();
         }
@@ -173,7 +173,7 @@ public final class StandardExtensionElement implements ExtensionElement {
         }
 
         public Builder addAttribute(String name, String value) {
-            StringUtils.requireNotNullOrEmpty(name, "Attribute name must be set");
+            StringUtils.requireNotNullNorEmpty(name, "Attribute name must be set");
             Objects.requireNonNull(value, "Attribute value must be not null");
             if (attributes == null) {
                 attributes = new LinkedHashMap<>();

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Stanza.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Stanza.java
@@ -17,7 +17,7 @@
 
 package org.jivesoftware.smack.packet;
 
-import static org.jivesoftware.smack.util.StringUtils.requireNotNullOrEmpty;
+import static org.jivesoftware.smack.util.StringUtils.requireNotNullNorEmpty;
 
 import java.util.Collection;
 import java.util.List;
@@ -122,7 +122,7 @@ public abstract class Stanza implements TopLevelStreamElement {
      */
     public void setStanzaId(String id) {
         if (id != null) {
-            requireNotNullOrEmpty(id, "id must either be null or not the empty String");
+            requireNotNullNorEmpty(id, "id must either be null or not the empty String");
         }
         this.id = id;
     }
@@ -324,8 +324,8 @@ public abstract class Stanza implements TopLevelStreamElement {
      * @since 4.1
      */
     public List<ExtensionElement> getExtensions(String elementName, String namespace) {
-        requireNotNullOrEmpty(elementName, "elementName must not be null or empty");
-        requireNotNullOrEmpty(namespace, "namespace must not be null or empty");
+        requireNotNullNorEmpty(elementName, "elementName must not be null nor empty");
+        requireNotNullNorEmpty(namespace, "namespace must not be null nor empty");
         String key = XmppStringUtils.generateKey(elementName, namespace);
         return packetExtensions.getAll(key);
     }

--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/packet/SaslStreamElements.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/packet/SaslStreamElements.java
@@ -39,8 +39,8 @@ public class SaslStreamElements {
 
         public AuthMechanism(String mechanism, String authenticationText) {
             this.mechanism = Objects.requireNonNull(mechanism, "SASL mechanism shouldn't be null.");
-            this.authenticationText = StringUtils.requireNotNullOrEmpty(authenticationText,
-                            "SASL authenticationText must not be null or empty (RFC6120 6.4.2)");
+            this.authenticationText = StringUtils.requireNotNullNorEmpty(authenticationText,
+                            "SASL authenticationText must not be null nor empty (RFC6120 6.4.2)");
         }
 
         @Override

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/Objects.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/Objects.java
@@ -31,7 +31,15 @@ public class Objects {
         return requireNonNull(obj, null);
     }
 
-    public static <T extends Collection<?>> T requireNonNullOrEmpty(T collection, String message) {
+    /**
+     * Require a collection to be neither null, nor empty.
+     *
+     * @param collection collection
+     * @param message error message
+     * @param <T> Collection type
+     * @return collection
+     */
+    public static <T extends Collection<?>> T requireNonNullNorEmpty(T collection, String message) {
         if (requireNonNull(collection).isEmpty()) {
             throw new IllegalArgumentException(message);
         }

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/StringUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/StringUtils.java
@@ -444,7 +444,29 @@ public class StringUtils {
         return csOne.toString().compareTo(csTwo.toString());
     }
 
+    /**
+     * Require a {@link CharSequence} to be neither null, nor empty.
+     *
+     * @deprecated use {@link #requireNotNullNorEmpty(CharSequence, String)} instead.
+     * @param cs CharSequence
+     * @param message error message
+     * @param <CS> CharSequence type
+     * @return cs
+     */
+    @Deprecated
     public static <CS extends CharSequence> CS requireNotNullOrEmpty(CS cs, String message) {
+        return requireNotNullNorEmpty(cs, message);
+    }
+
+    /**
+     * Require a {@link CharSequence} to be neither null, nor empty.
+     *
+     * @param cs CharSequence
+     * @param message error message
+     * @param <CS> CharSequence type
+     * @return cs
+     */
+    public static <CS extends CharSequence> CS requireNotNullNorEmpty(CS cs, String message) {
         if (isNullOrEmpty(cs)) {
             throw new IllegalArgumentException(message);
         }

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/XmlStringBuilder.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/XmlStringBuilder.java
@@ -372,7 +372,7 @@ public class XmlStringBuilder implements Appendable, CharSequence, Element {
         private final String xmlFragment;
 
         private XmlNsAttribute(String value) {
-            this.value = StringUtils.requireNotNullOrEmpty(value, "Value must not be null");
+            this.value = StringUtils.requireNotNullNorEmpty(value, "Value must not be null");
             this.xmlFragment = " xmlns='" + value + '\'';
         }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/dns/SRVRecord.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/dns/SRVRecord.java
@@ -48,7 +48,7 @@ public class SRVRecord extends HostAddress implements Comparable<SRVRecord> {
      */
     public SRVRecord(DnsName fqdn, int port, int priority, int weight, List<InetAddress> inetAddresses) {
         super(fqdn, port, inetAddresses);
-        StringUtils.requireNotNullOrEmpty(fqdn, "The FQDN must not be null");
+        StringUtils.requireNotNullNorEmpty(fqdn, "The FQDN must not be null");
         if (weight < 0 || weight > 65535)
             throw new IllegalArgumentException(
                     "DNS SRV records weight must be a 16-bit unsigned integer (i.e. between 0-65535. Weight was: "

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/eme/element/ExplicitMessageEncryptionElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/eme/element/ExplicitMessageEncryptionElement.java
@@ -87,7 +87,7 @@ public class ExplicitMessageEncryptionElement implements ExtensionElement {
     }
 
     public ExplicitMessageEncryptionElement(String encryptionNamespace, String name) {
-        this.encryptionNamespace = StringUtils.requireNotNullOrEmpty(encryptionNamespace,
+        this.encryptionNamespace = StringUtils.requireNotNullNorEmpty(encryptionNamespace,
                         "encryptionNamespace must not be null");
         this.name = name;
     }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/element/Tag.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/element/Tag.java
@@ -34,9 +34,9 @@ public class Tag implements NamedElement {
 
     public Tag(String name, Type type, String value) {
         // TODO According to XEP-0347 § 5.2 names are case insensitive. Uppercase them all?
-        this.name = StringUtils.requireNotNullOrEmpty(name, "name must not be null or empty");
+        this.name = StringUtils.requireNotNullNorEmpty(name, "name must not be null nor empty");
         this.type = Objects.requireNonNull(type);
-        this.value =  StringUtils.requireNotNullOrEmpty(value, "value must not be null or empty");
+        this.value =  StringUtils.requireNotNullNorEmpty(value, "value must not be null nor empty");
         if (this.name.length() > 32) {
             throw new IllegalArgumentException("Meta Tag names must not be longer then 32 characters (XEP-0347 § 5.2");
         }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/element/NodeInfo.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/element/NodeInfo.java
@@ -37,7 +37,7 @@ public final class NodeInfo {
     }
 
     public NodeInfo(String nodeId, String sourceId, String cacheType) {
-        this.nodeId = StringUtils.requireNotNullOrEmpty(nodeId, "Node ID must not be null or empty");
+        this.nodeId = StringUtils.requireNotNullNorEmpty(nodeId, "Node ID must not be null nor empty");
         this.sourceId = sourceId;
         this.cacheType = cacheType;
     }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bob/BoBHash.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bob/BoBHash.java
@@ -39,8 +39,8 @@ public class BoBHash {
      * @param hashType
      */
     public BoBHash(String hash, String hashType) {
-        this.hash = StringUtils.requireNotNullOrEmpty(hash, "hash must not be null or empty");
-        this.hashType = StringUtils.requireNotNullOrEmpty(hashType, "hashType must not be null or empty");
+        this.hash = StringUtils.requireNotNullNorEmpty(hash, "hash must not be null nor empty");
+        this.hashType = StringUtils.requireNotNullNorEmpty(hashType, "hashType must not be null nor empty");
         this.cid = this.hashType + '+' + this.hash + "@bob.xmpp.org";
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/packet/Bytestream.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/packet/Bytestream.java
@@ -288,7 +288,7 @@ public class Bytestream extends IQ {
          */
         public StreamHost(final Jid JID, final String address, int port) {
             this.JID = Objects.requireNonNull(JID, "StreamHost JID must not be null");
-            this.addy = StringUtils.requireNotNullOrEmpty(address, "StreamHost address must not be null");
+            this.addy = StringUtils.requireNotNullNorEmpty(address, "StreamHost address must not be null");
             this.port = port;
         }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/packet/DiscoverInfo.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/packet/DiscoverInfo.java
@@ -318,8 +318,8 @@ public class DiscoverInfo extends IQ implements TypedCloneable<DiscoverInfo> {
          * @param lang the entity's lang.
          */
         public Identity(String category, String type, String name, String lang) {
-            this.category = StringUtils.requireNotNullOrEmpty(category, "category cannot be null");
-            this.type = StringUtils.requireNotNullOrEmpty(type, "type cannot be null");
+            this.category = StringUtils.requireNotNullNorEmpty(category, "category cannot be null");
+            this.type = StringUtils.requireNotNullNorEmpty(type, "type cannot be null");
             this.key = XmppStringUtils.generateKey(category, type);
             this.name = name;
             this.lang = lang;
@@ -500,7 +500,7 @@ public class DiscoverInfo extends IQ implements TypedCloneable<DiscoverInfo> {
          * @param variable the feature's variable.
          */
         public Feature(String variable) {
-            this.variable = StringUtils.requireNotNullOrEmpty(variable, "variable cannot be null");
+            this.variable = StringUtils.requireNotNullNorEmpty(variable, "variable cannot be null");
         }
 
         /**

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqversion/packet/Version.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqversion/packet/Version.java
@@ -68,8 +68,8 @@ public class Version extends IQ {
     public Version(String name, String version, String os) {
         super(ELEMENT, NAMESPACE);
         this.setType(IQ.Type.result);
-        this.name = StringUtils.requireNotNullOrEmpty(name, "name must not be null");
-        this.version = StringUtils.requireNotNullOrEmpty(version, "version must not be null");
+        this.name = StringUtils.requireNotNullNorEmpty(name, "name must not be null");
+        this.version = StringUtils.requireNotNullNorEmpty(version, "version must not be null");
         this.os = os;
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/Jingle.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/Jingle.java
@@ -68,7 +68,7 @@ public final class Jingle extends IQ {
     private Jingle(String sessionId, JingleAction action, FullJid initiator, FullJid responder, JingleReason reason,
                     List<JingleContent> contents) {
         super(ELEMENT, NAMESPACE);
-        this.sessionId = StringUtils.requireNotNullOrEmpty(sessionId, "Jingle session ID must not be null");
+        this.sessionId = StringUtils.requireNotNullNorEmpty(sessionId, "Jingle session ID must not be null");
         this.action = Objects.requireNonNull(action, "Jingle action must not be null");
         this.initiator = initiator;
         this.responder = responder;
@@ -190,7 +190,7 @@ public final class Jingle extends IQ {
         }
 
         public Builder setSessionId(String sessionId) {
-            StringUtils.requireNotNullOrEmpty(sessionId, "Session ID must not be null or empty");
+            StringUtils.requireNotNullNorEmpty(sessionId, "Session ID must not be null nor empty");
             this.sid = sessionId;
             return this;
         }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContent.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleContent.java
@@ -75,7 +75,7 @@ public final class JingleContent implements NamedElement {
                     JingleContentDescription description, JingleContentTransport transport) {
         this.creator = Objects.requireNonNull(creator, "Jingle content creator must not be null");
         this.disposition = disposition;
-        this.name = StringUtils.requireNotNullOrEmpty(name, "Jingle content name must not be null or empty");
+        this.name = StringUtils.requireNotNullNorEmpty(name, "Jingle content name must not be null nor empty");
         this.senders = senders;
         this.description = description;
         this.transport = transport;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_s5b/elements/JingleS5BTransport.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_s5b/elements/JingleS5BTransport.java
@@ -41,7 +41,7 @@ public class JingleS5BTransport extends JingleContentTransport {
 
     protected JingleS5BTransport(List<JingleContentTransportCandidate> candidates, JingleContentTransportInfo info, String streamId, String dstAddr, Bytestream.Mode mode) {
         super(candidates, info);
-        StringUtils.requireNotNullOrEmpty(streamId, "sid MUST be neither null, nor empty.");
+        StringUtils.requireNotNullNorEmpty(streamId, "sid MUST be neither null, nor empty.");
         this.streamId = streamId;
         this.dstAddr = dstAddr;
         this.mode = mode;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/element/MessageCorrectExtension.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/message_correct/element/MessageCorrectExtension.java
@@ -55,7 +55,7 @@ public class MessageCorrectExtension implements ExtensionElement {
     private final String idInitialMessage;
 
     public MessageCorrectExtension(String idInitialMessage) {
-        this.idInitialMessage = StringUtils.requireNotNullOrEmpty(idInitialMessage, "idInitialMessage must not be null");
+        this.idInitialMessage = StringUtils.requireNotNullNorEmpty(idInitialMessage, "idInitialMessage must not be null");
     }
 
     public String getIdInitialMessage() {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/PrivacyListManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/PrivacyListManager.java
@@ -399,7 +399,7 @@ public final class PrivacyListManager extends Manager {
      * @throws InterruptedException
      */
     public PrivacyList getPrivacyList(String listName) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException  {
-        listName = StringUtils.requireNotNullOrEmpty(listName, "List name must not be null");
+        listName = StringUtils.requireNotNullNorEmpty(listName, "List name must not be null");
         return new PrivacyList(false, false, listName, getPrivacyListItems(listName));
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/Affiliation.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/Affiliation.java
@@ -86,7 +86,7 @@ public class Affiliation implements ExtensionElement {
      * @param namespace the affiliation's namespace.
      */
     public Affiliation(String node, Type affiliation, AffiliationNamespace namespace) {
-        this.node = StringUtils.requireNotNullOrEmpty(node, "node must not be null or empty");
+        this.node = StringUtils.requireNotNullNorEmpty(node, "node must not be null nor empty");
         this.affiliation = affiliation;
         this.jid = null;
         this.namespace = Objects.requireNonNull(namespace);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/SimplePayload.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/SimplePayload.java
@@ -57,8 +57,8 @@ public class SimplePayload implements ExtensionElement {
 
         payload = xmlPayload;
 
-        elemName = StringUtils.requireNotNullOrEmpty(qname.getLocalPart(), "Could not determine element name from XML payload");
-        ns = StringUtils.requireNotNullOrEmpty(qname.getNamespaceURI(), "Could not determine namespace from XML payload");
+        elemName = StringUtils.requireNotNullNorEmpty(qname.getLocalPart(), "Could not determine element name from XML payload");
+        ns = StringUtils.requireNotNullNorEmpty(qname.getNamespaceURI(), "Could not determine namespace from XML payload");
     }
 
     /**

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/FormField.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/FormField.java
@@ -156,7 +156,7 @@ public class FormField implements NamedElement {
      * @param variable the variable name of the question.
      */
     public FormField(String variable) {
-        this.variable = StringUtils.requireNotNullOrEmpty(variable, "Variable must not be null or empty");
+        this.variable = StringUtils.requireNotNullNorEmpty(variable, "Variable must not be null nor empty");
     }
 
     /**

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -218,19 +218,19 @@ public final class Configuration {
         }
 
         public Builder setAdminAccountUsernameAndPassword(String adminAccountUsername, String adminAccountPassword) {
-            this.adminAccountUsername = StringUtils.requireNotNullOrEmpty(adminAccountUsername, "adminAccountUsername must not be null or empty");
-            this.adminAccountPassword = StringUtils.requireNotNullOrEmpty(adminAccountPassword, "adminAccountPassword must no be null or empty");
+            this.adminAccountUsername = StringUtils.requireNotNullNorEmpty(adminAccountUsername, "adminAccountUsername must not be null nor empty");
+            this.adminAccountPassword = StringUtils.requireNotNullNorEmpty(adminAccountPassword, "adminAccountPassword must no be null nor empty");
             return this;
         }
 
         public Builder setUsernamesAndPassword(String accountOneUsername, String accountOnePassword,
                         String accountTwoUsername, String accountTwoPassword, String accountThreeUsername, String accountThreePassword) {
-            this.accountOneUsername = StringUtils.requireNotNullOrEmpty(accountOneUsername, "accountOneUsername must not be null or empty");
-            this.accountOnePassword = StringUtils.requireNotNullOrEmpty(accountOnePassword, "accountOnePassword must not be null or empty");
-            this.accountTwoUsername = StringUtils.requireNotNullOrEmpty(accountTwoUsername, "accountTwoUsername must not be null or empty");
-            this.accountTwoPassword = StringUtils.requireNotNullOrEmpty(accountTwoPassword, "accountTwoPasswordmust not be null or empty");
-            this.accountThreeUsername = StringUtils.requireNotNullOrEmpty(accountThreeUsername, "accountThreeUsername must not be null or empty");
-            this.accountThreePassword = StringUtils.requireNotNullOrEmpty(accountThreePassword, "accountThreePassword must not be null or empty");
+            this.accountOneUsername = StringUtils.requireNotNullNorEmpty(accountOneUsername, "accountOneUsername must not be null nor empty");
+            this.accountOnePassword = StringUtils.requireNotNullNorEmpty(accountOnePassword, "accountOnePassword must not be null nor empty");
+            this.accountTwoUsername = StringUtils.requireNotNullNorEmpty(accountTwoUsername, "accountTwoUsername must not be null nor empty");
+            this.accountTwoPassword = StringUtils.requireNotNullNorEmpty(accountTwoPassword, "accountTwoPasswordmust not be null nor empty");
+            this.accountThreeUsername = StringUtils.requireNotNullNorEmpty(accountThreeUsername, "accountThreeUsername must not be null nor empty");
+            this.accountThreePassword = StringUtils.requireNotNullNorEmpty(accountThreePassword, "accountThreePassword must not be null nor empty");
             return this;
         }
 

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -598,7 +598,7 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
                 failedAddresses.add(hostAddress);
             } else {
                 socket = socketFactory.createSocket();
-                StringUtils.requireNotNullOrEmpty(host, "Host of HostAddress " + hostAddress + " must not be null when using a Proxy");
+                StringUtils.requireNotNullNorEmpty(host, "Host of HostAddress " + hostAddress + " must not be null when using a Proxy");
                 final String hostAndPort = host + " at port " + port;
                 LOGGER.finer("Trying to establish TCP connection via Proxy to " + hostAndPort);
                 try {


### PR DESCRIPTION
Replace  `StringUtils.requireNotNullOrEmpty()` with `StringUtils.requireNotNullNorEmpty()` and add deprecated `StringUtils.requireNotNullOrEmpty()` to not break the API. Also fix any error messages which used wrong grammar.
Rename `Objects.requireNonNullOrEmpty()` to `Objects.requireNonNullNorEmpty()` as it has not been used yet.