### PR TITLE
Enables the HTTP compression in JBOSH

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -157,6 +157,8 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
             if (config.isProxyEnabled()) {
                 cfgBuilder.setProxy(config.getProxyAddress(), config.getProxyPort());
             }
+            cfgBuilder.setCompressionEnabled(config.isCompressionEnabled());
+
             client = BOSHClient.create(cfgBuilder.build());
 
             client.addBOSHClientConnListener(new BOSHConnectionListener());

--- a/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java
@@ -125,6 +125,8 @@ public abstract class ConnectionConfiguration {
 
     private final Set<String> enabledSaslMechanisms;
 
+    private final boolean compressionEnabled;
+
     protected ConnectionConfiguration(Builder<?,?> builder) {
         authzid = builder.authzid;
         username = builder.username;
@@ -161,6 +163,8 @@ public abstract class ConnectionConfiguration {
         debuggerFactory = builder.debuggerFactory;
         allowNullOrEmptyUsername = builder.allowEmptyOrNullUsername;
         enabledSaslMechanisms = builder.enabledSaslMechanisms;
+
+        compressionEnabled = builder.compressionEnabled;
 
         // If the enabledSaslmechanisms are set, then they must not be empty
         assert (enabledSaslMechanisms != null ? !enabledSaslMechanisms.isEmpty() : true);
@@ -440,8 +444,7 @@ public abstract class ConnectionConfiguration {
      * @return true if the connection is going to use stream compression.
      */
     public boolean isCompressionEnabled() {
-        // Compression for non-TCP connections is always disabled
-        return false;
+        return compressionEnabled;
     }
 
     /**
@@ -513,6 +516,7 @@ public abstract class ConnectionConfiguration {
         private boolean saslMechanismsSealed;
         private Set<String> enabledSaslMechanisms;
         private X509TrustManager customX509TrustManager;
+        private boolean compressionEnabled = false;
 
         protected Builder() {
             if (SmackConfiguration.DEBUG) {
@@ -945,6 +949,21 @@ public abstract class ConnectionConfiguration {
             this.authzid = authzid;
             return getThis();
         }
+
+        /**
+         * Sets if the connection is going to use compression (default false).
+         *
+         * Compression is only activated if the server offers compression. With compression network
+         * traffic can be reduced up to 90%. By default compression is disabled.
+         *
+         * @param compressionEnabled if the connection is going to use compression on the HTTP level.
+         * @return a reference to this object.
+         */
+        public B setCompressionEnabled(boolean compressionEnabled) {
+            this.compressionEnabled = compressionEnabled;
+            return getThis();
+        }
+
 
         public abstract C build();
 

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnectionConfiguration.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnectionConfiguration.java
@@ -41,8 +41,6 @@ public final class XMPPTCPConnectionConfiguration extends ConnectionConfiguratio
      */
     public static int DEFAULT_CONNECT_TIMEOUT = 30000;
 
-    private final boolean compressionEnabled;
-
     /**
      * How long the socket will wait until a TCP connection is established (in milliseconds).
      */
@@ -50,21 +48,7 @@ public final class XMPPTCPConnectionConfiguration extends ConnectionConfiguratio
 
     private XMPPTCPConnectionConfiguration(Builder builder) {
         super(builder);
-        compressionEnabled = builder.compressionEnabled;
         connectTimeout = builder.connectTimeout;
-    }
-
-    /**
-     * Returns true if the connection is going to use stream compression. Stream compression
-     * will be requested after TLS was established (if TLS was enabled) and only if the server
-     * offered stream compression. With stream compression network traffic can be reduced
-     * up to 90%. By default compression is disabled.
-     *
-     * @return true if the connection is going to use stream compression.
-     */
-    @Override
-    public boolean isCompressionEnabled() {
-        return compressionEnabled;
     }
 
     /**
@@ -89,20 +73,6 @@ public final class XMPPTCPConnectionConfiguration extends ConnectionConfiguratio
         private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
 
         private Builder() {
-        }
-
-        /**
-         * Sets if the connection is going to use stream compression. Stream compression
-         * will be requested after TLS was established (if TLS was enabled) and only if the server
-         * offered stream compression. With stream compression network traffic can be reduced
-         * up to 90%. By default compression is disabled.
-         *
-         * @param compressionEnabled if the connection is going to use stream compression.
-         * @return a reference to this object.
-         */
-        public Builder setCompressionEnabled(boolean compressionEnabled) {
-            this.compressionEnabled = compressionEnabled;
-            return this;
         }
 
         /**


### PR DESCRIPTION
Add an extra parameter "httpCompressionEnabled" to BOSHConfiguration
that is used to set the setCompressionEnabled() of BOSHClientConfig

Related to issue SMACK-642