### PR TITLE
Correct ALPHABET in `BASE32.java`

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/stringencoder/Base32.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/stringencoder/Base32.java
@@ -45,7 +45,7 @@ public class Base32 {
         }
 
     };
-    private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ2345678";
+    private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
     public static StringEncoder<String> getStringEncoder() {
         return base32Stringencoder;


### PR DESCRIPTION
As per [RFC 4648](https://tools.ietf.org/html/rfc4648#section-6) Table 3, no `Value` gives its encoding as `8`.