### PR TITLE
Fix duplicate NS in stanza error child element

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Stanza.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Stanza.java
@@ -544,7 +544,7 @@ public abstract class Stanza implements TopLevelStreamElement {
     protected void appendErrorIfExists(XmlStringBuilder xml) {
         StanzaError error = getError();
         if (error != null) {
-            xml.append(error.toXML());
+            xml.append(error.toXML(StreamOpen.CLIENT_NAMESPACE));
         }
     }
 }


### PR DESCRIPTION
This PR fixes an inconvenience, where an IQ with the implicit namespace `jabber:client` would append the namespace to an error child element like this:

```
<iq (xmlns='jabber:client) <!-- in parenthesis since the NS is implicit --> ... >
    <error xmlns='jabber:client' <!-- this NS is too much --> ... />
</iq>
```

The fix I found is to hand the IQs namespace down to the error element to prevent appending it twice.