### PR TITLE
OMEMO: Allow prekey ID 0

### DIFF
--- a/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/element/OmemoBundleElement.java
+++ b/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/element/OmemoBundleElement.java
@@ -60,8 +60,8 @@ public abstract class OmemoBundleElement implements ExtensionElement {
      * @param preKeysB64 HashMap of base64 encoded preKeys
      */
     public OmemoBundleElement(int signedPreKeyId, String signedPreKeyB64, String signedPreKeySigB64, String identityKeyB64, HashMap<Integer, String> preKeysB64) {
-        if (signedPreKeyId <= 0) {
-            throw new IllegalArgumentException("signedPreKeyId MUST be greater than 0.");
+        if (signedPreKeyId < 0) {
+            throw new IllegalArgumentException("signedPreKeyId MUST be greater than or equal to 0.");
         }
         this.signedPreKeyId = signedPreKeyId;
         this.signedPreKeyB64 = StringUtils.requireNotNullNorEmpty(signedPreKeyB64, "signedPreKeyB64 MUST NOT be null nor empty.");


### PR DESCRIPTION
Fixes compatibility issues with conversejs.

Related [forum thread](https://discourse.igniterealtime.org/t/smack-4-4-0-omemo-throws-an-illegalargumentexception-when-an-omemo-device-published-prekeys-bundle-with-index-0/85975)