### PR TITLE
Fixing Javadoc duplicate with inheritDoc

### DIFF
--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/jmf/AudioMediaSession.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/jmf/AudioMediaSession.java
@@ -119,10 +119,7 @@ public class AudioMediaSession extends JingleMediaSession {
     }
 
     /**
-     * Set transmit activity. If the active is true, the instance should transmit.
-     * If it is set to false, the instance should pause transmit.
-     *
-     * @param active active state
+     * {@inheritDoc}
      */
     @Override
     public void setTransmit(boolean active) {

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/sshare/ScreenShareSession.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/sshare/ScreenShareSession.java
@@ -150,10 +150,7 @@ public class ScreenShareSession extends JingleMediaSession {
     }
 
     /**
-     * Set transmit activity. If the active is true, the instance should transmit.
-     * If it is set to false, the instance should pause transmit.
-     *
-     * @param active active state
+     * {@inheritDoc}
      */
     @Override
     public void setTransmit(boolean active) {


### PR DESCRIPTION
I'm a PhD Student from University of Bordeaux working on documentation copy-pastes (duplicates).
I've noticed that your project does have a few documentation duplicates.
For my research work, i've tried fix this duplicate and i'd love to have your feedback about it:

- Do you think that this duplicate documentation should co-evolve forever?
- Are you aware of copy-pastes in your documentation?
- If yes, how do you handle them?
- Were you aware of JavaDoc reuse features such as {@inheritdoc}?
- Would you like to have a tool that helps you maintain duplicate documentation?