### PR TITLE
Admin should be disconnected after tests.

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
@@ -240,6 +240,10 @@ public class XmppConnectionManager<DC extends AbstractXMPPConnection> {
         }
 
         connections.clear();
+
+        if (accountRegistrationConnection != null) {
+            accountRegistrationConnection.disconnect();
+        }
     }
 
 


### PR DESCRIPTION
The Smack Integration tests can use an admin account to provision
accounts that are used by the tests. This admin account uses an XMPP
connection to interact with the server-under-test.

When the tests are over, this account should be disconnected
explicitly, to prevent stream management from keeping it alive longer
than it needs to.