### PR TITLE
Add note about BookmarkManager to MUCManager

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -282,6 +282,9 @@ public final class MultiUserChatManager extends Manager {
      * Returns a Set of the rooms where the user has joined. The Iterator will contain Strings where each String
      * represents a room (e.g. room@muc.jabber.org).
      *
+     * Note: In order to get a list of bookmarked (but not necessarily joined) conferences, use
+     * {@link org.jivesoftware.smackx.bookmarks.BookmarkManager#getBookmarkedConferences()}.
+     *
      * @return a List of the rooms where the user has joined using a given connection.
      */
     public Set<EntityBareJid> getJoinedRooms() {


### PR DESCRIPTION
Since this came up in the Forums, I thought it would be a good idea to add a note in the javadoc.

This PR adds a note about `BookmarkManager.getBookmarkedConferences()` to the Javadoc of `MultiUserChatManager.getJoinedRooms()`.