### PR TITLE
IntegrationTest: allow configuration of hostname and ports for involved connections

### DIFF
--- a/documentation/developer/integrationtest.md
+++ b/documentation/developer/integrationtest.md
@@ -58,24 +58,34 @@ debugger=console
 
 ### Framework properties
 
-| Name                 |                                           |
-|----------------------|-------------------------------------------|
-| service              | XMPP service to run the tests on          |
+| Name                 |                                             |
+|----------------------|---------------------------------------------|
+| service              | XMPP service to run the tests on            |
 | serviceTlsPin        | TLS Pin (used by [java-pinning](https://github.com/Flowdalic/java-pinning))            |
-| securityMode         | Either 'required' or 'disabled'           |
-| replyTimeout         | In milliseconds                           |
-| adminAccountUsername | Username of the XEP-0133 Admin account    |
-| adminAccountPassword | Password of the XEP-0133 Admin account    |
-| accountOneUsername   | Username of the first XMPP account        |
-| accountOnePassword   | Password of the first XMPP account        |
-| accountTwoUsername   | Username of the second XMPP account       |
-| accountTwoPassword   | Password of the second XMPP account       |
-| accountThreeUsername | Username of the third XMPP account        |
-| accountThreePassword | Password of the third XMPP account        |
+| securityMode         | Either 'required' or 'disabled'             |
+| replyTimeout         | In milliseconds                             |
+| adminAccountUsername | Username of the XEP-0133 Admin account      |
+| adminAccountPassword | Password of the XEP-0133 Admin account      |
+| adminAccountHostname | Hostname to use for the Admin account       |
+| adminAccountPort     | Port to use with the Admin account          |
+| accountOneUsername   | Username of the first XMPP account          |
+| accountOnePassword   | Password of the first XMPP account          |
+| accountOneHostname   | Hostname to use for the first XMPP account  |
+| accountOnePort       | Port to use for the first XMPP account      |
+| accountTwoUsername   | Username of the second XMPP account         |
+| accountTwoPassword   | Password of the second XMPP account         |
+| accountTwoHostname   | Hostname to use for the second XMPP account |
+| accountTwoPort       | Port to use for the second XMPP account     |
+| accountThreeUsername | Username of the third XMPP account          |
+| accountThreePassword | Password of the third XMPP account          |
+| accountThreeHostname | Hostname to use for the third XMPP account  |
+| accountThreePort     | Port to use for the third XMPP account      |
 | debugger             | 'console' for console debugger, 'enhanced' for the enhanced debugger  |
-| enabledTests         | List of enabled tests                     |
-| disabledTests        | List of disabled tests                    |
-| testPackages         | List of packages with tests               |
+| enabledTests         | List of enabled tests                       |
+| disabledTests        | List of disabled tests                      |
+| testPackages         | List of packages with tests                 |
+
+The hostname and port properties may come in handy when testing on clustered systems.
 
 ### Where to place the properties file
 

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.net.ssl.SSLContext;
@@ -545,6 +546,12 @@ public final class Configuration {
 
     private static int getIntProperty(Properties properties, String propertyName, int defaultValue) {
         String s = properties.getProperty(propertyName, Integer.toString(defaultValue));
-        return Integer.parseInt(s);
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            LOGGER.log(Level.WARNING, "Could not parse value of property " + propertyName +
+                    ". Using default value " + defaultValue + " instead.");
+            return defaultValue;
+        }
     }
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -76,17 +76,33 @@ public final class Configuration {
 
     public final String adminAccountPassword;
 
+    public final String adminAccountHostname;
+
+    public final int adminAccountPort;
+
     public final String accountOneUsername;
 
     public final String accountOnePassword;
+
+    public final String accountOneHostname;
+
+    public final int accountOnePort;
 
     public final String accountTwoUsername;
 
     public final String accountTwoPassword;
 
+    public final String accountTwoHostname;
+
+    public final int accountTwoPort;
+
     public final String accountThreeUsername;
 
     public final String accountThreePassword;
+
+    public final String accountThreeHostname;
+
+    public final int accountThreePort;
 
     public final Debugger debugger;
 
@@ -98,10 +114,13 @@ public final class Configuration {
 
     public final ConnectionConfigurationBuilderApplier configurationApplier;
 
-    private Configuration(DomainBareJid service, String serviceTlsPin, SecurityMode securityMode, int replyTimeout,
-                    Debugger debugger, String accountOneUsername, String accountOnePassword, String accountTwoUsername,
-                    String accountTwoPassword, String accountThreeUsername, String accountThreePassword, Set<String> enabledTests, Set<String> disabledTests,
-                    Set<String> testPackages, String adminAccountUsername, String adminAccountPassword)
+    private Configuration(DomainBareJid service, String serviceTlsPin, SecurityMode securityMode,
+                          int replyTimeout, Debugger debugger,
+                          String accountOneUsername, String accountOnePassword, String accountOneHostname, int accountOnePort,
+                          String accountTwoUsername, String accountTwoPassword, String accountTwoHostname, int accountTwoPort,
+                          String accountThreeUsername, String accountThreePassword, String accountThreeHostname, int accountThreePort,
+                          Set<String> enabledTests, Set<String> disabledTests, Set<String> testPackages,
+                          String adminAccountUsername, String adminAccountPassword, String adminAccountHostname, int adminAccountPort)
                     throws KeyManagementException, NoSuchAlgorithmException {
         this.service = Objects.requireNonNull(service,
                         "'service' must be set. Either via 'properties' files or via system property 'sinttest.service'.");
@@ -131,6 +150,8 @@ public final class Configuration {
 
         this.adminAccountUsername = adminAccountUsername;
         this.adminAccountPassword = adminAccountPassword;
+        this.adminAccountHostname = adminAccountHostname;
+        this.adminAccountPort = adminAccountPort;
 
         boolean accountOnePasswordSet = StringUtils.isNotEmpty(accountOnePassword);
         if (accountOnePasswordSet != StringUtils.isNotEmpty(accountTwoPassword) ||
@@ -141,10 +162,19 @@ public final class Configuration {
 
         this.accountOneUsername = accountOneUsername;
         this.accountOnePassword = accountOnePassword;
+        this.accountOneHostname = accountOneHostname;
+        this.accountOnePort = accountOnePort;
+
         this.accountTwoUsername = accountTwoUsername;
         this.accountTwoPassword = accountTwoPassword;
+        this.accountTwoHostname = accountTwoHostname;
+        this.accountTwoPort = accountTwoPort;
+
         this.accountThreeUsername = accountThreeUsername;
         this.accountThreePassword = accountThreePassword;
+        this.accountThreeHostname = accountThreeHostname;
+        this.accountThreePort = accountThreePort;
+
         this.enabledTests = enabledTests;
         this.disabledTests = disabledTests;
         this.testPackages = testPackages;
@@ -192,17 +222,33 @@ public final class Configuration {
 
         private String adminAccountPassword;
 
+        private String adminAccountHostname;
+
+        private int adminAccountPort;
+
         private String accountOneUsername;
 
         private String accountOnePassword;
+
+        private String accountOneHostname;
+
+        private int accountOnePort;
 
         private String accountTwoUsername;
 
         private String accountTwoPassword;
 
-        public String accountThreeUsername;
+        private String accountTwoHostname;
 
-        public String accountThreePassword;
+        private int accountTwoPort;
+
+        private String accountThreeUsername;
+
+        private String accountThreePassword;
+
+        private String accountThreeHostname;
+
+        private int accountThreePort;
 
         private Debugger debugger = Debugger.none;
 
@@ -256,6 +302,12 @@ public final class Configuration {
             return this;
         }
 
+        public Builder setAdminHostnameAndPort(String adminAccountHostname, int adminAccountPort) {
+            this.adminAccountHostname = adminAccountHostname;
+            this.adminAccountPort = adminAccountPort;
+            return this;
+        }
+
         public Builder setUsernamesAndPassword(String accountOneUsername, String accountOnePassword,
                         String accountTwoUsername, String accountTwoPassword, String accountThreeUsername, String accountThreePassword) {
             this.accountOneUsername = StringUtils.requireNotNullNorEmpty(accountOneUsername, "accountOneUsername must not be null nor empty");
@@ -264,6 +316,18 @@ public final class Configuration {
             this.accountTwoPassword = StringUtils.requireNotNullNorEmpty(accountTwoPassword, "accountTwoPasswordmust not be null nor empty");
             this.accountThreeUsername = StringUtils.requireNotNullNorEmpty(accountThreeUsername, "accountThreeUsername must not be null nor empty");
             this.accountThreePassword = StringUtils.requireNotNullNorEmpty(accountThreePassword, "accountThreePassword must not be null nor empty");
+            return this;
+        }
+
+        public Builder setUserHostnamesAndPorts(String accountOneHostname, int accountOnePort,
+                                                String accountTwoHostname, int accountTwoPort,
+                                                String accountThreeHostname, int accountThreePort) {
+            this.accountOneHostname = accountOneHostname;
+            this.accountOnePort = accountOnePort;
+            this.accountTwoHostname = accountTwoHostname;
+            this.accountTwoPort = accountTwoPort;
+            this.accountThreeHostname = accountThreeHostname;
+            this.accountThreePort = accountThreePort;
             return this;
         }
 
@@ -351,9 +415,12 @@ public final class Configuration {
         }
 
         public Configuration build() throws KeyManagementException, NoSuchAlgorithmException {
-            return new Configuration(service, serviceTlsPin, securityMode, replyTimeout, debugger, accountOneUsername,
-                            accountOnePassword, accountTwoUsername, accountTwoPassword, accountThreeUsername, accountThreePassword, enabledTests, disabledTests,
-                            testPackages, adminAccountUsername, adminAccountPassword);
+            return new Configuration(service, serviceTlsPin, securityMode, replyTimeout, debugger,
+                    accountOneUsername, accountOnePassword, accountOneHostname, accountOnePort,
+                    accountTwoUsername, accountTwoPassword, accountTwoHostname, accountTwoPort,
+                    accountThreeUsername, accountThreePassword, accountThreeHostname, accountThreePort,
+                    enabledTests, disabledTests, testPackages,
+                    adminAccountUsername, adminAccountPassword, adminAccountHostname, adminAccountPort);
         }
     }
 
@@ -394,6 +461,12 @@ public final class Configuration {
             builder.setAdminAccountUsernameAndPassword(adminAccountUsername, adminAccountPassword);
         }
 
+        String adminAccountHostname = properties.getProperty("adminAccountHostname");
+        int adminAccountPort = getIntProperty(properties, "adminAccountPort", 0);
+        if (StringUtils.isNotEmpty(adminAccountHostname)) {
+            builder.setAdminHostnameAndPort(adminAccountHostname, adminAccountPort);
+        }
+
         String accountOneUsername = properties.getProperty("accountOneUsername");
         String accountOnePassword = properties.getProperty("accountOnePassword");
         String accountTwoUsername = properties.getProperty("accountTwoUsername");
@@ -404,6 +477,19 @@ public final class Configuration {
                         || accountTwoPassword != null || accountThreeUsername != null || accountThreePassword != null) {
             builder.setUsernamesAndPassword(accountOneUsername, accountOnePassword, accountTwoUsername,
                             accountTwoPassword, accountThreeUsername, accountThreePassword);
+        }
+
+        String accountOneHostname = properties.getProperty("accountOneHostname");
+        int accountOnePort = getIntProperty(properties, "accountOnePort", 0);
+        String accountTwoHostname = properties.getProperty("accountTwoHostname");
+        int accountTwoPort = getIntProperty(properties, "accountTwoPort", 0);
+        String accountThreeHostname = properties.getProperty("accountThreeHostname");
+        int accountThreePort = getIntProperty(properties, "accountThreePort", 0);
+        if (accountOneHostname != null || accountTwoHostname != null || accountThreeHostname != null) {
+            builder.setUserHostnamesAndPorts(
+                    accountOneHostname, accountOnePort,
+                    accountTwoHostname, accountTwoPort,
+                    accountThreeHostname, accountThreePort);
         }
 
         String debugString = properties.getProperty("debug");
@@ -455,5 +541,10 @@ public final class Configuration {
             string = "org.jivesoftware." + string;
         }
         return string;
+    }
+
+    private static int getIntProperty(Properties properties, String propertyName, int defaultValue) {
+        String s = properties.getProperty(propertyName, Integer.toString(defaultValue));
+        return Integer.parseInt(s);
     }
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
@@ -336,11 +336,11 @@ public class XmppConnectionManager<DC extends AbstractXMPPConnection> {
             break;
         case inBandRegistration:
             if (!accountManager.supportsAccountCreation()) {
-                throw new UnsupportedOperationException("Account creation/registation is not supported");
+                throw new UnsupportedOperationException("Account creation/registration is not supported");
             }
             Set<String> requiredAttributes = accountManager.getAccountAttributes();
             if (requiredAttributes.size() > 4) {
-                throw new IllegalStateException("Unkown required attributes");
+                throw new IllegalStateException("Unknown required attributes");
             }
             Map<String, String> additionalAttributes = new HashMap<>();
             additionalAttributes.put("name", "Smack Integration Test");

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
@@ -133,7 +133,15 @@ public class XmppConnectionManager<DC extends AbstractXMPPConnection> {
         switch (sinttestConfiguration.accountRegistration) {
         case serviceAdministration:
         case inBandRegistration:
-            accountRegistrationConnection = defaultConnectionDescriptor.construct(sinttestConfiguration);
+            accountRegistrationConnection = defaultConnectionDescriptor.construct(sinttestConfiguration,
+                    builder -> {
+                        if (sinttestConfiguration.adminAccountHostname != null) {
+                            builder.setHost(sinttestConfiguration.adminAccountHostname);
+                        }
+                        if (sinttestConfiguration.adminAccountPort != 0) {
+                            builder.setPort(sinttestConfiguration.adminAccountPort);
+                        }
+                    });
             accountRegistrationConnection.connect();
             accountRegistrationConnection.login(sinttestConfiguration.adminAccountUsername,
                             sinttestConfiguration.adminAccountPassword);
@@ -255,20 +263,28 @@ public class XmppConnectionManager<DC extends AbstractXMPPConnection> {
         String middlefix;
         String accountUsername;
         String accountPassword;
+        String accountHostname;
+        int accountPort;
         switch (accountNum) {
         case One:
             accountUsername = sinttestConfiguration.accountOneUsername;
             accountPassword = sinttestConfiguration.accountOnePassword;
+            accountHostname = sinttestConfiguration.accountOneHostname;
+            accountPort = sinttestConfiguration.accountOnePort;
             middlefix = "one";
             break;
         case Two:
             accountUsername = sinttestConfiguration.accountTwoUsername;
             accountPassword = sinttestConfiguration.accountTwoPassword;
+            accountHostname = sinttestConfiguration.accountTwoHostname;
+            accountPort = sinttestConfiguration.accountTwoPort;
             middlefix = "two";
             break;
         case Three:
             accountUsername = sinttestConfiguration.accountThreeUsername;
             accountPassword = sinttestConfiguration.accountThreePassword;
+            accountHostname = sinttestConfiguration.accountThreeHostname;
+            accountPort = sinttestConfiguration.accountThreePort;
             middlefix = "three";
             break;
         default:
@@ -284,6 +300,12 @@ public class XmppConnectionManager<DC extends AbstractXMPPConnection> {
         }
 
         DC mainConnection = defaultConnectionDescriptor.construct(sinttestConfiguration, builder -> {
+            if (accountHostname != null) {
+                builder.setHost(accountHostname);
+            }
+            if (accountPort != 0) {
+                builder.setPort(accountPort);
+            }
             try {
                 builder.setUsernameAndPassword(finalAccountUsername, finalAccountPassword)
                     .setResource(middlefix + '-' + testRunId);


### PR DESCRIPTION
This PR adds additional properties for the IntegrationTest that allow specifying hostname and ports of involved test accounts.

The added properties are:

* `adminAccountHostname`: host name for the admin account
* `adminAccountPort`: port for the admin account
* `account{One,Two,Three}Hostname`: host to use for the n-th test account
* `account{One,Two,Three}Port`: port to use for the n-th test account

These options are only briefly tested (basically I made sure that connecting did *not* work when using invalid values) and I expect @guusdk to do the testing for me and to provide the pay check :P