### PR TITLE
Fix in documentation. StanzaTypeFilter to uppercase as in code.

### DIFF
--- a/documentation/processing.md
+++ b/documentation/processing.md
@@ -20,7 +20,7 @@ and a stanza listener:
 ```
 // Create a stanza filter to listen for new messages from a particular
 // user. We use an AndFilter to combine two other filters._
-StanzaFilter filter = new AndFilter(StanzaTypeFilter.Message, FromMatchesFilter.create("mary@jivesoftware.com"));
+StanzaFilter filter = new AndFilter(StanzaTypeFilter.MESSAGE, FromMatchesFilter.create("mary@jivesoftware.com"));
 // Assume we've created an XMPPConnection named "connection".
 
 // First, register a stanza collector using the filter we created.


### PR DESCRIPTION
That constant should be written in documentation in uppercase:
public static final StanzaTypeFilter MESSAGE = new StanzaTypeFilter(Message.class);