### PR TITLE
build.gradle: Improve android API exception message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -680,7 +680,7 @@ def getAndroidRuntimeJar() {
 	if (androidJar.isFile()) {
 		return androidJar
 	} else {
-		throw new Exception("Can't find android.jar for $androidApiLevel API. Please install corresponding SDK platform package")
+		throw new Exception("Can't find android.jar for API level ${androidApiLevel}. Please install corresponding SDK platform package")
 	}
 }
 


### PR DESCRIPTION
This is just a small fix that improves the wording of the exception message that gets thrown when android.jar for API level 16 is missing.