### PR TITLE
Generic Exception replaced with Type Specific Exceptions.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -1251,7 +1251,7 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         try {
             stanza = PacketParserUtils.parseStanza(parser, incomingStreamXmlEnvironment);
         }
-        catch (Exception e) {
+        catch (XmlPullParserException | SmackParsingException | IOException e) {
             CharSequence content = PacketParserUtils.parseContentDepth(parser,
                             parserDepth);
             UnparseableStanza message = new UnparseableStanza(content, e);

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
@@ -55,6 +55,7 @@ import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
 import org.jxmpp.jid.Jid;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 /**
  * Utility class that helps to parse packets. Any parsing packets method that must be shared
@@ -89,7 +90,7 @@ public class PacketParserUtils {
     }
 
     @SuppressWarnings("unchecked")
-    public static <S extends Stanza> S parseStanza(String stanza) throws Exception {
+    public static <S extends Stanza> S parseStanza(String stanza) throws XmlPullParserException, SmackParsingException, IOException {
         return (S) parseStanza(getParserFor(stanza), null);
     }
 
@@ -101,9 +102,11 @@ public class PacketParserUtils {
      * @param parser
      * @param outerXmlEnvironment the outer XML environment (optional).
      * @return a stanza which is either a Message, IQ or Presence.
-     * @throws Exception
+     * @throws XmlPullParserException
+     * @throws SmackParsingException
+     * @throws IOException
      */
-    public static Stanza parseStanza(XmlPullParser parser, XmlEnvironment outerXmlEnvironment) throws Exception {
+    public static Stanza parseStanza(XmlPullParser parser, XmlEnvironment outerXmlEnvironment) throws XmlPullParserException, SmackParsingException, IOException {
         ParserUtils.assertAtStartTag(parser);
         final String name = parser.getName();
         switch (name) {
@@ -508,9 +511,12 @@ public class PacketParserUtils {
      * @param parser the XML parser, positioned at the start of an IQ packet.
      * @param outerXmlEnvironment the outer XML environment (optional).
      * @return an IQ object.
-     * @throws Exception
+     * @throws XmlPullParserException
+     * @throws XmppStringprepException
+     * @throws IOException
+     * @throws SmackParsingException
      */
-    public static IQ parseIQ(XmlPullParser parser, XmlEnvironment outerXmlEnvironment) throws Exception {
+    public static IQ parseIQ(XmlPullParser parser, XmlEnvironment outerXmlEnvironment) throws XmlPullParserException, XmppStringprepException, IOException, SmackParsingException {
         ParserUtils.assertAtStartTag(parser);
         final int initialDepth = parser.getDepth();
         XmlEnvironment iqXmlEnvironment = XmlEnvironment.from(parser, outerXmlEnvironment);


### PR DESCRIPTION
The 'AbstractXMPPConnection.parseAndProcessStanza()' throws generic Exceptions.
Since there are plenty of exceptions that should not be catched by smack, it's better to throw Type Specific Exceptions. 
This Commit is was in response to SMACK-839.
Also if found, I would want to convert more Generic Exceptions into Type Specific Exceptions.