### PR TITLE
Return obtained XmlStringBuilder instead of null

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/mediaelement/element/MediaElement.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/mediaelement/element/MediaElement.java
@@ -90,7 +90,7 @@ public class MediaElement implements FormFieldChildElement {
         xml.append(uris, xmlEnvironment);
 
         xml.closeElement(this);
-        return null;
+        return xml;
     }
 
     public MediaElement from(FormField formField) {


### PR DESCRIPTION
Previously, `MediaElement.toXml()` returned `null` value.
Through this PR, it will return obtained `XmlStringBuilder`.