### PR TITLE
Fixed NPE in Roster.getPresencesInternal(BareJid)

### DIFF
--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
@@ -371,7 +371,7 @@ public final class Roster extends Manager {
      * @return the user presences
      */
     private Map<Resourcepart, Presence> getPresencesInternal(BareJid entity) {
-        Map<Resourcepart, Presence> entityPresences = presenceMap.get(entity);
+        Map<Resourcepart, Presence> entityPresences = entity == null ? null : presenceMap.get(entity);
         if (entityPresences == null) {
             entityPresences = nonRosterPresenceMap.lookup(entity);
         }


### PR DESCRIPTION
Key used in getPresencesInternal can be null.
(see final BareJid key = from != null ? from.asBareJid() : null;)
But ConcurrentHashMap does not allow null keys.
So handle null key separately.