### PR TITLE
Don't compile android.jar contents into smack-android jar

### DIFF
--- a/smack-android/build.gradle
+++ b/smack-android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
 	}
 
 	// Add the Android jar to the Eclipse .classpath.
-	compile files(androidBootClasspath)
+	compileOnly files(androidBootClasspath)
 }


### PR DESCRIPTION
gradles `compile` command (which is deprecated and should be replaced with `implementation`) includes the arguments resources into the result jar.
That means that smack-android will contain resources found at the android boot classpath.

This results in a +~11mb increase in size of the resulting apk when including Smack as a composite build. The increase comes from 11mb of Android resources, mainly drawables.

`compileOnly` (formerly `provided`) on the other hand will assert that the android.jar classes are provided by the system, which is probably what we want in this case.