### PR TITLE
Saving an instance of ServiceDiscoveryManager in MultiUserChatManager.

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -152,8 +152,11 @@ public final class MultiUserChatManager extends Manager {
 
     private AutoJoinFailedCallback autoJoinFailedCallback;
 
+    private final ServiceDiscoveryManager serviceDiscoveryManager;
+
     private MultiUserChatManager(XMPPConnection connection) {
         super(connection);
+        serviceDiscoveryManager = ServiceDiscoveryManager.getInstanceFor(connection);
         // Listens for all messages that include a MUCUser extension and fire the invitation
         // listeners if the message includes an invitation.
         StanzaListener invitationPacketListener = new StanzaListener() {
@@ -277,7 +280,7 @@ public final class MultiUserChatManager extends Manager {
      * @throws InterruptedException
      */
     public boolean isServiceEnabled(Jid user) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        return ServiceDiscoveryManager.getInstanceFor(connection()).supportsFeature(user, MUCInitialPresence.NAMESPACE);
+        return serviceDiscoveryManager.supportsFeature(user, MUCInitialPresence.NAMESPACE);
     }
 
     /**
@@ -304,7 +307,7 @@ public final class MultiUserChatManager extends Manager {
     public List<EntityBareJid> getJoinedRooms(EntityJid user) throws NoResponseException, XMPPErrorException,
                     NotConnectedException, InterruptedException {
         // Send the disco packet to the user
-        DiscoverItems result = ServiceDiscoveryManager.getInstanceFor(connection()).discoverItems(user, DISCO_NODE);
+        DiscoverItems result = serviceDiscoveryManager.discoverItems(user, DISCO_NODE);
         List<DiscoverItems.Item> items = result.getItems();
         List<EntityBareJid> answer = new ArrayList<>(items.size());
         // Collect the entityID for each returned item
@@ -331,7 +334,7 @@ public final class MultiUserChatManager extends Manager {
      * @throws InterruptedException
      */
     public RoomInfo getRoomInfo(EntityBareJid room) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        DiscoverInfo info = ServiceDiscoveryManager.getInstanceFor(connection()).discoverInfo(room);
+        DiscoverInfo info = serviceDiscoveryManager.discoverInfo(room);
         return new RoomInfo(info);
     }
 
@@ -345,8 +348,7 @@ public final class MultiUserChatManager extends Manager {
      * @throws InterruptedException
      */
     public List<DomainBareJid> getMucServiceDomains() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        ServiceDiscoveryManager sdm = ServiceDiscoveryManager.getInstanceFor(connection());
-        return sdm.findServices(MUCInitialPresence.NAMESPACE, false, false);
+        return serviceDiscoveryManager.findServices(MUCInitialPresence.NAMESPACE, false, false);
     }
 
     /**
@@ -379,7 +381,7 @@ public final class MultiUserChatManager extends Manager {
      */
     public boolean providesMucService(DomainBareJid domainBareJid) throws NoResponseException,
                     XMPPErrorException, NotConnectedException, InterruptedException {
-        return ServiceDiscoveryManager.getInstanceFor(connection()).supportsFeature(domainBareJid,
+        return serviceDiscoveryManager.supportsFeature(domainBareJid,
                         MUCInitialPresence.NAMESPACE);
     }
 
@@ -402,8 +404,7 @@ public final class MultiUserChatManager extends Manager {
         if (!providesMucService(serviceName)) {
             throw new NotAMucServiceException(serviceName);
         }
-        ServiceDiscoveryManager discoManager = ServiceDiscoveryManager.getInstanceFor(connection());
-        DiscoverItems discoverItems = discoManager.discoverItems(serviceName);
+        DiscoverItems discoverItems = serviceDiscoveryManager.discoverItems(serviceName);
         List<DiscoverItems.Item> items = discoverItems.getItems();
 
         Map<EntityBareJid, HostedRoom> answer = new HashMap<>(items.size());


### PR DESCRIPTION
Previously, the costly method 'ServiceDiscoveryManager.getInstance()' was called at multiple instances inside MultiUserChatManager.
In this commit I wish to replace this call by saving a private final instance of 'ServiceDiscoveryManager' which will is an attempt at solving SMACK-836.