### PR TITLE
Adding public final ServiceDiscoveryManager instance to MultiUserChatManager

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -82,7 +82,7 @@ public final class MultiUserChatManager extends Manager {
     private static final String DISCO_NODE = MUCInitialPresence.NAMESPACE + "#rooms";
 
     private static final Logger LOGGER = Logger.getLogger(MultiUserChatManager.class.getName());
-    private final ServiceDiscoveryManager serviceDiscoveryManager;
+
     static {
         XMPPConnectionRegistry.addConnectionCreationListener(new ConnectionCreationListener() {
             @Override
@@ -151,6 +151,8 @@ public final class MultiUserChatManager extends Manager {
     private boolean autoJoinOnReconnect;
 
     private AutoJoinFailedCallback autoJoinFailedCallback;
+
+    private final ServiceDiscoveryManager serviceDiscoveryManager;
 
     private MultiUserChatManager(XMPPConnection connection) {
         super(connection);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -82,7 +82,7 @@ public final class MultiUserChatManager extends Manager {
     private static final String DISCO_NODE = MUCInitialPresence.NAMESPACE + "#rooms";
 
     private static final Logger LOGGER = Logger.getLogger(MultiUserChatManager.class.getName());
-
+    private final ServiceDiscoveryManager serviceDiscoveryManager;
     static {
         XMPPConnectionRegistry.addConnectionCreationListener(new ConnectionCreationListener() {
             @Override
@@ -154,6 +154,7 @@ public final class MultiUserChatManager extends Manager {
 
     private MultiUserChatManager(XMPPConnection connection) {
         super(connection);
+        serviceDiscoveryManager = ServiceDiscoveryManager.getInstanceFor(connection);
         // Listens for all messages that include a MUCUser extension and fire the invitation
         // listeners if the message includes an invitation.
         StanzaListener invitationPacketListener = new StanzaListener() {
@@ -277,7 +278,7 @@ public final class MultiUserChatManager extends Manager {
      * @throws InterruptedException
      */
     public boolean isServiceEnabled(Jid user) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        return ServiceDiscoveryManager.getInstanceFor(connection()).supportsFeature(user, MUCInitialPresence.NAMESPACE);
+        return serviceDiscoveryManager.supportsFeature(user, MUCInitialPresence.NAMESPACE);
     }
 
     /**
@@ -304,7 +305,7 @@ public final class MultiUserChatManager extends Manager {
     public List<EntityBareJid> getJoinedRooms(EntityJid user) throws NoResponseException, XMPPErrorException,
                     NotConnectedException, InterruptedException {
         // Send the disco packet to the user
-        DiscoverItems result = ServiceDiscoveryManager.getInstanceFor(connection()).discoverItems(user, DISCO_NODE);
+        DiscoverItems result = serviceDiscoveryManager.discoverItems(user, DISCO_NODE);
         List<DiscoverItems.Item> items = result.getItems();
         List<EntityBareJid> answer = new ArrayList<>(items.size());
         // Collect the entityID for each returned item
@@ -331,7 +332,7 @@ public final class MultiUserChatManager extends Manager {
      * @throws InterruptedException
      */
     public RoomInfo getRoomInfo(EntityBareJid room) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        DiscoverInfo info = ServiceDiscoveryManager.getInstanceFor(connection()).discoverInfo(room);
+        DiscoverInfo info = serviceDiscoveryManager.discoverInfo(room);
         return new RoomInfo(info);
     }
 
@@ -345,8 +346,7 @@ public final class MultiUserChatManager extends Manager {
      * @throws InterruptedException
      */
     public List<DomainBareJid> getMucServiceDomains() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        ServiceDiscoveryManager sdm = ServiceDiscoveryManager.getInstanceFor(connection());
-        return sdm.findServices(MUCInitialPresence.NAMESPACE, false, false);
+        return serviceDiscoveryManager.findServices(MUCInitialPresence.NAMESPACE, false, false);
     }
 
     /**
@@ -379,7 +379,7 @@ public final class MultiUserChatManager extends Manager {
      */
     public boolean providesMucService(DomainBareJid domainBareJid) throws NoResponseException,
                     XMPPErrorException, NotConnectedException, InterruptedException {
-        return ServiceDiscoveryManager.getInstanceFor(connection()).supportsFeature(domainBareJid,
+        return serviceDiscoveryManager.supportsFeature(domainBareJid,
                         MUCInitialPresence.NAMESPACE);
     }
 
@@ -402,8 +402,7 @@ public final class MultiUserChatManager extends Manager {
         if (!providesMucService(serviceName)) {
             throw new NotAMucServiceException(serviceName);
         }
-        ServiceDiscoveryManager discoManager = ServiceDiscoveryManager.getInstanceFor(connection());
-        DiscoverItems discoverItems = discoManager.discoverItems(serviceName);
+        DiscoverItems discoverItems = serviceDiscoveryManager.discoverItems(serviceName);
         List<DiscoverItems.Item> items = discoverItems.getItems();
 
         Map<EntityBareJid, HostedRoom> answer = new HashMap<>(items.size());


### PR DESCRIPTION
The expensive method ServiceDiscoveryManager.getInstanceFor() is replaced by a final private field