### PR TITLE
Minor fix to integrationtest.md formatting

### DIFF
--- a/documentation/developer/integrationtest.md
+++ b/documentation/developer/integrationtest.md
@@ -80,6 +80,7 @@ debugger=console
 ### Where to place the properties file
 
 The framework will first load the properties file from `~/.config/smack-integration-test/properties`
+
 Overview of the components
 --------------------------
 


### PR DESCRIPTION
The preceding paragraph was being treated as part of the header.