### PR TITLE
Partially improve XML boolean parsing

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/ParserUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/ParserUtils.java
@@ -141,7 +141,7 @@ public class ParserUtils {
         if (valueString == null)
             return null;
         valueString = valueString.toLowerCase(Locale.US);
-        return valueString.equals("true") || valueString.equals("0");
+        return valueString.equals("true") || valueString.equals("1");
     }
 
     public static boolean getBooleanAttribute(XmlPullParser parser, String name,

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bookmarks/Bookmarks.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bookmarks/Bookmarks.java
@@ -269,12 +269,12 @@ public class Bookmarks implements PrivateData {
 
     private static BookmarkedConference getConferenceStorage(XmlPullParser parser) throws XmlPullParserException, IOException {
         String name = parser.getAttributeValue("", "name");
-        String autojoin = parser.getAttributeValue("", "autojoin");
+        boolean autojoin = ParserUtils.getBooleanAttribute(parser, "autojoin", false);
         EntityBareJid jid = ParserUtils.getBareJidAttribute(parser);
 
         BookmarkedConference conf = new BookmarkedConference(jid);
         conf.setName(name);
-        conf.setAutoJoin(Boolean.valueOf(autojoin));
+        conf.setAutoJoin(autojoin);
 
         // Check for nickname
         boolean done = false;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/RoomInfo.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/RoomInfo.java
@@ -207,7 +207,8 @@ public class RoomInfo {
 
             FormField subjectmodField = form.getField("muc#roominfo_subjectmod");
             if (subjectmodField != null && !subjectmodField.getValues().isEmpty()) {
-                subjectmod = Boolean.valueOf(subjectmodField.getFirstValue());
+                String firstValue = subjectmodField.getFirstValue();
+                subjectmod = ("true".equals(firstValue) || "1".equals(firstValue));
             }
 
             FormField urlField = form.getField("muc#roominfo_logs");


### PR DESCRIPTION
This fixes some occurences of Boolean.valueOf() in the XML parsing code. There are some more in components I haven't looked into yet (JivePropertiesExtensionProvider.java, HttpOverXmppReqProvider.java, WorkgroupProperties.java, SetBoolData.java).

Somebody else should fix them please.