### PR TITLE
Fix failing JUnit test by bumping PGPainless to 0.0.1-alpha4

### DIFF
--- a/smack-openpgp/build.gradle
+++ b/smack-openpgp/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 	compile project(':smack-extensions')
 	compile project(':smack-experimental')
 
-	compile 'org.pgpainless:pgpainless-core:0.0.1-alpha3'
+	compile 'org.pgpainless:pgpainless-core:0.0.1-alpha4'
 
 	testCompile project(path: ":smack-core", configuration: "testRuntime")
 	testCompile project(path: ":smack-core", configuration: "archives")


### PR DESCRIPTION
The reason for the failing JUnit test was a bug in PGPainless's function for converting a fingerprint to a key id. That method was failing in rare cases. PGPainless 0.0.1-alpha4 [fixed](https://github.com/pgpainless/pgpainless/commit/fe52a7f398b0efb4f109633f04d338191ade8f58) this issue.