### PR TITLE
Fix namespace contextualization in `MediaElement`

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/mediaelement/element/MediaElement.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/mediaelement/element/MediaElement.java
@@ -87,6 +87,12 @@ public class MediaElement implements FormFieldChildElement {
             .optAttribute("width", width)
             .rightAngleBracket();
 
+        if (!NAMESPACE.contentEquals(xmlEnvironment.getNamespace())) {
+            xmlEnvironment = XmlEnvironment.builder()
+                    .withNamespace(MediaElement.NAMESPACE)
+                    .withNext(null)
+                    .build();
+        }
         xml.append(uris, xmlEnvironment);
 
         xml.closeElement(this);


### PR DESCRIPTION

This commit addresses #328 in respose to [review](https://github.com/igniterealtime/Smack/pull/328#issuecomment-523897472).

The intended XML is
`<uri type='image/jpeg'> http://www.shakespeare.lit/clients/exodus.jpg </uri>`
in place of
`<uri xmlns='urn:xmpp:media-element' type='image/jpeg'> http://www.shakespeare.lit/clients/exodus.jpg </uri>.`