### PR TITLE
Fix Roster.getPresence ConcurrentModificationException

### DIFF
--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
@@ -951,8 +951,7 @@ public final class Roster extends Manager {
             // This is used in case no available presence is found
             Presence unavailable = null;
 
-            for (Resourcepart resource : userPresences.keySet()) {
-                Presence p = userPresences.get(resource);
+            for (Presence p : userPresences.values()) {
                 if (!p.isAvailable()) {
                     unavailable = p;
                     continue;


### PR DESCRIPTION
Since Smack 4.2.4, the getPresencesInternal method in the Roster class can return a LruCache object, which is a LinkedHashMap with access order. This means that any access using get or getOrDefault will be a modification of the Map. If you loop over the keySet of the Map and there are more than one, the second call to get will throw a ConcurrentModificationException!

Since the keys are only used here to obtain the corresponding values, the simplest solution is to just loop over the values instead.