### PR TITLE
Remove trailing semicolon in the header used in HttpFileUploadManager

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadManager.java
@@ -399,7 +399,7 @@ public final class HttpFileUploadManager extends Manager {
         urlConnection.setUseCaches(false);
         urlConnection.setDoOutput(true);
         urlConnection.setFixedLengthStreamingMode(fileSize);
-        urlConnection.setRequestProperty("Content-Type", "application/octet-stream;");
+        urlConnection.setRequestProperty("Content-Type", "application/octet-stream");
         for (Entry<String, String> header : slot.getHeaders().entrySet()) {
             urlConnection.setRequestProperty(header.getKey(), header.getValue());
         }


### PR DESCRIPTION
`HttpFileUploadManager` uses different content type for slot request and for the actual request to the upload URL. Extra semicolon results in signature error when min.io is used for the storage and quite probably doesn't work for Amazon S3 as well.

This PR fixes it.
