### PR TITLE
Update Consistent Color Generation to 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ extensions/bin
 
 target/
 .metadata
+
+local.properties

--- a/documentation/extensions/index.md
+++ b/documentation/extensions/index.md
@@ -103,7 +103,7 @@ Experimental Smack Extensions and currently supported XEPs of smack-experimental
 | [OpenPGP for XMPP: Instant Messaging](ox-im.md)           | [XEP-0374](https://xmpp.org/extensions/xep-0374.html)  | 0.2.0     | OpenPGP encrypted Instant Messaging. |
 | [Spoiler Messages](spoiler.md)                            | [XEP-0382](https://xmpp.org/extensions/xep-0382.html)  | 0.2.0     | Indicate that the body of a message should be treated as a spoiler. |
 | [OMEMO Multi End Message and Object Encryption](omemo.md) | [XEP-0384](https://xmpp.org/extensions/xep-0384.html)  | n/a       | Encrypt messages using OMEMO encryption (currently only with smack-omemo-signal -> GPLv3). |
-| [Consistent Color Generation](consistent_colors.md)       | [XEP-0392](https://xmpp.org/extensions/xep-0392.html)  | 0.4.0     | Generate consistent colors for identifiers like usernames to provide a consistent user experience. |
+| [Consistent Color Generation](consistent_colors.md)       | [XEP-0392](https://xmpp.org/extensions/xep-0392.html)  | 0.6.0     | Generate consistent colors for identifiers like usernames to provide a consistent user experience. |
 | [Message Markup](messagemarkup.md)                        | [XEP-0394](https://xmpp.org/extensions/xep-0394.html)  | 0.1.0     | Style message bodies while keeping body and markup information separated. |
 | DNS Queries over XMPP (DoX)                               | [XEP-0418](https://xmpp.org/extensions/xep-0418.html)  | 0.1.0     | Send DNS queries and responses over XMPP. |
 

--- a/smack-experimental/build.gradle
+++ b/smack-experimental/build.gradle
@@ -12,4 +12,5 @@ dependencies {
 	testCompile project(path: ":smack-extensions", configuration: "testRuntime")
 
 	compile "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
+	compile "org.hsluv:hsluv:0.2"
 }

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/colors/ConsistentColorsTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/colors/ConsistentColorsTest.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2018 Paul Schaub
+ * Copyright © 2018-2019 Paul Schaub
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,8 @@
 package org.jivesoftware.smackx.colors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;
-
 import org.jivesoftware.smackx.colors.ConsistentColor.Deficiency;
 
 import org.junit.jupiter.api.Test;
@@ -34,103 +32,95 @@ public class ConsistentColorsTest extends SmackTestSuite {
     private static final ConsistentColor.ConsistentColorSettings redGreenDeficiency = new ConsistentColor.ConsistentColorSettings(Deficiency.redGreenBlindness);
     private static final ConsistentColor.ConsistentColorSettings blueBlindnessDeficiency = new ConsistentColor.ConsistentColorSettings(Deficiency.blueBlindness);
 
+    private static final String romeo = "Romeo";
+    private static final String juliet = "juliet@capulet.lit";
+    private static final String emoji = "\uD83D\uDE3A";
+    private static final String council = "council";
+
     /*
-    Below tests check the test vectors from XEP-0392 §13.2.
+    Below tests check the test vectors from XEP-0392 §13.
      */
 
     @Test
     public void romeoNoDeficiencyTest() {
-        String value = "Romeo";
-        float[] expected = new float[] {0.281f, 0.790f, 1.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, noDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        float[] rgb = new float[] {0.865f, 0.000f, 0.686f};
+        assertRGBEquals(rgb, ConsistentColor.RGBFrom(romeo), EPS);
     }
 
     @Test
     public void romeoRedGreenBlindnessTest() {
-        String value = "Romeo";
-        float[] expected = new float[] {1.000f, 0.674f, 0.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, redGreenDeficiency);
+        float[] expected = new float[] {0.865f, 0.000f, 0.686f};
+        float[] actual = ConsistentColor.RGBFrom(romeo, redGreenDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void romeoBlueBlindnessTest() {
-        String value = "Romeo";
-        float[] expected = new float[] {1.000f, 0.674f, 0.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, blueBlindnessDeficiency);
+        float[] expected = new float[] {0.000f, 0.535f, 0.350f};
+        float[] actual = ConsistentColor.RGBFrom(romeo, blueBlindnessDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void julietNoDeficiencyTest() {
-        String value = "juliet@capulet.lit";
-        float[] expected = new float[] {0.337f, 1.000f, 0.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, noDeficiency);
+        float[] expected = new float[] {0.000f, 0.515f, 0.573f};
+        float[] actual = ConsistentColor.RGBFrom(juliet, noDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void julietRedGreenBlindnessTest() {
-        String value = "juliet@capulet.lit";
-        float[] expected = new float[] {1.000f, 0.359f, 1.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, redGreenDeficiency);
+        float[] expected = new float[] {0.742f, 0.359f, 0.000f};
+        float[] actual = ConsistentColor.RGBFrom(juliet, redGreenDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void julietBlueBlindnessTest() {
-        String value = "juliet@capulet.lit";
-        float[] expected = new float[] {0.337f, 1.000f, 0.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, blueBlindnessDeficiency);
+        float[] expected = new float[] {0.742f, 0.359f, 0.000f};
+        float[] actual = ConsistentColor.RGBFrom(juliet, blueBlindnessDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void emojiNoDeficiencyTest() {
-        String value = "\uD83D\uDE3A";
-        float[] expected = new float[] {0.347f, 0.756f, 1.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, noDeficiency);
+        float[] expected = new float[] {0.872f, 0.000f, 0.659f};
+        float[] actual = ConsistentColor.RGBFrom(emoji, noDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void emojiRedGreenBlindnessTest() {
-        String value = "\uD83D\uDE3A";
-        float[] expected = new float[] {1.000f, 0.708f, 0.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, redGreenDeficiency);
+        float[] expected = new float[] {0.872f, 0.000f, 0.659f};
+        float[] actual = ConsistentColor.RGBFrom(emoji, redGreenDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void emojiBlueBlindnessTest() {
-        String value = "\uD83D\uDE3A";
-        float[] expected = new float[] {1.000f, 0.708f, 0.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, blueBlindnessDeficiency);
+        float[] expected = new float[] {0.000f, 0.533f, 0.373f};
+        float[] actual = ConsistentColor.RGBFrom(emoji, blueBlindnessDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void councilNoDeficiencyTest() {
-        String value = "council";
-        float[] expected = new float[] {0.732f, 0.560f, 1.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, noDeficiency);
+        float[] expected = new float[] {0.918f, 0.000f, 0.394f};
+        float[] actual = ConsistentColor.RGBFrom(council, noDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void councilRedGreenBlindnessTest() {
-        String value = "council";
-        float[] expected = new float[] {0.732f, 0.904f, 0.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, redGreenDeficiency);
+        float[] expected = new float[] {0.918f, 0.000f, 0.394f};
+        float[] actual = ConsistentColor.RGBFrom(council, redGreenDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
     @Test
     public void councilBlueBlindnessTest() {
-        String value = "council";
-        float[] expected = new float[] {0.732f, 0.904f, 0.000f};
-        float[] actual = ConsistentColor.RGBFrom(value, blueBlindnessDeficiency);
+        float[] expected = new float[] {0.000f, 0.524f, 0.485f};
+        float[] actual = ConsistentColor.RGBFrom(council, blueBlindnessDeficiency);
         assertRGBEquals(expected, actual, EPS);
     }
 
@@ -146,7 +136,7 @@ public class ConsistentColorsTest extends SmackTestSuite {
         assertEquals(3, actual.length);
 
         for (int i = 0; i < actual.length; i++) {
-            assertTrue(Math.abs(expected[i] - actual[i]) < eps);
+            assertEquals(expected[i], actual[i], eps);
         }
     }
 }


### PR DESCRIPTION
This PR updates the implementation of XEP-0392: Consistent Color Generation to version 0.6.0.
Changes include switch from CbCr color space to HSLuv.
smack-experimental now depends on the `hsluv.org:hsluv' java library for color space conversion.
