### PR TITLE
Synchronize handling of received BOSH events

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -458,7 +458,7 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
          * @param event the BOSH client response which includes the received packet.
          */
         @Override
-        public void responseReceived(BOSHMessageEvent event) {
+        public synchronized void responseReceived(BOSHMessageEvent event) {
             AbstractBody body = event.getBody();
             if (body != null) {
                 try {


### PR DESCRIPTION
Added synchronized modifier to responseReceived function in BOSHPacketReader to keep order of incoming events as required especially by SyncStanzaListeners.