### PR TITLE
Prevent extremely long reply timeouts from being set.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -1146,7 +1146,12 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
 
     @Override
     public void setReplyTimeout(long timeout) {
-        replyTimeout = timeout;
+    	if (Long.MAX_VALUE - System.currentTimeMillis() < timeout) {
+    		throw new IllegalArgumentException("Extremely long reply timeout");
+        }
+        else {
+        	replyTimeout = timeout;
+        }
     }
 
     private SmackConfiguration.UnknownIqRequestReplyMode unknownIqRequestReplyMode = SmackConfiguration.getUnknownIqRequestReplyMode();


### PR DESCRIPTION
Smack will throw an IllegalArguementException if extremely long reply
timeouts are tried to be set.I assumed currentTimeMillis() was the
boundary as per SMACK-718.