### PR TITLE
XEP-0359: Fix filtering of messages applicable to SIDs.

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/sid/StableUniqueStanzaIdManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/sid/StableUniqueStanzaIdManager.java
@@ -36,6 +36,15 @@ import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 import org.jivesoftware.smackx.sid.element.OriginIdElement;
 
+/**
+ * Manager class for Stable and Unique Stanza IDs.
+ *
+ * In order to start automatically appending origin ids to outgoing messages, use {@link #enable()}.
+ * This will announce support via the {@link ServiceDiscoveryManager}. If you want to stop appending origin-ids
+ * and de-announce support, call {@link #disable()}.
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0359.html">XEP-0359: Stable and Unique Stanza IDs</a>
+ */
 public final class StableUniqueStanzaIdManager extends Manager {
 
     public static final String NAMESPACE = "urn:xmpp:sid:0";
@@ -70,7 +79,7 @@ public final class StableUniqueStanzaIdManager extends Manager {
 
     /**
      * Private constructor.
-     * @param connection TODO javadoc me please
+     * @param connection XMPP connection
      */
     private StableUniqueStanzaIdManager(XMPPConnection connection) {
         super(connection);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/sid/StableUniqueStanzaIdManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/sid/StableUniqueStanzaIdManager.java
@@ -27,6 +27,7 @@ import org.jivesoftware.smack.XMPPConnectionRegistry;
 import org.jivesoftware.smack.filter.AndFilter;
 import org.jivesoftware.smack.filter.MessageTypeFilter;
 import org.jivesoftware.smack.filter.NotFilter;
+import org.jivesoftware.smack.filter.StanzaExtensionFilter;
 import org.jivesoftware.smack.filter.StanzaFilter;
 import org.jivesoftware.smack.filter.ToTypeFilter;
 import org.jivesoftware.smack.packet.Message;
@@ -45,6 +46,9 @@ public final class StableUniqueStanzaIdManager extends Manager {
     private static final StanzaFilter OUTGOING_FILTER = new AndFilter(
             MessageTypeFilter.NORMAL_OR_CHAT_OR_HEADLINE,
             ToTypeFilter.ENTITY_FULL_OR_BARE_JID);
+
+    // Filter that filters for messages with an origin id
+    private static final StanzaFilter ORIGIN_ID_FILTER = new StanzaExtensionFilter(OriginIdElement.ELEMENT, NAMESPACE);
 
     // Listener for outgoing stanzas that adds origin-ids to outgoing stanzas.
     private static final StanzaListener ADD_ORIGIN_ID_INTERCEPTOR = new StanzaListener() {
@@ -93,7 +97,8 @@ public final class StableUniqueStanzaIdManager extends Manager {
      */
     public synchronized void enable() {
         ServiceDiscoveryManager.getInstanceFor(connection()).addFeature(NAMESPACE);
-        StanzaFilter filter = new AndFilter(OUTGOING_FILTER, new NotFilter(OUTGOING_FILTER));
+        // We need a filter for outgoing messages that do not carry an origin-id already
+        StanzaFilter filter = new AndFilter(OUTGOING_FILTER, new NotFilter(ORIGIN_ID_FILTER));
         connection().addStanzaInterceptor(ADD_ORIGIN_ID_INTERCEPTOR, filter);
     }
 


### PR DESCRIPTION
I noticed, that despite calling `sidManager.enable()`, the `StableAndUniqueStanzaIdManager` did not append any `<origin-id/>` elements to outgoing messages.

This patch fixes the filter logic, which was borked to begin with. The filter basically checked `A and not A` which never becomes true. I wonder how this happened :thinking: 