### PR TITLE
Getgitcommit fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -650,13 +650,16 @@ def getGitCommit() {
 	def dotGit = new File("$projectDir/.git")
 	if (!dotGit.isDirectory()) return 'non-git build'
 
+	def projectDir = dotGit.getParentFile()
 	def cmd = 'git describe --always --tags --dirty=+'
-	def proc = cmd.execute()
+	def proc = cmd.execute(null, projectDir)
+	proc.waitForOrKill(10 * 1000)
+
 	def gitCommit = proc.text.trim()
 	assert !gitCommit.isEmpty()
 
     def srCmd = 'git symbolic-ref --short HEAD'
-    def srProc = srCmd.execute()
+    def srProc = srCmd.execute(null, projectDir)
     srProc.waitForOrKill(10 * 1000)
     if (srProc.exitValue() == 0) {
         // Only add the information if the git command was

--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
@@ -113,30 +113,6 @@ public final class SmackConfiguration {
      * the server. The default value is 5000 ms.
      *
      * @return the milliseconds to wait for a response from the server
-     * @deprecated use {@link #getDefaultReplyTimeout()} instead.
-     */
-    @Deprecated
-    public static int getDefaultPacketReplyTimeout() {
-        return getDefaultReplyTimeout();
-    }
-
-    /**
-     * Sets the number of milliseconds to wait for a response from
-     * the server.
-     *
-     * @param timeout the milliseconds to wait for a response from the server
-     * @deprecated use {@link #setDefaultReplyTimeout(int)} instead.
-     */
-    @Deprecated
-    public static void setDefaultPacketReplyTimeout(int timeout) {
-        setDefaultReplyTimeout(timeout);
-    }
-
-    /**
-     * Returns the number of milliseconds to wait for a response from
-     * the server. The default value is 5000 ms.
-     *
-     * @return the milliseconds to wait for a response from the server
      */
     public static int getDefaultReplyTimeout() {
         // The timeout value must be greater than 0 otherwise we will answer the default value


### PR DESCRIPTION
The assert on line 659 was causing my build to fail. Two issues caused gitCommit to be empty.

1. The cmd `'git describe --always --tags --dirty=+'` was not given enough time to complete and had not exited which meant no text in proc.text
2. The two git commands on lines 653 and 658 were run from the CWD of my Eclipse IDE, not the $projectDir which caused git to return an error 128.

To solve the two issues I added a `waitForOrKill` method call to proc (like the srCmd had) and I set the `execute` to run in $projectDir which I think was the intent/assumption in the original code.