### PR TITLE
Fixes a failure to call left()

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -239,12 +239,12 @@ public class MultiUserChat {
                             presence.getFrom().equals(myRoomJID),
                             mucUser,
                             from);
-                    } else {
-                        // An occupant has left the room
-                        if (!isUserStatusModification) {
-                            for (ParticipantStatusListener listener : participantStatusListeners) {
-                                listener.left(from);
-                            }
+                    }
+
+                    // An occupant has left the room
+                    if (!isUserStatusModification) {
+                        for (ParticipantStatusListener listener : participantStatusListeners) {
+                            listener.left(from);
                         }
                     }
                     break;


### PR DESCRIPTION
for occupants that leave with a status.

We see presence like this coming from a prosody MUC:
```xml
<presence to='focus@auth.meet.jit.si/focus133654828839' from='torture319875@conference.meet.jit.si/279b2764' type='unavailable'>
  <status>Kicked: recipient unavailable</status>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <item affiliation='owner' jid='279b2764-ca7e-4f5a-8c5a-148ce31a29a8@meet.jit.si/pC0pYlU8' role='none'></item>
    <status code='333'/>
  </x>
</presence>
```

Smack recognizes that there is *a* status code, but doesn't handle [code 333](https://xmpp.org/extensions/xep-0045.html#service-error-kick) explicitly in `checkPresenceCode`, thus failing to call any of the callbacks.

I think presence with type `unavailable` should always result in calling `left()`, which is why I did the change this way. As a side effect, unavailable presence with codes 307 (kicked) and 301 (banned) will call both `kicked` (or `banned`) and `left`. If this is not desired for some reason I can change the patch.