### PR TITLE
(Re)move duplicate FileUtils methods

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/FileUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/FileUtils.java
@@ -31,7 +31,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -154,50 +153,6 @@ public final class FileUtils {
         catch (IOException e) {
             LOGGER.log(Level.WARNING, "writeFile", e);
             return false;
-        }
-    }
-
-    public static void deleteDirectory(File root) {
-        if (!root.exists()) {
-            return;
-        }
-        File[] currList;
-        Stack<File> stack = new Stack<>();
-        stack.push(root);
-        while (!stack.isEmpty()) {
-            if (stack.lastElement().isDirectory()) {
-                currList = stack.lastElement().listFiles();
-                if (currList != null && currList.length > 0) {
-                    for (File curr : currList) {
-                        stack.push(curr);
-                    }
-                } else {
-                    stack.pop().delete();
-                }
-            } else {
-                stack.pop().delete();
-            }
-        }
-    }
-
-    /**
-     * Returns a {@link File} pointing to a temporary directory. On unix like systems this might be {@code /tmp}
-     * for example.
-     * If {@code suffix} is not null, the returned file points to {@code <temp>/suffix}.
-     *
-     * @param suffix optional path suffix
-     * @return temp directory
-     */
-    public static File getTempDir(String suffix) {
-        String temp = System.getProperty("java.io.tmpdir");
-        if (temp == null) {
-            temp = "tmp";
-        }
-
-        if (suffix == null) {
-            return new File(temp);
-        } else {
-            return new File(temp, suffix);
         }
     }
 }

--- a/smack-core/src/test/java/org/jivesoftware/smack/test/util/FileTestUtil.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/test/util/FileTestUtil.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.smack.test.util;
 
 import java.io.File;
+import java.util.Stack;
 
 public class FileTestUtil {
 
@@ -38,6 +39,34 @@ public class FileTestUtil {
             return new File(temp);
         } else {
             return new File(temp, suffix);
+        }
+    }
+
+    /**
+     * Recursively delete a directory and its contents.
+     *
+     * @param root root directory
+     */
+    public static void deleteDirectory(File root) {
+        if (!root.exists()) {
+            return;
+        }
+        File[] currList;
+        Stack<File> stack = new Stack<>();
+        stack.push(root);
+        while (!stack.isEmpty()) {
+            if (stack.lastElement().isDirectory()) {
+                currList = stack.lastElement().listFiles();
+                if (currList != null && currList.length > 0) {
+                    for (File curr : currList) {
+                        stack.push(curr);
+                    }
+                } else {
+                    stack.pop().delete();
+                }
+            } else {
+                stack.pop().delete();
+            }
         }
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox/OXSecretKeyBackupIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox/OXSecretKeyBackupIntegrationTest.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
-import org.jivesoftware.smack.util.FileUtils;
+import org.jivesoftware.smack.test.util.FileTestUtil;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smackx.ox.callback.backup.AskForBackupCodeCallback;
 import org.jivesoftware.smackx.ox.callback.backup.DisplayBackupCodeCallback;
@@ -63,8 +63,8 @@ import org.pgpainless.key.protection.UnprotectedKeysProtector;
 public class OXSecretKeyBackupIntegrationTest extends AbstractOpenPgpIntegrationTest {
 
     private static final String sessionId = StringUtils.randomString(10);
-    private static final File beforePath = FileUtils.getTempDir("ox_backup_" + sessionId);
-    private static final File afterPath = FileUtils.getTempDir("ox_restore_" + sessionId);
+    private static final File beforePath = FileTestUtil.getTempDir("ox_backup_" + sessionId);
+    private static final File afterPath = FileTestUtil.getTempDir("ox_restore_" + sessionId);
 
     private String backupCode = null;
 
@@ -110,8 +110,8 @@ public class OXSecretKeyBackupIntegrationTest extends AbstractOpenPgpIntegration
     @BeforeClass
     public static void cleanStore() {
         LOGGER.log(Level.INFO, "Delete store directories...");
-        FileUtils.deleteDirectory(afterPath);
-        FileUtils.deleteDirectory(beforePath);
+        FileTestUtil.deleteDirectory(afterPath);
+        FileTestUtil.deleteDirectory(beforePath);
     }
 
     @After

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingIntegrationTest.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.packet.Message;
-import org.jivesoftware.smack.util.FileUtils;
+import org.jivesoftware.smack.test.util.FileTestUtil;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smackx.ox.AbstractOpenPgpIntegrationTest;
 import org.jivesoftware.smackx.ox.OpenPgpContact;
@@ -49,8 +49,8 @@ import org.pgpainless.key.protection.UnprotectedKeysProtector;
 public class OXInstantMessagingIntegrationTest extends AbstractOpenPgpIntegrationTest {
 
     private static final String sessionId = StringUtils.randomString(10);
-    private static final File aliceStorePath = FileUtils.getTempDir("basic_ox_messaging_test_alice_" + sessionId);
-    private static final File bobStorePath = FileUtils.getTempDir("basic_ox_messaging_test_bob_" + sessionId);
+    private static final File aliceStorePath = FileTestUtil.getTempDir("basic_ox_messaging_test_alice_" + sessionId);
+    private static final File bobStorePath = FileTestUtil.getTempDir("basic_ox_messaging_test_bob_" + sessionId);
 
     private OpenPgpV4Fingerprint aliceFingerprint = null;
     private OpenPgpV4Fingerprint bobFingerprint = null;
@@ -97,8 +97,8 @@ public class OXInstantMessagingIntegrationTest extends AbstractOpenPgpIntegratio
     @AfterClass
     public static void deleteStore() {
         LOGGER.log(Level.INFO, "Deleting storage directories...");
-        FileUtils.deleteDirectory(aliceStorePath);
-        FileUtils.deleteDirectory(bobStorePath);
+        FileTestUtil.deleteDirectory(aliceStorePath);
+        FileTestUtil.deleteDirectory(bobStorePath);
     }
 
     @SmackIntegrationTest

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/OpenPgpStoreTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/OpenPgpStoreTest.java
@@ -35,8 +35,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jivesoftware.smack.test.util.FileTestUtil;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
-import org.jivesoftware.smack.util.FileUtils;
 import org.jivesoftware.smackx.ox.callback.SecretKeyPassphraseCallback;
 import org.jivesoftware.smackx.ox.exception.MissingUserIdOnKeyException;
 import org.jivesoftware.smackx.ox.store.definition.OpenPgpStore;
@@ -65,7 +65,7 @@ import org.pgpainless.util.Passphrase;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class OpenPgpStoreTest extends SmackTestSuite {
 
-    private static File storagePath;
+    private static final File storagePath;
 
     private static final BareJid alice = JidTestUtil.BARE_JID_1;
     private static final BareJid bob = JidTestUtil.BARE_JID_2;
@@ -78,7 +78,7 @@ public class OpenPgpStoreTest extends SmackTestSuite {
     private final OpenPgpStore openPgpStoreInstance2;
 
     static {
-        storagePath = FileUtils.getTempDir("storeTest");
+        storagePath = FileTestUtil.getTempDir("storeTest");
         Security.addProvider(new BouncyCastleProvider());
     }
 
@@ -101,7 +101,7 @@ public class OpenPgpStoreTest extends SmackTestSuite {
     @Before
     @After
     public void deletePath() {
-        FileUtils.deleteDirectory(storagePath);
+        FileTestUtil.deleteDirectory(storagePath);
     }
 
     /*

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
@@ -32,8 +32,8 @@ import java.util.List;
 import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.test.util.FileTestUtil;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
-import org.jivesoftware.smack.util.FileUtils;
 import org.jivesoftware.smackx.ox.crypto.OpenPgpElementAndMetadata;
 import org.jivesoftware.smackx.ox.crypto.PainlessOpenPgpProvider;
 import org.jivesoftware.smackx.ox.element.CryptElement;
@@ -62,13 +62,13 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
     private static final BareJid bob = JidTestUtil.BARE_JID_2;
 
     static {
-        storagePath = FileUtils.getTempDir("smack-painlessprovidertest");
+        storagePath = FileTestUtil.getTempDir("smack-painlessprovidertest");
     }
 
     @BeforeClass
     @AfterClass
     public static void deletePath() {
-        FileUtils.deleteDirectory(storagePath);
+        FileTestUtil.deleteDirectory(storagePath);
     }
 
     @Test

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/SecretKeyBackupHelperTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/SecretKeyBackupHelperTest.java
@@ -28,8 +28,8 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.jivesoftware.smack.DummyConnection;
+import org.jivesoftware.smack.test.util.FileTestUtil;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
-import org.jivesoftware.smack.util.FileUtils;
 import org.jivesoftware.smackx.ox.crypto.PainlessOpenPgpProvider;
 import org.jivesoftware.smackx.ox.element.SecretkeyElement;
 import org.jivesoftware.smackx.ox.exception.InvalidBackupCodeException;
@@ -54,7 +54,7 @@ public class SecretKeyBackupHelperTest extends SmackTestSuite {
     private static final File basePath;
 
     static {
-        basePath = FileUtils.getTempDir("ox_secret_keys");
+        basePath = FileTestUtil.getTempDir("ox_secret_keys");
     }
 
     @Test
@@ -98,6 +98,6 @@ public class SecretKeyBackupHelperTest extends SmackTestSuite {
     @AfterClass
     @BeforeClass
     public static void deleteDirs() {
-        FileUtils.deleteDirectory(basePath);
+        FileTestUtil.deleteDirectory(basePath);
     }
 }

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingManagerTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingManagerTest.java
@@ -34,8 +34,8 @@ import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.test.util.FileTestUtil;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
-import org.jivesoftware.smack.util.FileUtils;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smackx.eme.element.ExplicitMessageEncryptionElement;
 import org.jivesoftware.smackx.ox.OpenPgpContact;
@@ -62,7 +62,7 @@ public class OXInstantMessagingManagerTest extends SmackTestSuite {
     private static final File basePath;
 
     static {
-        basePath = FileUtils.getTempDir("ox_im_test_" + StringUtils.randomString(10));
+        basePath = FileTestUtil.getTempDir("ox_im_test_" + StringUtils.randomString(10));
     }
 
     @Test
@@ -170,6 +170,6 @@ public class OXInstantMessagingManagerTest extends SmackTestSuite {
     @AfterClass
     @BeforeClass
     public static void deleteDirs() {
-        FileUtils.deleteDirectory(basePath);
+        FileTestUtil.deleteDirectory(basePath);
     }
 }


### PR DESCRIPTION
* Remove `FileUtils.getTempDir()` in favor of `FileTestUtil.getTempDir()` which was introduced in #243 
* Move `FileUtils.deleteDirectory()` to `FileTestUtil.deleteDirectory()`