### PR TITLE
OMEMO: Switch to sending 12 byte IV

### DIFF
--- a/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/util/OmemoMessageBuilder.java
+++ b/smack-omemo/src/main/java/org/jivesoftware/smackx/omemo/util/OmemoMessageBuilder.java
@@ -274,13 +274,13 @@ public class OmemoMessageBuilder<T_IdKeyPair, T_IdKey, T_PreKey, T_SigPreKey, T_
     }
 
     /**
-     * Generate a 16 byte initialization vector for AES encryption.
+     * Generate a 12 byte initialization vector for AES encryption.
      *
-     * @return iv TODO javadoc me please
+     * @return iv initialization vector
      */
     public static byte[] generateIv() {
         SecureRandom random = new SecureRandom();
-        byte[] iv = new byte[16];
+        byte[] iv = new byte[12];
         random.nextBytes(iv);
         return iv;
     }


### PR DESCRIPTION
This PR fixes https://github.com/xsf/xeps/pull/894 for smack-omemo.

A while ago, the community decided to switch from 16 bytes IV to 12 bytes, as that is what most AES-GCM libraries use internally anyways. Using 16 bytes as IV would not result in improved security, as the IV is getting hashed down to 12 bytes anyways.

For quite a while now, most implementations of OMEMO supported receiving both 12 and 16 byte IV, but kept sending 16 for a grace period. Now is the time to make the switch to sending 12.