### PR TITLE
Improvements to the MUC join code

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -329,7 +329,7 @@ public class MultiUserChat {
                     XMPPErrorException, InterruptedException, NotAMucServiceException {
         final DomainBareJid mucService = room.asDomainBareJid();
         if (!KNOWN_MUC_SERVICES.containsKey(mucService)) {
-            if (multiUserChatManager.providesMucService(mucService)) {
+            if (multiUserChatManager.providesMucService(mucService) || multiUserChatManager.providesMucService(room)) {
                 KNOWN_MUC_SERVICES.put(mucService, null);
             } else {
                 throw new NotAMucServiceException(this);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -57,6 +57,7 @@ import org.jivesoftware.smackx.muc.MultiUserChatException.NotAMucServiceExceptio
 import org.jivesoftware.smackx.muc.packet.MUCInitialPresence;
 import org.jivesoftware.smackx.muc.packet.MUCUser;
 
+import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
@@ -386,7 +387,7 @@ public final class MultiUserChatManager extends Manager {
      * @see <a href="http://xmpp.org/extensions/xep-0045.html#disco-service-features">XEP-45 § 6.2 Discovering the Features Supported by a MUC Service</a>
      * @since 4.2
      */
-    public boolean providesMucService(DomainBareJid domainBareJid) throws NoResponseException,
+    public boolean providesMucService(BareJid domainBareJid) throws NoResponseException,
                     XMPPErrorException, NotConnectedException, InterruptedException {
         return serviceDiscoveryManager.supportsFeature(domainBareJid,
                         MUCInitialPresence.NAMESPACE);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/RoomInfo.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/RoomInfo.java
@@ -132,7 +132,7 @@ public class RoomInfo {
      */
     private final Form form;
 
-    RoomInfo(DiscoverInfo info) {
+    public RoomInfo(DiscoverInfo info) {
         final Jid from = info.getFrom();
         if (from != null) {
             this.room = info.getFrom().asEntityBareJidIfPossible();


### PR DESCRIPTION
This code addresses some corner cases when joining certain MUCs, like dino@chat.im, and provides `MUC.getRoomInfo()` to access the room information from the disco#info that is queried before join.