### PR TITLE
XEP-0420: Stanza Content Encryption

### DIFF
--- a/documentation/extensions/index.md
+++ b/documentation/extensions/index.md
@@ -123,6 +123,7 @@ Experimental Smack Extensions and currently supported XEPs of smack-experimental
 | [Consistent Color Generation](consistent_colors.md)       | [XEP-0392](https://xmpp.org/extensions/xep-0392.html)  | 0.6.0     | Generate consistent colors for identifiers like usernames to provide a consistent user experience. |
 | [Message Markup](messagemarkup.md)                        | [XEP-0394](https://xmpp.org/extensions/xep-0394.html)  | 0.1.0     | Style message bodies while keeping body and markup information separated. |
 | DNS Queries over XMPP (DoX)                               | [XEP-0418](https://xmpp.org/extensions/xep-0418.html)  | 0.1.0     | Send DNS queries and responses over XMPP. |
+| Stanza Content Encryption                                 | [XEP-0420](https://xmpp.org/extensions/xep-0420.html)  | 0.3.0     | End-to-end encryption of arbitrary extension elements. Smack provides elements and providers to be used by encryption mechanisms. |
 | Message Fastening                                         | [XEP-0422](https://xmpp.org/extensions/xep-0422.html)  | 0.1.1     | Mark payloads on a message to be logistically fastened to a previous message. |
 | Message Retraction                                        | [XEP-0424](https://xmpp.org/extensions/xep-0424.html)  | 0.2.0     | Mark messages as retracted. |
 | Fallback Indication                                       | [XEP-0428](https://xmpp.org/extensions/xep-0428.html)  | 0.1.0     | Declare body elements of a message as ignorable fallback for naive legacy clients. |

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/sid/element/OriginIdElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/sid/element/OriginIdElement.java
@@ -16,6 +16,8 @@
  */
 package org.jivesoftware.smackx.sid.element;
 
+import javax.xml.namespace.QName;
+
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.MessageBuilder;
 import org.jivesoftware.smack.util.XmlStringBuilder;
@@ -25,6 +27,8 @@ import org.jivesoftware.smackx.sid.StableUniqueStanzaIdManager;
 public class OriginIdElement extends StableAndUniqueIdElement {
 
     public static final String ELEMENT = "origin-id";
+    public static final String NAMESPACE = StableUniqueStanzaIdManager.NAMESPACE;
+    public static final QName QNAME = new QName(NAMESPACE, ELEMENT);
 
     public OriginIdElement() {
         super();

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/AffixElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/AffixElement.java
@@ -1,0 +1,29 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import org.jivesoftware.smack.packet.Element;
+
+/**
+ * Interface that marks elements that may be used as affix elements inside a {@link ContentElement}.
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0420.html#affix_elements">
+ *     XEP-0420: Stanza Content Encryption - §4. Affix Elements</a>
+ */
+public interface AffixElement extends Element {
+
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/AffixExtensionElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/AffixExtensionElement.java
@@ -1,0 +1,32 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+
+/**
+ * Affix element that is identified by element name and namespace.
+ * You should extend this interface with your custom affix extension elements
+ * and also provide a {@link org.jivesoftware.smackx.stanza_content_encryption.provider.AffixExtensionElementProvider}
+ * for them.
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0420.html#affix_elements">
+ *     XEP-0420: Stanza Content Encryption - §4. Affix Elements</a>
+ */
+public interface AffixExtensionElement extends ExtensionElement, AffixElement {
+
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/ContentElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/ContentElement.java
@@ -1,0 +1,288 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.xml.namespace.QName;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.util.Objects;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+import org.jivesoftware.smackx.address.packet.MultipleAddresses;
+import org.jivesoftware.smackx.hints.element.MessageProcessingHint;
+import org.jivesoftware.smackx.sid.element.StanzaIdElement;
+
+import org.jxmpp.jid.Jid;
+
+/**
+ * Extension element that holds the payload element, as well as a list of affix elements.
+ * In SCE, the XML representation of this element is what will be encrypted using the encryption mechanism of choice.
+ */
+public class ContentElement implements ExtensionElement {
+
+    private static final String NAMESPACE_UNVERSIONED = "urn:xmpp:sce";
+    public static final String NAMESPACE_0 = NAMESPACE_UNVERSIONED + ":0";
+    public static final String NAMESPACE = NAMESPACE_0;
+    public static final String ELEMENT = "content";
+    public static final QName QNAME = new QName(NAMESPACE, ELEMENT);
+
+    private final PayloadElement payload;
+    private final List<AffixElement> affixElements;
+
+    ContentElement(PayloadElement payload, List<AffixElement> affixElements) {
+        this.payload = payload;
+        this.affixElements = Collections.unmodifiableList(affixElements);
+    }
+
+    /**
+     * Return the {@link PayloadElement} which holds the sensitive payload extensions.
+     *
+     * @return payload element
+     */
+    public PayloadElement getPayload() {
+        return payload;
+    }
+
+    /**
+     * Return a list of affix elements.
+     * Those are elements that need to be verified upon reception by the encryption mechanisms implementation.
+     *
+     * @see <a href="https://xmpp.org/extensions/xep-0420.html#affix_elements">
+     *     XEP-0420: Stanza Content Encryption - §4. Affix Elements</a>
+     *
+     * @return list of affix elements
+     */
+    public List<AffixElement> getAffixElements() {
+        return affixElements;
+    }
+
+    @Override
+    public String getNamespace() {
+        return NAMESPACE;
+    }
+
+    @Override
+    public String getElementName() {
+        return ELEMENT;
+    }
+
+    @Override
+    public XmlStringBuilder toXML(XmlEnvironment xmlEnvironment) {
+        XmlStringBuilder xml = new XmlStringBuilder(this).rightAngleBracket();
+        xml.append(affixElements);
+        xml.append(payload);
+        return xml.closeElement(this);
+    }
+
+    @Override
+    public QName getQName() {
+        return QNAME;
+    }
+
+    /**
+     * Return a {@link Builder} that can be used to build the {@link ContentElement}.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private static final Set<String> BLACKLISTED_NAMESPACES = Collections.singleton(MessageProcessingHint.NAMESPACE);
+        private static final Set<QName> BLACKLISTED_QNAMES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                StanzaIdElement.QNAME,
+                MultipleAddresses.QNAME
+        )));
+
+        private FromAffixElement from = null;
+        private TimestampAffixElement timestamp = null;
+        private RandomPaddingAffixElement rpad = null;
+
+        private final List<AffixElement> otherAffixElements = new ArrayList<>();
+        private final List<ExtensionElement> payloadItems = new ArrayList<>();
+
+        private Builder() {
+
+        }
+
+        /**
+         * Add an affix element of type 'to' which addresses one recipient.
+         * The jid in the 'to' element SHOULD be a bare jid.
+         *
+         * @param jid jid
+         * @return builder
+         */
+        public Builder addTo(Jid jid) {
+            return addTo(new ToAffixElement(jid));
+        }
+
+        /**
+         * Add an affix element of type 'to' which addresses one recipient.
+         *
+         * @param to affix element
+         * @return builder
+         */
+        public Builder addTo(ToAffixElement to) {
+            this.otherAffixElements.add(Objects.requireNonNull(to, "'to' affix element MUST NOT be null."));
+            return this;
+        }
+
+        /**
+         * Set the senders jid as a 'from' affix element.
+         *
+         * @param jid jid of the sender
+         * @return builder
+         */
+        public Builder setFrom(Jid jid) {
+            return setFrom(new FromAffixElement(jid));
+        }
+
+        /**
+         * Set the senders jid as a 'from' affix element.
+         *
+         * @param from affix element
+         * @return builder
+         */
+        public Builder setFrom(FromAffixElement from) {
+            this.from = Objects.requireNonNull(from, "'form' affix element MUST NOT be null.");
+            return this;
+        }
+
+        /**
+         * Set the given date as a 'time' affix element.
+         *
+         * @param date timestamp as date
+         * @return builder
+         */
+        public Builder setTimestamp(Date date) {
+            return setTimestamp(new TimestampAffixElement(date));
+        }
+
+        /**
+         * Set the timestamp of the message as a 'time' affix element.
+         *
+         * @param timestamp timestamp affix element
+         * @return builder
+         */
+        public Builder setTimestamp(TimestampAffixElement timestamp) {
+            this.timestamp = Objects.requireNonNull(timestamp, "'time' affix element MUST NOT be null.");
+            return this;
+        }
+
+        /**
+         * Set some random length random content padding.
+         *
+         * @return builder
+         */
+        public Builder setRandomPadding() {
+            this.rpad = new RandomPaddingAffixElement();
+            return this;
+        }
+
+        /**
+         * Set the given string as padding.
+         * The padding should be of length between 1 and 200 characters.
+         *
+         * @param padding padding string
+         * @return builder
+         */
+        public Builder setRandomPadding(String padding) {
+            return setRandomPadding(new RandomPaddingAffixElement(padding));
+        }
+
+        /**
+         * Set a padding affix element.
+         *
+         * @param padding affix element
+         * @return builder
+         */
+        public Builder setRandomPadding(RandomPaddingAffixElement padding) {
+            this.rpad = Objects.requireNonNull(padding, "'rpad' affix element MUST NOT be empty.");
+            return this;
+        }
+
+        /**
+         * Add an additional, SCE profile specific affix element.
+         *
+         * @param customAffixElement additional affix element
+         * @return builder
+         */
+        public Builder addFurtherAffixElement(AffixElement customAffixElement) {
+            this.otherAffixElements.add(Objects.requireNonNull(customAffixElement,
+                    "Custom affix element MUST NOT be null."));
+            return this;
+        }
+
+        /**
+         * Add a payload item as child element of the payload element.
+         * There are some items that are not allowed as payload.
+         * Adding those will throw an exception.
+         *
+         * @see <a href="https://xmpp.org/extensions/xep-0420.html#server-processed">
+         *     XEP-0420: Stanza Content Encryption - §9. Server-processed Elements</a>
+         *
+         * @param payloadItem extension element
+         * @return builder
+         * @throws IllegalArgumentException in case an extension element from the blacklist is added.
+         */
+        public Builder addPayloadItem(ExtensionElement payloadItem) {
+            Objects.requireNonNull(payloadItem, "Payload item MUST NOT be null.");
+            this.payloadItems.add(checkForIllegalPayloadsAndPossiblyThrow(payloadItem));
+            return this;
+        }
+
+        /**
+         * Construct a content element from this builder.
+         *
+         * @return content element
+         */
+        public ContentElement build() {
+            List<AffixElement> allAffixElements = collectAffixElements();
+            PayloadElement payloadElement = new PayloadElement(payloadItems);
+            return new ContentElement(payloadElement, allAffixElements);
+        }
+
+        private static ExtensionElement checkForIllegalPayloadsAndPossiblyThrow(ExtensionElement payloadItem) {
+            QName qName = payloadItem.getQName();
+            if (BLACKLISTED_QNAMES.contains(qName)) {
+                throw new IllegalArgumentException("Element identified by " + qName +
+                        " is not allowed as payload item. See https://xmpp.org/extensions/xep-0420.html#server-processed");
+            }
+
+            String namespace = payloadItem.getNamespace();
+            if (BLACKLISTED_NAMESPACES.contains(namespace)) {
+                throw new IllegalArgumentException("Elements of namespace '" + namespace +
+                        "' are not allowed as payload items. See https://xmpp.org/extensions/xep-0420.html#server-processed");
+            }
+
+            return payloadItem;
+        }
+
+        private List<AffixElement> collectAffixElements() {
+            List<AffixElement> allAffixElements = new ArrayList<>(Arrays.asList(rpad, from, timestamp));
+            allAffixElements.addAll(otherAffixElements);
+            return allAffixElements;
+        }
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/FromAffixElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/FromAffixElement.java
@@ -1,0 +1,33 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import org.jxmpp.jid.Jid;
+
+public class FromAffixElement extends JidAffixElement {
+
+    public static final String ELEMENT = "from";
+
+    public FromAffixElement(Jid jid) {
+        super(jid);
+    }
+
+    @Override
+    public String getElementName() {
+        return ELEMENT;
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/JidAffixElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/JidAffixElement.java
@@ -1,0 +1,57 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import org.jivesoftware.smack.packet.NamedElement;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.util.EqualsUtil;
+import org.jivesoftware.smack.util.Objects;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+import org.jxmpp.jid.Jid;
+
+public abstract class JidAffixElement implements NamedElement, AffixElement {
+
+    public static final String ATTR_JID = "jid";
+
+    private final Jid jid;
+
+    public JidAffixElement(Jid jid) {
+        this.jid = Objects.requireNonNull(jid, "Value of 'jid' MUST NOT be null.");
+    }
+
+    public Jid getJid() {
+        return jid;
+    }
+
+    @Override
+    public XmlStringBuilder toXML(XmlEnvironment xmlEnvironment) {
+        return new XmlStringBuilder(this)
+                .attribute(ATTR_JID, getJid())
+                .closeEmptyElement();
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return EqualsUtil.equals(this, obj, (e, o) -> e.append(getJid(), o.getJid()).append(getElementName(), o.getElementName()));
+    }
+
+    @Override
+    public final int hashCode() {
+        return (getElementName() + getJid().toString()).hashCode();
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/PayloadElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/PayloadElement.java
@@ -1,0 +1,52 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.NamedElement;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+public class PayloadElement implements NamedElement {
+
+    public static final String ELEMENT = "payload";
+
+    private final List<ExtensionElement> payloadElements;
+
+    public PayloadElement(List<ExtensionElement> payloadElements) {
+        this.payloadElements = Collections.unmodifiableList(payloadElements);
+    }
+
+    public List<ExtensionElement> getItems() {
+        return payloadElements;
+    }
+
+    @Override
+    public String getElementName() {
+        return ELEMENT;
+    }
+
+    @Override
+    public XmlStringBuilder toXML(XmlEnvironment xmlEnvironment) {
+        XmlStringBuilder xml = new XmlStringBuilder(this).rightAngleBracket();
+        xml.append(payloadElements);
+        return xml.closeElement(this);
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/RandomPaddingAffixElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/RandomPaddingAffixElement.java
@@ -1,0 +1,75 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import java.security.SecureRandom;
+
+import org.jivesoftware.smack.packet.NamedElement;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.util.EqualsUtil;
+import org.jivesoftware.smack.util.RandomUtil;
+import org.jivesoftware.smack.util.StringUtils;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+public class RandomPaddingAffixElement implements NamedElement, AffixElement {
+
+    private static final int minPaddingLength = 1;
+    private static final int maxPaddingLength = 200;
+    public static final String ELEMENT = "rpad";
+
+    private final String padding;
+
+    public RandomPaddingAffixElement(String padding) {
+        this.padding = StringUtils.escapeForXmlText(
+                StringUtils.requireNotNullNorEmpty(padding, "Value of 'rpad' MUST NOT be null nor empty."))
+                .toString();
+    }
+
+    public RandomPaddingAffixElement() {
+        this(StringUtils.randomString(randomPaddingLength(), new SecureRandom()));
+    }
+
+    private static int randomPaddingLength() {
+        return minPaddingLength + RandomUtil.nextSecureRandomInt(maxPaddingLength - minPaddingLength);
+    }
+
+    public String getPadding() {
+        return padding;
+    }
+
+    @Override
+    public String getElementName() {
+        return ELEMENT;
+    }
+
+    @Override
+    public XmlStringBuilder toXML(XmlEnvironment xmlEnvironment) {
+        return new XmlStringBuilder(this).rightAngleBracket()
+                .append(getPadding())
+                .closeElement(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsUtil.equals(this, obj, (e, o) -> e.append(getPadding(), o.getPadding()));
+    }
+
+    @Override
+    public int hashCode() {
+        return getPadding().hashCode();
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/TimestampAffixElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/TimestampAffixElement.java
@@ -1,0 +1,63 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import java.util.Date;
+
+import org.jivesoftware.smack.packet.NamedElement;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.util.EqualsUtil;
+import org.jivesoftware.smack.util.Objects;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+public class TimestampAffixElement implements NamedElement, AffixElement {
+
+    public static final String ELEMENT = "time";
+    public static final String ATTR_STAMP = "stamp";
+
+    private final Date timestamp;
+
+    public TimestampAffixElement(Date timestamp) {
+        this.timestamp = Objects.requireNonNull(timestamp, "Date must not be null.");
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String getElementName() {
+        return ELEMENT;
+    }
+
+    @Override
+    public CharSequence toXML(XmlEnvironment xmlEnvironment) {
+        return new XmlStringBuilder(this)
+                .attribute(ATTR_STAMP, getTimestamp())
+                .closeEmptyElement();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsUtil.equals(this, obj, (e, o) -> e.append(getTimestamp(), o.getTimestamp()));
+    }
+
+    @Override
+    public int hashCode() {
+        return timestamp.hashCode();
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/ToAffixElement.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/ToAffixElement.java
@@ -1,0 +1,34 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import org.jxmpp.jid.Jid;
+
+public class ToAffixElement extends JidAffixElement {
+
+    public static final String ELEMENT = "to";
+
+    public ToAffixElement(Jid jid) {
+        super(jid);
+    }
+
+    @Override
+    public String getElementName() {
+        return ELEMENT;
+    }
+
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/package-info.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/element/package-info.java
@@ -1,0 +1,20 @@
+/**
+ *
+ * Copyright 2018 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Smack's API for XEP-0420: Stanza Content Encryption: Element classes.
+  */
+package org.jivesoftware.smackx.stanza_content_encryption.element;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/package-info.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/package-info.java
@@ -1,0 +1,22 @@
+/**
+ *
+ * Copyright 2018 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Smack's API for XEP-0420: Stanza Content Encryption.
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0420.html">XEP-0420: Stanza Content Encryption</a>
+  */
+package org.jivesoftware.smackx.stanza_content_encryption;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/provider/AffixExtensionElementProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/provider/AffixExtensionElementProvider.java
@@ -1,0 +1,29 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.provider;
+
+import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smackx.stanza_content_encryption.element.AffixExtensionElement;
+
+/**
+ * Abstract class that needs to be extended by provider classes that parse out affix extension elements.
+ *
+ * @param <AE> affix extension element.
+ */
+public abstract class AffixExtensionElementProvider<AE extends AffixExtensionElement> extends ExtensionElementProvider<AE> {
+
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/provider/ContentElementProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/provider/ContentElementProvider.java
@@ -1,0 +1,137 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.provider;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.parsing.SmackParsingException;
+import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smack.util.PacketParserUtils;
+import org.jivesoftware.smack.util.ParserUtils;
+import org.jivesoftware.smack.xml.XmlPullParser;
+import org.jivesoftware.smack.xml.XmlPullParserException;
+import org.jivesoftware.smackx.stanza_content_encryption.element.AffixElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.ContentElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.FromAffixElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.PayloadElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.RandomPaddingAffixElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.TimestampAffixElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.ToAffixElement;
+
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+public class ContentElementProvider extends ExtensionElementProvider<ContentElement> {
+
+    @Override
+    public ContentElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+            throws XmlPullParserException, IOException, SmackParsingException {
+        ContentElement.Builder builder = ContentElement.builder();
+
+        while (true) {
+            XmlPullParser.Event tag = parser.next();
+            if (tag == XmlPullParser.Event.START_ELEMENT) {
+                String name = parser.getName();
+                switch (name) {
+                    case ToAffixElement.ELEMENT:
+                        parseToAffix(parser, builder);
+                        break;
+
+                    case FromAffixElement.ELEMENT:
+                        parseFromAffix(parser, builder);
+                        break;
+
+                    case TimestampAffixElement.ELEMENT:
+                        parseTimestampAffix(parser, builder);
+                        break;
+
+                    case RandomPaddingAffixElement.ELEMENT:
+                        parseRPadAffix(parser, builder);
+                        break;
+
+                    case PayloadElement.ELEMENT:
+                        parsePayload(parser, xmlEnvironment, builder);
+                        break;
+
+                    default:
+                        parseCustomAffix(parser, xmlEnvironment, builder);
+                        break;
+                }
+            } else if (tag == XmlPullParser.Event.END_ELEMENT) {
+                if (parser.getDepth() == initialDepth) {
+                    break;
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    private static void parseCustomAffix(XmlPullParser parser, XmlEnvironment outerXmlEnvironment, ContentElement.Builder builder)
+            throws XmlPullParserException, IOException, SmackParsingException {
+        String name = parser.getName();
+        String namespace = parser.getNamespace();
+
+        AffixElement element = (AffixElement) PacketParserUtils.parseExtensionElement(name, namespace, parser, outerXmlEnvironment);
+        builder.addFurtherAffixElement(element);
+    }
+
+    private static void parsePayload(XmlPullParser parser, XmlEnvironment outerXmlEnvironment, ContentElement.Builder builder)
+            throws IOException, XmlPullParserException, SmackParsingException {
+        final int initialDepth = parser.getDepth();
+        while (true) {
+            XmlPullParser.Event tag = parser.next();
+
+            if (tag == XmlPullParser.Event.START_ELEMENT) {
+                String name = parser.getName();
+                String namespace = parser.getNamespace();
+                ExtensionElement element = PacketParserUtils.parseExtensionElement(name, namespace, parser, outerXmlEnvironment);
+                builder.addPayloadItem(element);
+            }
+
+            if (tag == XmlPullParser.Event.END_ELEMENT && parser.getDepth() == initialDepth) {
+                return;
+            }
+        }
+    }
+
+    private static void parseRPadAffix(XmlPullParser parser, ContentElement.Builder builder)
+            throws IOException, XmlPullParserException {
+        builder.setRandomPadding(parser.nextText());
+    }
+
+    private static void parseTimestampAffix(XmlPullParser parser, ContentElement.Builder builder)
+            throws SmackParsingException.SmackTextParseException {
+        Date timestamp = ParserUtils.getDateFromXep82String(
+                parser.getAttributeValue("", TimestampAffixElement.ATTR_STAMP));
+        builder.setTimestamp(timestamp);
+    }
+
+    private static void parseFromAffix(XmlPullParser parser, ContentElement.Builder builder)
+            throws XmppStringprepException {
+        String jidString = parser.getAttributeValue("", FromAffixElement.ATTR_JID);
+        builder.setFrom(JidCreate.from(jidString));
+    }
+
+    private static void parseToAffix(XmlPullParser parser, ContentElement.Builder builder)
+            throws XmppStringprepException {
+        String jidString = parser.getAttributeValue("", ToAffixElement.ATTR_JID);
+        builder.addTo(JidCreate.from(jidString));
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/provider/package-info.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/provider/package-info.java
@@ -1,0 +1,20 @@
+/**
+ *
+ * Copyright 2018 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Smack's API for XEP-0420: Stanza Content Encryption: Provider classes.
+  */
+package org.jivesoftware.smackx.stanza_content_encryption.provider;

--- a/smack-experimental/src/main/resources/org.jivesoftware.smack.experimental/experimental.providers
+++ b/smack-experimental/src/main/resources/org.jivesoftware.smack.experimental/experimental.providers
@@ -292,6 +292,13 @@
       <className>org.jivesoftware.smackx.dox.provider.DnsIqProvider</className>
     </iqProvider>
 
+    <!-- XEP-0420: Stanza Content Encryption (SCE) -->
+    <extensionProvider>
+      <elementName>content</elementName>
+      <namespace>urn:xmpp:sce:0</namespace>
+      <className>org.jivesoftware.smackx.stanza_content_encryption.provider.ContentElementProvider</className>
+    </extensionProvider>
+
     <!-- XEP-0422: Message Fastening -->
     <extensionProvider>
       <elementName>apply-to</elementName>

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/stanza_content_encryption/element/AffixElementsTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/stanza_content_encryption/element/AffixElementsTest.java
@@ -1,0 +1,156 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import static org.jivesoftware.smack.test.util.XmlAssertUtil.assertXmlSimilar;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.util.XmppDateTime;
+
+public class AffixElementsTest {
+
+    public static final EntityBareJid JID_HOUSTON = JidCreate.entityBareFromOrThrowUnchecked("missioncontrol@houston.nasa.gov");
+    public static final EntityBareJid JID_OPPORTUNITY = JidCreate.entityBareFromOrThrowUnchecked("opportunity@mars.planet");
+
+    /**
+     * Test serialization of 'to' affix element.
+     *
+     * @see <a href="https://xmpp.org/extensions/xep-0420.html#example-1">XEP-420 Example 1</a>
+     */
+    @Test
+    public void testToAffixElement() {
+        ToAffixElement to = new ToAffixElement(JID_HOUSTON);
+        String expectedXml = "<to jid='missioncontrol@houston.nasa.gov'/>";
+
+        assertXmlSimilar(expectedXml, to.toXML());
+        assertEquals(JID_HOUSTON, to.getJid());
+    }
+
+    @Test
+    public void testToAffixElementEquals() {
+        ToAffixElement to1 = new ToAffixElement(JID_HOUSTON);
+        ToAffixElement to2 = new ToAffixElement(JID_HOUSTON);
+
+        assertEquals(to1, to2);
+        assertEquals(to1, to1);
+        assertEquals(to1.hashCode(), to2.hashCode());
+        assertFalse(to1.equals(null));
+    }
+
+    @Test
+    public void toElementNullArgThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new ToAffixElement(null));
+    }
+
+    /**
+     * Test serialization of 'from' affix element.
+     *
+     * @see <a href="https://xmpp.org/extensions/xep-0420.html#example-1">XEP-420 Example 1</a>
+     */
+    @Test
+    public void testFromAffixElement() {
+        FromAffixElement from = new FromAffixElement(JID_OPPORTUNITY);
+        String expectedXml = "<from jid='opportunity@mars.planet'/>";
+
+        assertXmlSimilar(expectedXml, from.toXML());
+        assertEquals(JID_OPPORTUNITY, from.getJid());
+    }
+
+    @Test
+    public void testFromAffixElementEquals() {
+        FromAffixElement from1 = new FromAffixElement(JID_HOUSTON);
+        FromAffixElement from2 = new FromAffixElement(JID_HOUSTON);
+
+        assertEquals(from1, from2);
+        assertEquals(from1, from1);
+        assertEquals(from1.hashCode(), from2.hashCode());
+        assertFalse(from1.equals(null));
+    }
+
+    @Test
+    public void fromElementNullArgThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new FromAffixElement(null));
+    }
+
+    @Test
+    public void testTimestampAffixElement() throws ParseException {
+        Date date = XmppDateTime.parseDate("2004-01-25T05:05:00.000+00:00");
+        TimestampAffixElement timestamp = new TimestampAffixElement(date);
+        String expectedXml = "<time stamp='2004-01-25T05:05:00.000+00:00'/>";
+
+        assertXmlSimilar(expectedXml, timestamp.toXML());
+        assertEquals(date, timestamp.getTimestamp());
+    }
+
+    @Test
+    public void timestampElementNullArgThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new TimestampAffixElement(null));
+    }
+
+    @Test
+    public void testTimestampElementEquals() throws ParseException {
+        TimestampAffixElement t1 = new TimestampAffixElement(XmppDateTime.parseDate("2004-01-25T05:05:00.000+00:00"));
+        TimestampAffixElement t2 = new TimestampAffixElement(t1.getTimestamp());
+
+        assertEquals(t1, t2);
+        assertEquals(t1, t1);
+        assertEquals(t1.hashCode(), t2.hashCode());
+        assertFalse(t1.equals(null));
+    }
+
+    @Test
+    public void testRandomPaddingElement() {
+        RandomPaddingAffixElement rpad = new RandomPaddingAffixElement();
+
+        assertNotNull(rpad.getPadding());
+        assertTrue(rpad.getPadding().length() < 200);
+    }
+
+    @Test
+    public void testRandomPaddingEquals() {
+        RandomPaddingAffixElement rpad1 = new RandomPaddingAffixElement();
+        RandomPaddingAffixElement rpad2 = new RandomPaddingAffixElement(rpad1.getPadding());
+
+        assertEquals(rpad1, rpad2);
+        assertEquals(rpad1, rpad1);
+        assertEquals(rpad1.hashCode(), rpad2.hashCode());
+        assertFalse(rpad1.equals(null));
+    }
+
+    @Test
+    public void testRandomPaddingSerialization() {
+        RandomPaddingAffixElement rpad = new RandomPaddingAffixElement();
+        String expectedXml = "<rpad>" + rpad.getPadding() + "</rpad>";
+
+        assertXmlSimilar(expectedXml, rpad.toXML());
+    }
+
+    @Test
+    public void rpadElementNullArgThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new RandomPaddingAffixElement(null));
+    }
+}

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/stanza_content_encryption/element/ContentElementTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/stanza_content_encryption/element/ContentElementTest.java
@@ -1,0 +1,81 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.element;
+
+import static org.jivesoftware.smack.test.util.XmlAssertUtil.assertXmlSimilar;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.ParseException;
+import java.util.Collections;
+
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smackx.hints.element.StoreHint;
+import org.jivesoftware.smackx.sid.element.StanzaIdElement;
+
+import org.junit.jupiter.api.Test;
+import org.jxmpp.util.XmppDateTime;
+
+public class ContentElementTest {
+
+    @Test
+    public void testContentElement() throws ParseException {
+        Message.Body body = new Message.Body("en", "My battery is low and it’s getting dark"); // :'(
+
+        ContentElement contentElement = ContentElement.builder()
+                .addPayloadItem(body)
+                .setFrom(AffixElementsTest.JID_OPPORTUNITY)
+                .addTo(AffixElementsTest.JID_HOUSTON)
+                .setTimestamp(XmppDateTime.parseXEP0082Date("2018-06-10T00:00:00.000+00:00"))
+                .setRandomPadding("RANDOMPADDING")
+                .build();
+
+        String expectedXml = "" +
+                "<content xmlns='urn:xmpp:sce:0'>" +
+                "  <to jid='missioncontrol@houston.nasa.gov'/>" +
+                "  <from jid='opportunity@mars.planet'/>" +
+                "  <time stamp='2018-06-10T00:00:00.000+00:00'/>" +
+                "  <rpad>RANDOMPADDING</rpad>" +
+                "  <payload>" +
+                "    <body xmlns='jabber:client' xml:lang='en'>My battery is low and it’s getting dark</body>" +
+                "  </payload>" +
+                "</content>";
+
+        assertXmlSimilar(expectedXml, contentElement.toXML());
+        assertEquals(Collections.singletonList(body), contentElement.getPayload().getItems());
+
+        assertEquals(4, contentElement.getAffixElements().size());
+        assertTrue(contentElement.getAffixElements().contains(new ToAffixElement(AffixElementsTest.JID_HOUSTON)));
+        assertTrue(contentElement.getAffixElements().contains(new FromAffixElement(AffixElementsTest.JID_OPPORTUNITY)));
+        assertTrue(contentElement.getAffixElements().contains(
+                new TimestampAffixElement(XmppDateTime.parseXEP0082Date("2018-06-10T00:00:00.000+00:00"))));
+        assertTrue(contentElement.getAffixElements().contains(new RandomPaddingAffixElement("RANDOMPADDING")));
+    }
+
+    @Test
+    public void stanzaIdForbiddenInContentElementPayload() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ContentElement.builder().addPayloadItem(new StanzaIdElement("alice@wonderland.lit")));
+    }
+
+    @Test
+    public void processingHintsForbiddenInContentElementPayload() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ContentElement.builder().addPayloadItem(StoreHint.INSTANCE));
+    }
+}

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/stanza_content_encryption/provider/ContentElementProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/stanza_content_encryption/provider/ContentElementProviderTest.java
@@ -1,0 +1,84 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.stanza_content_encryption.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.StandardExtensionElement;
+import org.jivesoftware.smack.parsing.SmackParsingException;
+import org.jivesoftware.smack.test.util.TestUtils;
+import org.jivesoftware.smack.util.ParserUtils;
+import org.jivesoftware.smack.xml.XmlPullParserException;
+import org.jivesoftware.smackx.stanza_content_encryption.element.ContentElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.FromAffixElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.RandomPaddingAffixElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.TimestampAffixElement;
+import org.jivesoftware.smackx.stanza_content_encryption.element.ToAffixElement;
+
+import org.junit.jupiter.api.Test;
+import org.jxmpp.jid.impl.JidCreate;
+
+public class ContentElementProviderTest {
+
+    @Test
+    public void testParsing() throws XmlPullParserException, IOException, SmackParsingException {
+        String xml = "" +
+                "<content xmlns='urn:xmpp:sce:0'>\n" +
+                "  <payload>\n" +
+                "    <body xmlns='jabber:client'>Have you seen that new movie?</body>\n" +
+                "    <x xmlns='jabber:x:oob'>\n" +
+                "      <url>https://en.wikipedia.org/wiki/Fight_Club#Plot</url>\n" +
+                "    </x>\n" +
+                "  </payload>\n" +
+                "  <from jid='ladymacbeth@shakespear.lit/castle'/>\n" +
+                "  <to jid='doctor@shakespeare.lit/pda'/>\n" +
+                "  <time stamp='1993-10-12T03:13:10.000+00:00'/>\n" +
+                "  <rpad>A98D7KJF1ASDVG232sdff341</rpad>\n" +
+                "</content>";
+
+        ContentElementProvider provider = new ContentElementProvider();
+        ContentElement contentElement = provider.parse(TestUtils.getParser(xml));
+
+        assertNotNull(contentElement);
+
+        assertEquals(4, contentElement.getAffixElements().size());
+        assertTrue(contentElement.getAffixElements().contains(
+                new FromAffixElement(JidCreate.from("ladymacbeth@shakespear.lit/castle"))));
+        assertTrue(contentElement.getAffixElements().contains(
+                new ToAffixElement(JidCreate.from("doctor@shakespeare.lit/pda"))));
+        assertTrue(contentElement.getAffixElements().contains(
+                new TimestampAffixElement(ParserUtils.getDateFromXep82String("1993-10-12T03:13:10.000+00:00"))));
+        assertTrue(contentElement.getAffixElements().contains(
+                new RandomPaddingAffixElement("A98D7KJF1ASDVG232sdff341")));
+
+        assertEquals(2, contentElement.getPayload().getItems().size());
+
+        assertTrue(contentElement.getPayload().getItems().get(0) instanceof Message.Body);
+        Message.Body body = (Message.Body) contentElement.getPayload().getItems().get(0);
+        assertEquals("Have you seen that new movie?", body.getMessage());
+
+        StandardExtensionElement oob = (StandardExtensionElement) contentElement.getPayload().getItems().get(1);
+        assertEquals("x", oob.getElementName());
+        assertEquals("jabber:x:oob", oob.getNamespace());
+        assertEquals("https://en.wikipedia.org/wiki/Fight_Club#Plot", oob.getFirstElement("url").getText());
+    }
+}


### PR DESCRIPTION
This PR adds initial support for [XEP-0420: Stanza Content Encryption](https://xmpp.org/extensions/xep-0420.html) (SCE).

Initial support means that elements and providers are implemented, but no higher level Manager class exists. This is partly due to the fact that SCE is intended to be used by E2EE protocols which would simply make use of the elements.