### PR TITLE
Locale: return a random body/subject if none matched language=null

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Message.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Message.java
@@ -201,6 +201,8 @@ public final class Message extends Stanza implements TypedCloneable<Message> {
                 return subject;
             }
         }
+        if (language == null && !subjects.isEmpty())
+            return subjects.iterator().next();
         return null;
     }
 
@@ -320,6 +322,8 @@ public final class Message extends Stanza implements TypedCloneable<Message> {
                 return body;
             }
         }
+        if (language == null && !getBodies().isEmpty())
+            return getBodies().iterator().next();
         return null;
     }
 


### PR DESCRIPTION
This is related to the time-out-closed thread on body language [0].

If no language is requested (language parameter is null), then return a
random subject / body from the respective Set. This is better than not
returning any body because of unexpected conditions.

However, this is just a workaround. The whole language code inside of
Message needs to be rewritten to properly do language tag matching
between the user's locale (which is not accessible from the Message
class), the stream language (same), and what's actually available in the
message.

Signed-off-by: Georg Lukas <georg@op-co.de>

[0] https://discourse.igniterealtime.org/t/message-getbody-returns-null-if-all-bodies-have-an-xml-lang/83923/7