### PR TITLE
Use new BareJidEncoder class in FileBasedOmemoStore

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/stringencoder/BareJidEncoder.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/stringencoder/BareJidEncoder.java
@@ -1,0 +1,59 @@
+/**
+ *
+ * Copyright 2018 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.util.stringencoder;
+
+import org.jxmpp.jid.BareJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+public abstract class BareJidEncoder implements StringEncoder<BareJid> {
+
+    @Deprecated
+    public static class LegacyEncoder extends BareJidEncoder {
+
+        @Override
+        public String encode(BareJid jid) {
+            return jid.toString();
+        }
+
+        @Override
+        public BareJid decode(String string) {
+            try {
+                return JidCreate.bareFrom(string);
+            } catch (XmppStringprepException e) {
+                throw new IllegalArgumentException("BareJid cannot be decoded.", e);
+            }
+        }
+    }
+
+    public static class UrlSafeEncoder extends BareJidEncoder {
+
+        @Override
+        public String encode(BareJid jid) {
+            return jid.asUrlEncodedString();
+        }
+
+        @Override
+        public BareJid decode(String string) {
+            try {
+                return JidCreate.bareFromUrlEncoded(string);
+            } catch (XmppStringprepException e) {
+                throw new IllegalArgumentException("BareJid cannot be decoded.", e);
+            }
+        }
+    }
+}

--- a/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/FileBasedOmemoStore.java
+++ b/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/FileBasedOmemoStore.java
@@ -37,7 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jivesoftware.smack.util.CloseableUtil;
-
+import org.jivesoftware.smack.util.stringencoder.BareJidEncoder;
 import org.jivesoftware.smackx.omemo.exceptions.CorruptedOmemoKeyException;
 import org.jivesoftware.smackx.omemo.internal.OmemoCachedDeviceList;
 import org.jivesoftware.smackx.omemo.internal.OmemoDevice;
@@ -54,6 +54,7 @@ public abstract class FileBasedOmemoStore<T_IdKeyPair, T_IdKey, T_PreKey, T_SigP
 
     private final FileHierarchy hierarchy;
     private static final Logger LOGGER = Logger.getLogger(FileBasedOmemoStore.class.getName());
+    private static BareJidEncoder bareJidEncoder = new BareJidEncoder.UrlSafeEncoder();
 
     public FileBasedOmemoStore(File basePath) {
         super();
@@ -769,7 +770,7 @@ public abstract class FileBasedOmemoStore<T_IdKeyPair, T_IdKey, T_PreKey, T_SigP
         }
 
         File getUserDirectory(BareJid bareJid) {
-            return createDirectory(getStoreDirectory(), bareJid.toString());
+            return createDirectory(getStoreDirectory(), bareJidEncoder.encode(bareJid));
         }
 
         File getUserDeviceDirectory(OmemoDevice userDevice) {
@@ -782,7 +783,7 @@ public abstract class FileBasedOmemoStore<T_IdKeyPair, T_IdKey, T_PreKey, T_SigP
         }
 
         File getContactsDir(OmemoDevice userDevice, BareJid contact) {
-            return createDirectory(getContactsDir(userDevice), contact.toString());
+            return createDirectory(getContactsDir(userDevice), bareJidEncoder.encode(contact));
         }
 
         File getContactsDir(OmemoDevice userDevice, OmemoDevice contactsDevice) {
@@ -860,5 +861,16 @@ public abstract class FileBasedOmemoStore<T_IdKeyPair, T_IdKey, T_PreKey, T_SigP
             f.mkdirs();
             return f;
         }
+    }
+
+    /**
+     * Convert {@link BareJid BareJids} to Strings using the legacy {@link BareJid#toString()} method instead of the
+     * proper, url safe {@link BareJid#asUrlEncodedString()} method.
+     * While it is highly advised to use the new format, you can use this method to stay backwards compatible to data
+     * sets created by the old implementation.
+     */
+    @SuppressWarnings("deprecation")
+    public static void useLegacyBareJidEncoding() {
+        bareJidEncoder = new BareJidEncoder.LegacyEncoder();
     }
 }


### PR DESCRIPTION
Fixes GSO-002, GSO-005.
This PR sets the `FileBasedOmemoStore''s default encoding method for `BareJid`s to `BareJid.asUrlEncodedString()`. It also provides a method to restore the legacy behaviour.

Whats left to do is to create a migrator, which can migrate existing data sets from the old path layout to the new one.