### PR TITLE
Set message type to 'chat' for OMEMO messages

### DIFF
--- a/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/OmemoMessage.java
+++ b/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/OmemoMessage.java
@@ -127,8 +127,7 @@ public class OmemoMessage {
          */
         public Message asMessage(Jid recipient) {
 
-            Message messageStanza = new Message();
-            messageStanza.setTo(recipient);
+            Message messageStanza = new Message(recipient, Message.Type.chat);
             messageStanza.addExtension(getElement());
 
             if (OmemoConfiguration.getAddOmemoHintBody()) {


### PR DESCRIPTION
OMEMO messages accidentally had no type set, so Gajim would open them in a popup.
This PR sets the message type to 'chat'.