### PR TITLE
More specific Pubsub integration tests.

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/pubsub/PubSubIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/pubsub/PubSubIntegrationTest.java
@@ -17,9 +17,13 @@
 package org.jivesoftware.smackx.pubsub;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 
+import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
@@ -48,27 +52,57 @@ public class PubSubIntegrationTest extends AbstractSmackIntegrationTest {
         }
     }
 
+    /**
+     * Asserts that an event notification (publication without item) can be published to
+     * a node that is both 'notification-only' as well as 'transient'.
+     */
     @SmackIntegrationTest
-    public void simplePubSubNodeTest() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        final String nodename = "sinttest-simple-nodename-" + testRunId;
-        final String itemId = "sintest-simple-itemid-" + testRunId;
+    public void transientNotificationOnlyNodeWithoutItemTest() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
+        final String nodename = "sinttest-transient-notificationonly-withoutitem-nodename-" + testRunId;
         ConfigureForm defaultConfiguration = pubSubManagerOne.getDefaultConfiguration();
         ConfigureForm config = new ConfigureForm(defaultConfiguration.createAnswerForm());
-        // Configure the node as "Notification-Only Node", which in turn means that
-        // items do not need payload, to prevent payload-required error responses when
-        // publishing the item.
+        // Configure the node as "Notification-Only Node".
         config.setDeliverPayloads(false);
-        // Set persistent_items to 'false' (was previously 'true') as workaround for ejabberd issue #2799
-        // (https://github.com/processone/ejabberd/issues/2799).
+        // Configure the node as "transient" (set persistent_items to 'false')
+        config.setPersistentItems(false);
+        Node node = pubSubManagerOne.createNode(nodename, config);
+        try {
+            LeafNode leafNode = (LeafNode) node;
+            leafNode.publish();
+            List<Item> items = leafNode.getItems();
+            assertTrue(items.isEmpty());
+        }
+        finally {
+            pubSubManagerOne.deleteNode(nodename);
+        }
+    }
+
+    /**
+     * Asserts that an error is returned when a publish request to a node that is both
+     * 'notification-only' as well as 'transient' contains an item element.
+     *
+     * @see <a href="https://xmpp.org/extensions/xep-0060.html#publisher-publish-error-badrequest">
+     *     7.1.3.6 Request Does Not Match Configuration</a>
+     */
+    @SmackIntegrationTest
+    public void transientNotificationOnlyNodeWithItemTest() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
+        final String nodename = "sinttest-transient-notificationonly-withitem-nodename-" + testRunId;
+        final String itemId = "sinttest-transient-notificationonly-withitem-itemid-" + testRunId;
+        ConfigureForm defaultConfiguration = pubSubManagerOne.getDefaultConfiguration();
+        ConfigureForm config = new ConfigureForm(defaultConfiguration.createAnswerForm());
+        // Configure the node as "Notification-Only Node".
+        config.setDeliverPayloads(false);
+        // Configure the node as "transient" (set persistent_items to 'false')
         config.setPersistentItems(false);
         Node node = pubSubManagerOne.createNode(nodename, config);
         try {
             LeafNode leafNode = (LeafNode) node;
             leafNode.publish(new Item(itemId));
-            List<Item> items = leafNode.getItems();
-            assertEquals(1, items.size());
-            Item item = items.get(0);
-            assertEquals(itemId, item.getId());
+            fail("An exception should have been thrown.");
+        }
+        catch (XMPPErrorException e) {
+            assertEquals(StanzaError.Type.MODIFY, e.getStanzaError().getType());
+            assertNotNull(e.getStanzaError().getExtension("item-forbidden", "http://jabber.org/protocol/pubsub#errors"));
         }
         finally {
             pubSubManagerOne.deleteNode(nodename);


### PR DESCRIPTION
XEP-0060 prohibits publishing a request that contains an item to a node that
is both 'notification-only' and 'transient' (section 7.1.3.6)

In commit 8ed872ca639822aeff58eaaa673f953efb0ba6ee the existing pubsub publication
test was modified (to resolve a different issue) to operate on a node that's both
'notification-only' and 'transient'. This resulted in a test that should return
an error, even though the test implementation didn't expect one.

This commit explicitly verifies that publishing an item to such a node causes
an error to be returned. A new test is added that verifies that publishing an
event notification does succeed.