### PR TITLE
Remove namespace from Uri's XmlStringBuilder

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/mediaelement/element/MediaElement.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/mediaelement/element/MediaElement.java
@@ -168,7 +168,7 @@ public class MediaElement implements FormFieldChildElement {
 
         @Override
         public XmlStringBuilder toXML(XmlEnvironment xmlEnvironment) {
-            XmlStringBuilder xml = new XmlStringBuilder(this, xmlEnvironment);
+            XmlStringBuilder xml = new XmlStringBuilder(this);
             xml.attribute("type", type)
                .rightAngleBracket();
             xml.escape(uri.toString());


### PR DESCRIPTION
The intended XML is 
` <uri type='image/jpeg'>
        http://www.shakespeare.lit/clients/exodus.jpg
 </uri> `
in place of
`<uri xmlns='urn:xmpp:media-element' type='image/jpeg'>
	http://www.shakespeare.lit/clients/exodus.jpg
</uri>`.
So remove `xmlEnvironment` as a parameter from XmlStringBuilder Constructor.

