### PR TITLE
Improve attention

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/attention/packet/AttentionExtension.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/attention/packet/AttentionExtension.java
@@ -19,6 +19,7 @@ package org.jivesoftware.smackx.attention.packet;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smack.util.XmlStringBuilder;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 /**
@@ -69,11 +70,8 @@ public class AttentionExtension implements ExtensionElement {
      * @see org.jivesoftware.smack.packet.PacketExtension#toXML()
      */
     @Override
-    public String toXML(org.jivesoftware.smack.packet.XmlEnvironment enclosingNamespace) {
-        final StringBuilder sb = new StringBuilder();
-        sb.append('<').append(getElementName()).append(" xmlns=\"").append(
-                getNamespace()).append("\"/>");
-        return sb.toString();
+    public XmlStringBuilder toXML(org.jivesoftware.smack.packet.XmlEnvironment enclosingNamespace) {
+        return new XmlStringBuilder(this).closeEmptyElement();
     }
 
     /**

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/attention/AttentionElementTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/attention/AttentionElementTest.java
@@ -1,0 +1,38 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.attention;
+
+import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
+
+import org.jivesoftware.smackx.attention.packet.AttentionExtension;
+
+import org.junit.Test;
+
+public class AttentionElementTest {
+
+    /**
+     * Serialized Attention element.
+     * @see <a href="https://xmpp.org/extensions/xep-0224.html#example-2">XEP-0224: Attention - Example 2</a>
+     */
+    private static final String XML = "<attention xmlns='urn:xmpp:attention:0'/>";
+
+    @Test
+    public void serializationTest() {
+        AttentionExtension extension = new AttentionExtension();
+        assertXmlSimilar(XML, extension.toXML());
+    }
+}


### PR DESCRIPTION
This is a small change that makes use of `XmlStringBuilder` instead of handcrafting XML in `AttentionElement.toXml()`.
I also added a `AttentionElementTest` test case that compares the resulting XML with the XML from the XEP.