### PR TITLE
Better error messages when using a Proxy to connect to the XMPP server.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/proxy/HTTPProxySocketConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/proxy/HTTPProxySocketConnection.java
@@ -58,7 +58,7 @@ class HTTPProxySocketConnection implements ProxySocketConnection {
             proxyLine = "\r\nProxy-Authorization: Basic " + Base64.encode(username + ":" + password);
         }
         socket.getOutputStream().write((hostport + " HTTP/1.1\r\nHost: "
-            + hostport + proxyLine + "\r\n\r\n").getBytes("UTF-8"));
+            + host + ":" + port + proxyLine + "\r\n\r\n").getBytes("UTF-8"));
 
         InputStream in = socket.getInputStream();
         StringBuilder got = new StringBuilder(100);
@@ -115,7 +115,8 @@ class HTTPProxySocketConnection implements ProxySocketConnection {
         int code = Integer.parseInt(m.group(1));
 
         if (code != HttpURLConnection.HTTP_OK) {
-            throw new ProxyException(ProxyInfo.ProxyType.HTTP);
+            throw new ProxyException(ProxyInfo.ProxyType.HTTP,
+                "Error code in proxy response: " + code);
         }
     }
 

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -609,6 +609,7 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
                     proxyInfo.getProxySocketConnection().connect(socket, host, port, timeout);
                 } catch (IOException e) {
                     hostAddress.setException(e);
+                    failedAddresses.add(hostAddress);
                     continue;
                 }
                 LOGGER.finer("Established TCP connection to " + hostAndPort);


### PR DESCRIPTION
When proxy connection fails, show  more error details. Before it was only a general proxy error.