### PR TITLE
SMACK-868: Fix XHTMLText producing invalid XML

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xhtmlim/XHTMLText.java
@@ -105,7 +105,7 @@ public class XHTMLText {
     private XHTMLText appendOpenBodyTag(String style, String lang) {
         text.halfOpenElement(Message.BODY);
         text.xmlnsAttribute(NAMESPACE);
-        text.optElement(STYLE, style);
+        text.optAttribute(STYLE, style);
         text.xmllangAttribute(lang);
         text.rightAngleBracket();
         return this;


### PR DESCRIPTION
This PR fixes SMACK-868.
`XHTMLText` was producing invalid XML as it appended an attribute as an element.
See [forum thread](https://discourse.igniterealtime.org/t/smack-4-4-0-alpha2-xhtmlim-xhtmltext-gives-not-well-format-stanza-for-body-sytle/85022) and [bug tracker entry](https://issues.igniterealtime.org/browse/SMACK-868).