### PR TITLE
Use the default packages if the supplied list is empty as well as null

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -174,7 +174,7 @@ public class SmackIntegrationTestFramework<DC extends AbstractXMPPConnection> {
         // TODO print effective configuration
 
         String[] testPackages;
-        if (config.testPackages == null) {
+        if (config.testPackages == null || config.testPackages.isEmpty()) {
             testPackages = new String[] { "org.jivesoftware.smackx", "org.jivesoftware.smack" };
         }
         else {


### PR DESCRIPTION
For some reason, when running under Java 11, the config.testPackages is an empty Set instead of null - so this change allows for that. 