### PR TITLE
XEP-0333 Improvement

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/ChatMarkersListener.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/ChatMarkersListener.java
@@ -1,0 +1,38 @@
+/**
+ *
+ * Copyright 2017 Miguel Hincapie.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.chat_markers;
+
+import org.jivesoftware.smack.chat2.Chat;
+import org.jivesoftware.smack.packet.Message;
+
+/**
+ * Chat Markers Manager class (XEP-0333).
+ *
+ * @author Miguel Hincapie
+ * @see <a href="http://xmpp.org/extensions/xep-0333.html">XEP-0333: Chat
+ * Markers</a>
+ */
+public interface ChatMarkersListener {
+    /**
+     * Called in ChatMarkersManager when a new message with a markable tag arrives.
+     *
+     * @param chatMarkersState the current state of the message.
+     * @param message the new incoming message with a markable XML tag.
+     * @param chat associated to the message.
+     */
+    void newChatMarkerMessage(ChatMarkersState chatMarkersState, Message message, Chat chat);
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/ChatMarkersManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/ChatMarkersManager.java
@@ -169,11 +169,14 @@ public final class ChatMarkersManager extends Manager {
                         for (ChatMarkersListener listener : finalListeners) {
                             if (ChatMarkersElements.MarkableExtension.from(message) != null) {
                                 listener.newChatMarkerMessage(ChatMarkersState.markable, message, chat);
-                            } else if (ChatMarkersElements.ReceivedExtension.from(message) != null) {
+                            }
+                            else if (ChatMarkersElements.ReceivedExtension.from(message) != null) {
                                 listener.newChatMarkerMessage(ChatMarkersState.received, message, chat);
-                            } else if (ChatMarkersElements.DisplayedExtension.from(message) != null) {
+                            }
+                            else if (ChatMarkersElements.DisplayedExtension.from(message) != null) {
                                 listener.newChatMarkerMessage(ChatMarkersState.displayed, message, chat);
-                            } else if (ChatMarkersElements.AcknowledgedExtension.from(message) != null) {
+                            }
+                            else if (ChatMarkersElements.AcknowledgedExtension.from(message) != null) {
                                 listener.newChatMarkerMessage(ChatMarkersState.acknowledged, message, chat);
                             }
                         }
@@ -250,7 +253,8 @@ public final class ChatMarkersManager extends Manager {
             try {
                 state = ChatState.valueOf(chatStateElementName);
                 return !(state == ChatState.active);
-            } catch (Exception ex) {
+            }
+            catch (Exception ex) {
                 return true;
             }
         }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/ChatMarkersManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/ChatMarkersManager.java
@@ -16,25 +16,50 @@
  */
 package org.jivesoftware.smackx.chat_markers;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.jivesoftware.smack.AsyncButOrdered;
 import org.jivesoftware.smack.ConnectionCreationListener;
 import org.jivesoftware.smack.Manager;
+import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
+import org.jivesoftware.smack.StanzaListener;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPConnectionRegistry;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 
+import org.jivesoftware.smack.chat2.Chat;
+import org.jivesoftware.smack.chat2.ChatManager;
+import org.jivesoftware.smack.filter.AndFilter;
+import org.jivesoftware.smack.filter.MessageTypeFilter;
+import org.jivesoftware.smack.filter.NotFilter;
+import org.jivesoftware.smack.filter.OrFilter;
+import org.jivesoftware.smack.filter.StanzaExtensionFilter;
+import org.jivesoftware.smack.filter.StanzaFilter;
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.Stanza;
+import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smackx.chat_markers.element.ChatMarkersElements;
+import org.jivesoftware.smackx.chatstates.ChatState;
+import org.jivesoftware.smackx.chatstates.ChatStateManager;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.Jid;
 
 /**
  * Chat Markers Manager class (XEP-0333).
  *
  * @see <a href="http://xmpp.org/extensions/xep-0333.html">XEP-0333: Chat
  *      Markers</a>
+ * @author Miguel Hincapie
  * @author Fernando Ramirez
  *
  */
@@ -50,6 +75,25 @@ public final class ChatMarkersManager extends Manager {
     }
 
     private static final Map<XMPPConnection, ChatMarkersManager> INSTANCES = new WeakHashMap<>();
+
+    // @FORMATTER:OFF
+    private static final StanzaFilter FILTER = new NotFilter(new StanzaExtensionFilter(ChatMarkersElements.NAMESPACE));
+    private static final StanzaFilter CHAT_STATE_FILTER = new NotFilter(new StanzaExtensionFilter(ChatStateManager.NAMESPACE));
+
+    private static final StanzaFilter MESSAGE_FILTER = new OrFilter(
+            MessageTypeFilter.NORMAL_OR_CHAT,
+            MessageTypeFilter.GROUPCHAT
+    );
+
+    private static final StanzaFilter INCOMING_MESSAGE_FILTER = new AndFilter(
+            MESSAGE_FILTER,
+            new StanzaExtensionFilter(ChatMarkersElements.NAMESPACE)
+    );
+    // @FORMATTER:ON
+
+    private final Set<ChatMarkersListener> incomingListeners = new CopyOnWriteArraySet<>();
+
+    private final AsyncButOrdered<Chat> asyncButOrdered = new AsyncButOrdered<>();
 
     /**
      * Get the singleton instance of ChatMarkersManager.
@@ -70,6 +114,76 @@ public final class ChatMarkersManager extends Manager {
 
     private ChatMarkersManager(XMPPConnection connection) {
         super(connection);
+        connection.addStanzaInterceptor(new StanzaListener() {
+            @Override
+            public void processStanza(Stanza packet)
+                    throws
+                    NotConnectedException,
+                    InterruptedException,
+                    SmackException.NotLoggedInException {
+                Message message = (Message) packet;
+                if (shouldDiscardMessage(message)) {
+                    return;
+                }
+
+                if (message.getBodies().isEmpty()) {
+                    return;
+                }
+
+                // if message already has a chatMarkerExtension, then do nothing,
+                if (!FILTER.accept(message)) {
+                    return;
+                }
+
+                // otherwise add a markable extension,
+                message.addExtension(new ChatMarkersElements.MarkableExtension());
+            }
+        }, MESSAGE_FILTER);
+
+        connection.addSyncStanzaListener(new StanzaListener() {
+            @Override
+            public void processStanza(Stanza packet)
+                    throws
+                    NotConnectedException,
+                    InterruptedException,
+                    SmackException.NotLoggedInException {
+                final Message message = (Message) packet;
+                if (shouldDiscardMessage(message)) {
+                    return;
+                }
+
+                EntityFullJid fullFrom = message.getFrom().asEntityFullJidIfPossible();
+                EntityBareJid bareFrom = fullFrom.asEntityBareJid();
+                final Chat chat = ChatManager.getInstanceFor(connection()).chatWith(bareFrom);
+
+                List<ChatMarkersListener> listeners;
+                synchronized (incomingListeners) {
+                    listeners = new ArrayList<>(incomingListeners.size());
+                    listeners.addAll(incomingListeners);
+                }
+
+                final List<ChatMarkersListener> finalListeners = listeners;
+                asyncButOrdered.performAsyncButOrdered(chat, new Runnable() {
+                    @Override
+                    public void run() {
+                        for (ChatMarkersListener listener : finalListeners) {
+                            if (ChatMarkersElements.MarkableExtension.from(message) != null) {
+                                listener.newChatMarkerMessage(ChatMarkersState.markable, message, chat);
+                            } else if (ChatMarkersElements.ReceivedExtension.from(message) != null) {
+                                listener.newChatMarkerMessage(ChatMarkersState.received, message, chat);
+                            } else if (ChatMarkersElements.DisplayedExtension.from(message) != null) {
+                                listener.newChatMarkerMessage(ChatMarkersState.displayed, message, chat);
+                            } else if (ChatMarkersElements.AcknowledgedExtension.from(message) != null) {
+                                listener.newChatMarkerMessage(ChatMarkersState.acknowledged, message, chat);
+                            }
+                        }
+                    }
+                });
+
+            }
+        }, INCOMING_MESSAGE_FILTER);
+
+        ServiceDiscoveryManager.getInstanceFor(connection).addFeature(ChatMarkersElements.NAMESPACE);
     }
 
     /**
@@ -87,4 +201,100 @@ public final class ChatMarkersManager extends Manager {
                 .serverSupportsFeature(ChatMarkersElements.NAMESPACE);
     }
 
+    /**
+     * Register a ChatMarkersListener. That listener will be informed about new
+     * incoming markable messages.
+     *
+     * @param listener ChatMarkersListener
+     * @return true, if the listener was not registered before
+     */
+    public boolean addIncomingChatMarkerMessageListener(ChatMarkersListener listener) {
+        synchronized (incomingListeners) {
+            return incomingListeners.add(listener);
+        }
+    }
+
+    /**
+     * Unregister a ChatMarkersListener.
+     *
+     * @param listener ChatMarkersListener
+     * @return true, if the listener was registered before
+     */
+    public boolean removeIncomingChatMarkerMessageListener(ChatMarkersListener listener) {
+        synchronized (incomingListeners) {
+            return incomingListeners.remove(listener);
+        }
+    }
+
+    /**
+     * From XEP-0333, Protocol Format: The Chat Marker MUST have an 'id' which is the 'id' of the
+     * message being marked.<br>
+     * In order to make Chat Markers works together with XEP-0085 as it said in
+     * 8.5 Interaction with Chat States, only messages with <tt>active</tt> chat
+     * state are accepted.
+     *
+     * @param message to be analyzed.
+     * @return true if the message contains a stanza Id.
+     * @see <a href="http://xmpp.org/extensions/xep-0333.html">XEP-0333: Chat Markers</a>
+     */
+    private boolean shouldDiscardMessage(Message message) {
+        if (StringUtils.isNullOrEmpty(message.getStanzaId())) {
+            return true;
+        }
+
+        if (!CHAT_STATE_FILTER.accept(message)) {
+            ExtensionElement extension = message.getExtension(ChatStateManager.NAMESPACE);
+            String chatStateElementName = extension.getElementName();
+
+            ChatState state;
+            try {
+                state = ChatState.valueOf(chatStateElementName);
+                return !(state == ChatState.active);
+            } catch (Exception ex) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void markMessageAsReceived(String id, Jid to, Jid from, String thread)
+            throws
+            NotConnectedException,
+            InterruptedException {
+        Message message = createMessage(id, to, from, thread);
+        message.addExtension(new ChatMarkersElements.ReceivedExtension(id));
+        sendChatMarkerMessage(message);
+    }
+
+    public void markMessageAsDisplayed(String id, Jid to, Jid from, String thread)
+            throws
+            NotConnectedException,
+            InterruptedException {
+        Message message = createMessage(id, to, from, thread);
+        message.addExtension(new ChatMarkersElements.DisplayedExtension(id));
+        sendChatMarkerMessage(message);
+    }
+
+    public void markMessageAsAcknowledged(String id, Jid to, Jid from, String thread)
+            throws
+            NotConnectedException,
+            InterruptedException {
+        Message message = createMessage(id, to, from, thread);
+        message.addExtension(new ChatMarkersElements.AcknowledgedExtension(id));
+        sendChatMarkerMessage(message);
+    }
+
+    private Message createMessage(String id, Jid to, Jid from, String thread) {
+        Message message = new Message();
+        message.setStanzaId(id);
+        message.setTo(to);
+        message.setFrom(from);
+        message.setThread(thread);
+        return message;
+    }
+
+    private void sendChatMarkerMessage(Message message) throws NotConnectedException, InterruptedException {
+        connection().sendStanza(message);
+    }
 }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/ChatMarkersState.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/ChatMarkersState.java
@@ -1,0 +1,45 @@
+/**
+ *
+ * Copyright © 2018 Miguel Hincapie
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.chat_markers;
+
+/**
+ * Chat Markers elements (XEP-0333).
+ *
+ * @author Miguel Hincapie
+ * @see <a href="http://xmpp.org/extensions/xep-0333.html">XEP-0333: Chat
+ * Markers</a>
+ */
+public enum ChatMarkersState {
+    /**
+     *  Indicates that a message can be marked with a Chat Marker and is therefore
+     *  a "markable message".
+     */
+    markable,
+    /**
+     * The message has been received by a client.
+     */
+    received,
+    /**
+     * The message has been displayed to a user in a active chat and not in a system notification.
+     */
+    displayed,
+    /**
+     * The message has been acknowledged by some user interaction e.g. pressing an
+     * acknowledgement button.
+     */
+    acknowledged
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/element/ChatMarkersElements.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/chat_markers/element/ChatMarkersElements.java
@@ -19,6 +19,7 @@ package org.jivesoftware.smackx.chat_markers.element;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.util.XmlStringBuilder;
+import org.jivesoftware.smackx.chat_markers.ChatMarkersState;
 
 /**
  * Chat Markers elements (XEP-0333).
@@ -45,7 +46,7 @@ public class ChatMarkersElements {
         /**
          * markable element.
          */
-        public static final String ELEMENT = "markable";
+        public static final String ELEMENT = ChatMarkersState.markable.toString();
 
         public MarkableExtension() {
         }
@@ -85,7 +86,7 @@ public class ChatMarkersElements {
         /**
          * received element.
          */
-        public static final String ELEMENT = "received";
+        public static final String ELEMENT = ChatMarkersState.received.toString();
 
         private final String id;
 
@@ -138,7 +139,7 @@ public class ChatMarkersElements {
         /**
          * displayed element.
          */
-        public static final String ELEMENT = "displayed";
+        public static final String ELEMENT = ChatMarkersState.displayed.toString();
 
         private final String id;
 
@@ -191,7 +192,7 @@ public class ChatMarkersElements {
         /**
          * acknowledged element.
          */
-        public static final String ELEMENT = "acknowledged";
+        public static final String ELEMENT = ChatMarkersState.acknowledged.toString();
 
         private final String id;
 


### PR DESCRIPTION
# Description
In order to be able to use `ChatMarkersManager` following same pattern/architecture like `ChatStateManager` or `ChatManager` (version 2), some improvement needs to be done in the XEP-0333 implementation.

The goal of this improvement was obtain an interface to be implemented like `IncomingChatMessageListener` or `ChatStateListener`. For that, an interface was created (ChatMarkersListener), an enum (ChatMarkersState) and 2 files modified (ChatMarkersElements and ChatMarkersManager). For more details, please read commits description.

The changes done in `ChatMarkersManager` were done trying to mimic `ChatStateManager` and `ChatManager`.

Those changes has been implemented successfully in an app (I can't say the name :/).

Any suggestion is welcome.