### PR TITLE
RFC 3920 xml-not-well-formed error check moved to StreamError

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/StanzaError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/StanzaError.java
@@ -385,11 +385,6 @@ public class StanzaError extends AbstractError implements ExtensionElement {
         }
 
         public static Condition fromString(String string) {
-            // Backwards compatibility for older implementations still using RFC 3920. RFC 6120
-            // changed 'xml-not-well-formed' to 'not-well-formed'.
-            if ("xml-not-well-formed".equals(string)) {
-                string = "not-well-formed";
-            }
             string = string.replace('-', '_');
             Condition condition = null;
             try {

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/StreamError.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/StreamError.java
@@ -186,6 +186,11 @@ public class StreamError extends AbstractError implements Nonza {
         }
 
         public static Condition fromString(String string) {
+            // Backwards compatibility for older implementations still using RFC 3920. RFC 6120
+            // changed 'xml-not-well-formed' to 'not-well-formed'.
+            if ("xml-not-well-formed".equals(string)) {
+                string = "not-well-formed";
+            }
             string = string.replace('-', '_');
             Condition condition = null;
             try {

--- a/smack-core/src/test/java/org/jivesoftware/smack/packet/StreamErrorTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/packet/StreamErrorTest.java
@@ -104,4 +104,22 @@ public class StreamErrorTest {
         assertNotNull(appSpecificElement);
     }
 
+    @Test
+    public void testStreamErrorXmlNotWellFormed() {
+        StreamError error = null;
+        final String xml =
+                // Usually the stream:stream element has more attributes (to, version, ...)
+                // We omit those, since they are not relevant for testing
+                "<stream:stream from='im.example.com' id='++TR84Sm6A3hnt3Q065SnAbbk3Y=' xmlns:stream='http://etherx.jabber.org/streams'>" +
+                        "<stream:error><xml-not-well-formed xmlns='urn:ietf:params:xml:ns:xmpp-streams'/></stream:error>" +
+                        "</stream:stream>";
+        try {
+            XmlPullParser parser = PacketParserUtils.getParserFor(xml, "error");
+            error = PacketParserUtils.parseStreamError(parser);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+        assertNotNull(error);
+        assertEquals(Condition.not_well_formed, error.getCondition());
+    }
 }


### PR DESCRIPTION
Fixed java.lang.IllegalArgumentException: No enum constant org.jivesoftware.smack.packet.StreamError.Condition.xml_not_well_formed with old (RFC 3920) servers