### PR TITLE
Fix previous archive page requested incorrectly.

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/MamManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/MamManager.java
@@ -633,7 +633,7 @@ public final class MamManager extends Manager {
         public List<Message> pagePrevious(int count) throws NoResponseException, XMPPErrorException,
                         NotConnectedException, NotLoggedInException, InterruptedException {
             RSMSet previousResultRsmSet = getPreviousRsmSet();
-            RSMSet requestRsmSet = new RSMSet(count, previousResultRsmSet.getLast(), RSMSet.PageDirection.before);
+            RSMSet requestRsmSet = new RSMSet(count, previousResultRsmSet.getFirst(), RSMSet.PageDirection.before);
             return page(requestRsmSet);
         }
 


### PR DESCRIPTION
Unless I am mistaken, the previous archive page should be before the first message in the previous result set, not the last.