### PR TITLE
OMEMO: converse.js compatibility

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/StringUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/StringUtils.java
@@ -222,6 +222,10 @@ public class StringUtils {
         return out;
     }
 
+    public static String removeNewLines(String s) {
+        return s.trim().replaceAll("\n", "");
+    }
+
     /**
      * Hashes a String using the SHA-1 algorithm and returns the result as a
      * String of hexadecimal numbers. This method is synchronized to avoid

--- a/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/element/OmemoBundleElement.java
+++ b/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/element/OmemoBundleElement.java
@@ -60,8 +60,8 @@ public abstract class OmemoBundleElement implements ExtensionElement {
      * @param preKeysB64 HashMap of base64 encoded preKeys
      */
     public OmemoBundleElement(int signedPreKeyId, String signedPreKeyB64, String signedPreKeySigB64, String identityKeyB64, HashMap<Integer, String> preKeysB64) {
-        if (signedPreKeyId <= 0) {
-            throw new IllegalArgumentException("signedPreKeyId MUST be greater than 0.");
+        if (signedPreKeyId < 0) {
+            throw new IllegalArgumentException("signedPreKeyId MUST be greater than or equal to 0.");
         }
         this.signedPreKeyId = signedPreKeyId;
         this.signedPreKeyB64 = StringUtils.requireNotNullNorEmpty(signedPreKeyB64, "signedPreKeyB64 MUST NOT be null nor empty.");

--- a/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/provider/OmemoBundleVAxolotlProvider.java
+++ b/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/provider/OmemoBundleVAxolotlProvider.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -59,39 +60,39 @@ public class OmemoBundleVAxolotlProvider extends ExtensionElementProvider<OmemoB
                 case START_ELEMENT:
                     final int attributeCount = parser.getAttributeCount();
                     // <signedPreKeyPublic>
-                    if (name.equals(SIGNED_PRE_KEY_PUB)) {
+                    if (SIGNED_PRE_KEY_PUB.equals(name)) {
                         for (int i = 0; i < attributeCount; i++) {
-                            if (parser.getAttributeName(i).equals(SIGNED_PRE_KEY_ID)) {
+                            if (SIGNED_PRE_KEY_ID.equals(parser.getAttributeName(i))) {
                                 int id = Integer.parseInt(parser.getAttributeValue(i));
-                                signedPreKey = parser.nextText();
+                                signedPreKey = StringUtils.removeNewLines(parser.nextText());
                                 signedPreKeyId = id;
                             }
                         }
                     }
                     // <bundleGetSignedPreKeySignature>
-                    else if (name.equals(SIGNED_PRE_KEY_SIG)) {
-                        signedPreKeySignature = parser.nextText();
+                    else if (SIGNED_PRE_KEY_SIG.equals(name)) {
+                        signedPreKeySignature = StringUtils.removeNewLines(parser.nextText());
                     }
                     // <deserializeIdentityKey>
-                    else if (name.equals(IDENTITY_KEY)) {
-                        identityKey = parser.nextText();
+                    else if (IDENTITY_KEY.equals(name)) {
+                        identityKey = StringUtils.removeNewLines(parser.nextText());
                     }
                     // <deserializeECPublicKeys>
-                    else if (name.equals(PRE_KEYS)) {
+                    else if (PRE_KEYS.equals(name)) {
                         inPreKeys = true;
                     }
                     // <preKeyPublic preKeyId='424242'>
-                    else if (inPreKeys && name.equals(PRE_KEY_PUB)) {
+                    else if (inPreKeys && PRE_KEY_PUB.equals(name)) {
                         for (int i = 0; i < attributeCount; i++) {
-                            if (parser.getAttributeName(i).equals(PRE_KEY_ID)) {
+                            if (PRE_KEY_ID.equals(parser.getAttributeName(i))) {
                                 preKeys.put(Integer.parseInt(parser.getAttributeValue(i)),
-                                        parser.nextText());
+                                        StringUtils.removeNewLines(parser.nextText()));
                             }
                         }
                     }
                     break;
                 case END_ELEMENT:
-                    if (name.equals(BUNDLE)) {
+                    if (BUNDLE.equals(name)) {
                         stop = true;
                     }
                     break;


### PR DESCRIPTION
Fix some compatibility issues with converse.js and prevent NPE in provider class.

Converse was introducing linebreaks in the contents of the OMEMO bundle element, which would break base64 decoding.