### PR TITLE
Replace JUnit4 with JUnit5 in `smack-extensions`.

### DIFF
--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/ExtensionsInitializerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/ExtensionsInitializerTest.java
@@ -16,13 +16,13 @@
  */
 package org.jivesoftware.smackx;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.jivesoftware.smack.extensions.ExtensionsInitializer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExtensionsInitializerTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/amp/AMPExtensionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/amp/AMPExtensionTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.amp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,15 +30,15 @@ import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smackx.amp.packet.AMPExtension;
 import org.jivesoftware.smackx.amp.provider.AMPExtensionProvider;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AMPExtensionTest {
 
     private InputStream CORRECT_SENDING_STANZA_STREAM;
     private InputStream INCORRECT_RECEIVING_STANZA_STREAM;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         CORRECT_SENDING_STANZA_STREAM = getClass().getResourceAsStream("correct_stanza_test.xml");
         INCORRECT_RECEIVING_STANZA_STREAM = getClass().getResourceAsStream("incorrect_stanza_test.xml");

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/BlockContactsIQTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/BlockContactsIQTest.java
@@ -26,7 +26,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 
 import org.jivesoftware.smackx.blocking.element.BlockContactsIQ;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/BlockedErrorExtensionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/BlockedErrorExtensionTest.java
@@ -24,7 +24,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 
 import org.jivesoftware.smackx.blocking.element.BlockedErrorExtension;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BlockedErrorExtensionTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/GetBlockingListTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/GetBlockingListTest.java
@@ -25,7 +25,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 
 import org.jivesoftware.smackx.blocking.element.BlockListIQ;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.impl.JidCreate;
 
 public class GetBlockingListTest {

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/UnblockContactsIQTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/UnblockContactsIQTest.java
@@ -28,7 +28,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 
 import org.jivesoftware.smackx.blocking.element.UnblockContactsIQ;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bob/BoBIQTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bob/BoBIQTest.java
@@ -27,7 +27,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 
 import org.jivesoftware.smackx.bob.element.BoBIQ;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.impl.JidCreate;
 
 public class BoBIQTest extends SmackTestSuite {

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/CloseListenerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/CloseListenerTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -27,7 +27,7 @@ import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.bytestreams.ibb.packet.Close;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.JidTestUtil;
 import org.mockito.ArgumentCaptor;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/DataListenerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/DataListenerTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -28,7 +28,7 @@ import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.bytestreams.ibb.packet.Data;
 import org.jivesoftware.smackx.bytestreams.ibb.packet.DataPacketExtension;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.JidTestUtil;
 import org.mockito.ArgumentCaptor;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamManagerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamManagerTest.java
@@ -16,10 +16,11 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import org.jivesoftware.smack.SmackException;
@@ -36,8 +37,8 @@ import org.jivesoftware.smackx.bytestreams.ibb.packet.Open;
 import org.jivesoftware.util.ConnectionUtils;
 import org.jivesoftware.util.Protocol;
 import org.jivesoftware.util.Verification;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.JidTestUtil;
 
@@ -65,7 +66,7 @@ public class InBandBytestreamManagerTest extends InitExtensions {
      * @throws SmackException if Smack detected an exceptional situation.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    @Before
+    @BeforeEach
     public void setup() throws XMPPException, SmackException, InterruptedException {
 
         // build protocol verifier
@@ -130,10 +131,12 @@ public class InBandBytestreamManagerTest extends InitExtensions {
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowTooBigDefaultBlockSize() {
         InBandBytestreamManager byteStreamManager = InBandBytestreamManager.getByteStreamManager(connection);
-        byteStreamManager.setDefaultBlockSize(1000000);
+        assertThrows(IllegalArgumentException.class, () -> {
+            byteStreamManager.setDefaultBlockSize(1000000);
+        });
     }
 
     @Test
@@ -143,10 +146,12 @@ public class InBandBytestreamManagerTest extends InitExtensions {
         assertEquals(1024, byteStreamManager.getDefaultBlockSize());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowTooBigMaximumBlockSize() {
         InBandBytestreamManager byteStreamManager = InBandBytestreamManager.getByteStreamManager(connection);
-        byteStreamManager.setMaximumBlockSize(1000000);
+        assertThrows(IllegalArgumentException.class, () -> {
+            byteStreamManager.setMaximumBlockSize(1000000);
+        });
     }
 
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamRequestTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamRequestTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -29,8 +29,8 @@ import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.bytestreams.ibb.packet.Open;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.JidTestUtil;
 import org.mockito.ArgumentCaptor;
@@ -53,7 +53,7 @@ public class InBandBytestreamRequestTest extends InitExtensions {
     /**
      * Initialize fields used in the tests.
      */
-    @Before
+    @BeforeEach
     public void setup() {
 
         // mock connection

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamSessionMessageTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamSessionMessageTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,8 +42,8 @@ import org.jivesoftware.smackx.bytestreams.ibb.packet.Open;
 import org.jivesoftware.util.ConnectionUtils;
 import org.jivesoftware.util.Protocol;
 import org.jivesoftware.util.Verification;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.JidTestUtil;
 import org.powermock.reflect.Whitebox;
@@ -80,7 +80,7 @@ public class InBandBytestreamSessionMessageTest extends InitExtensions {
      * @throws SmackException if Smack detected an exceptional situation.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    @Before
+    @BeforeEach
     public void setup() throws XMPPException, SmackException, InterruptedException {
 
         // build protocol verifier

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamSessionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamSessionTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,8 +41,8 @@ import org.jivesoftware.smackx.bytestreams.ibb.packet.Open;
 import org.jivesoftware.util.ConnectionUtils;
 import org.jivesoftware.util.Protocol;
 import org.jivesoftware.util.Verification;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.JidTestUtil;
 import org.powermock.reflect.Whitebox;
@@ -80,7 +80,7 @@ public class InBandBytestreamSessionTest extends InitExtensions {
      * @throws SmackException if Smack detected an exceptional situation.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    @Before
+    @BeforeEach
     public void setup() throws XMPPException, SmackException, InterruptedException {
 
         // build protocol verifier

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InitiationListenerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/InitiationListenerTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -29,8 +29,8 @@ import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.bytestreams.BytestreamRequest;
 import org.jivesoftware.smackx.bytestreams.ibb.packet.Open;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.JidTestUtil;
 import org.jxmpp.jid.impl.JidCreate;
@@ -56,7 +56,7 @@ public class InitiationListenerTest extends InitExtensions {
     /**
      * Initialize fields used in the tests.
      */
-    @Before
+    @BeforeEach
     public void setup() {
 
         // mock connection

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/packet/CloseTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/packet/CloseTest.java
@@ -17,7 +17,8 @@
 package org.jivesoftware.smackx.bytestreams.ibb.packet;
 
 import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Properties;
 
@@ -27,7 +28,7 @@ import org.jivesoftware.smack.packet.StreamOpen;
 import org.jivesoftware.smackx.InitExtensions;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.impl.JidCreate;
 
 /**
@@ -37,14 +38,18 @@ import org.jxmpp.jid.impl.JidCreate;
  */
 public class CloseTest extends InitExtensions {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArguments1() {
-        new Close(null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Close(null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArguments2() {
-        new Close("");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Close("");
+        });
     }
 
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/packet/DataPacketExtensionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/packet/DataPacketExtensionTest.java
@@ -17,8 +17,9 @@
 package org.jivesoftware.smackx.bytestreams.ibb.packet;
 
 import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
@@ -26,7 +27,7 @@ import java.util.Properties;
 import org.jivesoftware.smackx.InitExtensions;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for the DataPacketExtension class.
@@ -35,29 +36,39 @@ import org.junit.Test;
  */
 public class DataPacketExtensionTest extends InitExtensions {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArgument1() {
-        new DataPacketExtension(null, 0, "data");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DataPacketExtension(null, 0, "data");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArgument2() {
-        new DataPacketExtension("", 0, "data");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DataPacketExtension("", 0, "data");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArgument3() {
-        new DataPacketExtension("sessionID", -1, "data");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DataPacketExtension("sessionID", -1, "data");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArgument4() {
-        new DataPacketExtension("sessionID", 70000, "data");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DataPacketExtension("sessionID", 70000, "data");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArgument5() {
-        new DataPacketExtension("sessionID", 0, null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DataPacketExtension("sessionID", 0, null);
+        });
     }
 
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/packet/DataTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/packet/DataTest.java
@@ -17,7 +17,8 @@
 package org.jivesoftware.smackx.bytestreams.ibb.packet;
 
 import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.util.Properties;
@@ -29,7 +30,7 @@ import org.jivesoftware.smack.util.stringencoder.Base64;
 import org.jivesoftware.smackx.InitExtensions;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.impl.JidCreate;
 
 /**
@@ -39,9 +40,11 @@ import org.jxmpp.jid.impl.JidCreate;
  */
 public class DataTest extends InitExtensions {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArgument() {
-        new Data(null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Data(null);
+        });
     }
 
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/packet/OpenTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/packet/OpenTest.java
@@ -17,7 +17,8 @@
 package org.jivesoftware.smackx.bytestreams.ibb.packet;
 
 import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Properties;
 
@@ -28,7 +29,8 @@ import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.bytestreams.ibb.InBandBytestreamManager.StanzaType;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.impl.JidCreate;
 
 /**
@@ -38,19 +40,25 @@ import org.jxmpp.jid.impl.JidCreate;
  */
 public class OpenTest extends InitExtensions {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArguments1() {
-        new Open(null, 1);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Open(null, 1);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArguments2() {
-        new Open("", 1);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Open("", 1);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotInstantiateWithInvalidArguments3() {
-        new Open("sessionID", -1);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Open("sessionID", -1);
+        });
     }
 
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/provider/OpenIQProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/provider/OpenIQProviderTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb.provider;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Properties;
 
@@ -28,7 +28,7 @@ import org.jivesoftware.smackx.bytestreams.ibb.InBandBytestreamManager.StanzaTyp
 import org.jivesoftware.smackx.bytestreams.ibb.packet.Open;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for the OpenIQProvider class.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/InitiationListenerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/InitiationListenerTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.bytestreams.socks5;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -30,8 +30,8 @@ import org.jivesoftware.smackx.bytestreams.BytestreamRequest;
 import org.jivesoftware.smackx.bytestreams.socks5.packet.Bytestream;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.JidTestUtil;
@@ -62,7 +62,7 @@ public class InitiationListenerTest {
     /**
      * Initialize fields used in the tests.
      */
-    @Before
+    @BeforeEach
     public void setup() {
 
         // mock connection

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ByteStreamManagerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ByteStreamManagerTest.java
@@ -16,13 +16,13 @@
  */
 package org.jivesoftware.smackx.bytestreams.socks5;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -56,7 +56,7 @@ import org.jivesoftware.smackx.disco.packet.DiscoverItems.Item;
 import org.jivesoftware.util.ConnectionUtils;
 import org.jivesoftware.util.Protocol;
 import org.jivesoftware.util.Verification;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.JidTestUtil;
@@ -611,8 +611,7 @@ public class Socks5ByteStreamManagerTest {
         // initiator can't connect to proxy because it is not running
         protocol.verifyAll();
         Throwable actualCause = e.getCause();
-        assertEquals("Unexpected throwable: " + actualCause + '.' + ExceptionUtil.getStackTrace(actualCause),
-                        TimeoutException.class, actualCause.getClass());
+        assertEquals(TimeoutException.class, actualCause.getClass(), "Unexpected throwable: " + actualCause + '.' + ExceptionUtil.getStackTrace(actualCause));
     }
 
     /**

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ByteStreamRequestTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ByteStreamRequestTest.java
@@ -16,11 +16,11 @@
  */
 package org.jivesoftware.smackx.bytestreams.socks5;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -37,7 +37,7 @@ import org.jivesoftware.smackx.bytestreams.socks5.packet.Bytestream;
 
 import org.jivesoftware.util.ConnectionUtils;
 import org.jivesoftware.util.Protocol;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.JidTestUtil;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ClientForInitiatorTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ClientForInitiatorTest.java
@@ -16,10 +16,10 @@
  */
 package org.jivesoftware.smackx.bytestreams.socks5;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -41,7 +41,7 @@ import org.jivesoftware.smackx.bytestreams.socks5.packet.Bytestream.StreamHost;
 import org.jivesoftware.util.ConnectionUtils;
 import org.jivesoftware.util.Protocol;
 import org.jivesoftware.util.Verification;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.JidTestUtil;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ClientTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ClientTest.java
@@ -16,10 +16,10 @@
  */
 package org.jivesoftware.smackx.bytestreams.socks5;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -32,9 +32,9 @@ import org.jivesoftware.smack.util.NetworkUtil;
 
 import org.jivesoftware.smackx.bytestreams.socks5.packet.Bytestream.StreamHost;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.JidTestUtil;
 
@@ -57,7 +57,7 @@ public class Socks5ClientTest {
      *
      * @throws Exception should not happen
      */
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         // create SOCKS5 proxy server socket
         serverSocket = NetworkUtil.getSocketOnLoopback();
@@ -333,7 +333,7 @@ public class Socks5ClientTest {
      *
      * @throws Exception should not happen
      */
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         // Avoid NPE if serverSocket could not get created for whateve reason.
         if (serverSocket != null) {

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ProxyTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5ProxyTest.java
@@ -16,11 +16,11 @@
  */
 package org.jivesoftware.smackx.bytestreams.socks5;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -35,7 +35,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for Socks5Proxy class.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/caps/EntityCapsManagerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/caps/EntityCapsManagerTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.caps;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +38,7 @@ import org.jivesoftware.smackx.disco.packet.DiscoverInfoBuilder;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.stringprep.XmppStringprepException;
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/caps/provider/CapsExtensionProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/caps/provider/CapsExtensionProviderTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.caps.provider;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.jivesoftware.smack.test.util.SmackTestUtil;
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/commands/provider/CommandsProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/commands/provider/CommandsProviderTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.commands.provider;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Stanza;
@@ -26,7 +26,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.commands.AdHocCommand;
 import org.jivesoftware.smackx.commands.packet.AdHocCommandData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CommandsProviderTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/delay/provider/DelayInformationTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/delay/provider/DelayInformationTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.delay.provider;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -40,7 +40,7 @@ import org.jivesoftware.smackx.delay.DelayInformationManager;
 import org.jivesoftware.smackx.delay.packet.DelayInformation;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.util.XmppDateTime;
 
 public class DelayInformationTest extends InitExtensions {

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/filetransfer/FileTransferNegotiatorTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/filetransfer/FileTransferNegotiatorTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.filetransfer;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.SmackException.NoResponseException;
@@ -25,15 +25,15 @@ import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.JidTestUtil;
 
 public class FileTransferNegotiatorTest extends InitExtensions {
     private DummyConnection connection;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         connection = new DummyConnection();
         connection.connect();
@@ -41,7 +41,7 @@ public class FileTransferNegotiatorTest extends InitExtensions {
         ServiceDiscoveryManager.getInstanceFor(connection);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (connection != null)
             connection.disconnect();

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/forward/ForwardedTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/forward/ForwardedTest.java
@@ -18,8 +18,9 @@ package org.jivesoftware.smackx.forward;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jivesoftware.smack.test.util.CharSequenceEquals.equalsCharSequence;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Properties;
 
@@ -31,7 +32,7 @@ import org.jivesoftware.smackx.forward.packet.Forwarded;
 import org.jivesoftware.smackx.forward.provider.ForwardedProvider;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ForwardedTest {
 
@@ -94,7 +95,7 @@ public class ForwardedTest {
         assertEquals("forwarded", parser.getName());
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void forwardedEmptyTest() throws Exception {
         XmlPullParser parser;
         String control;
@@ -104,6 +105,8 @@ public class ForwardedTest {
             .asString(outputProperties);
 
         parser = PacketParserUtils.getParserFor(control);
-        new ForwardedProvider().parse(parser);
+        assertThrows(Exception.class, () -> {
+            new ForwardedProvider().parse(parser);
+        });
     }
 }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/geoloc/packet/GeoLocationTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/geoloc/packet/GeoLocationTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.geoloc.packet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URI;
 import java.util.Calendar;
@@ -29,7 +29,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.time.packet.Time;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.util.XmppDateTime;
 
 /**

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/geoloc/provider/GeoLocationProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/geoloc/provider/GeoLocationProviderTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.geoloc.provider;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.net.URI;
 
@@ -28,7 +28,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.geoloc.packet.GeoLocation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.util.XmppDateTime;
 
 public class GeoLocationProviderTest extends InitExtensions {

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/iqlast/LastActivityTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/iqlast/LastActivityTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.iqlast;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.packet.IQ;
@@ -28,7 +28,7 @@ import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.iqlast.packet.LastActivity;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LastActivityTest extends InitExtensions {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/iqversion/VersionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/iqversion/VersionTest.java
@@ -18,8 +18,8 @@ package org.jivesoftware.smackx.iqversion;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jivesoftware.smack.test.util.CharSequenceEquals.equalsCharSequence;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.packet.IQ;
@@ -29,7 +29,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.iqversion.packet.Version;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VersionTest extends InitExtensions {
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleActionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleActionTest.java
@@ -16,13 +16,14 @@
  */
 package org.jivesoftware.smackx.jingle;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 
 import org.jivesoftware.smackx.jingle.element.JingleAction;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the JingleAction class.
@@ -39,8 +40,10 @@ public class JingleActionTest extends SmackTestSuite {
             }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void nonExistentEnumTest() {
-        JingleAction.fromString("inexistent-action");
+        assertThrows(IllegalArgumentException.class, () -> {
+            JingleAction.fromString("inexistent-action");
+        });
     }
 }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleContentTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleContentTest.java
@@ -16,33 +16,38 @@
  */
 package org.jivesoftware.smackx.jingle;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNotSame;
-import static junit.framework.TestCase.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 
 import org.jivesoftware.smackx.jingle.element.JingleContent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the JingleContent class.
  */
 public class JingleContentTest extends SmackTestSuite {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void emptyBuilderThrowsTest() {
         JingleContent.Builder builder = JingleContent.getBuilder();
-        builder.build();
+        assertThrows(IllegalArgumentException.class, () -> {
+            builder.build();
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void onlyCreatorBuilderThrowsTest() {
         JingleContent.Builder builder = JingleContent.getBuilder();
         builder.setCreator(JingleContent.Creator.initiator);
-        builder.build();
+        assertThrows(IllegalArgumentException.class, () -> {
+            builder.build();
+        });
     }
 
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleErrorTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleErrorTest.java
@@ -16,7 +16,8 @@
  */
 package org.jivesoftware.smackx.jingle;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smack.test.util.TestUtils;
@@ -24,7 +25,7 @@ import org.jivesoftware.smack.test.util.TestUtils;
 import org.jivesoftware.smackx.jingle.element.JingleError;
 import org.jivesoftware.smackx.jingle.provider.JingleErrorProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the JingleError class.
@@ -59,9 +60,11 @@ public class JingleErrorTest extends SmackTestSuite {
         assertEquals(xml, error.toXML().toString());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void illegalArgumentTest() {
-        JingleError.fromString("inexistent-error");
+        assertThrows(IllegalArgumentException.class, () -> {
+            JingleError.fromString("inexistent-error");
+        });
     }
 
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleReasonTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleReasonTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.jingle;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleTest.java
@@ -16,16 +16,17 @@
  */
 package org.jivesoftware.smackx.jingle;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 
 import org.jivesoftware.smackx.jingle.element.Jingle;
 import org.jivesoftware.smackx.jingle.element.JingleAction;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.FullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.stringprep.XmppStringprepException;
@@ -35,19 +36,23 @@ import org.jxmpp.stringprep.XmppStringprepException;
  */
 public class JingleTest extends SmackTestSuite {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void emptyBuilderTest() {
         Jingle.Builder builder = Jingle.getBuilder();
-        builder.build();
+        assertThrows(IllegalArgumentException.class, () -> {
+            builder.build();
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void onlySessionIdBuilderTest() {
         String sessionId = "testSessionId";
 
         Jingle.Builder builder = Jingle.getBuilder();
         builder.setSessionId(sessionId);
-        builder.build();
+        assertThrows(IllegalArgumentException.class, () -> {
+            builder.build();
+        });
     }
 
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleUtilTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/JingleUtilTest.java
@@ -23,8 +23,8 @@ import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smackx.jingle.element.Jingle;
 import org.jivesoftware.smackx.jingle.element.JingleContent;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.FullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.stringprep.XmppStringprepException;
@@ -37,7 +37,7 @@ public class JingleUtilTest extends SmackTestSuite {
     private XMPPConnection connection;
     private JingleUtil jutil;
 
-    @Before
+    @BeforeEach
     public void setup() {
         connection = new DummyConnection(
                 DummyConnection.getDummyConfigurationBuilder()

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/provider/JingleContentProviderManagerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/provider/JingleContentProviderManagerTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.jingle.provider;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 
@@ -26,7 +26,7 @@ import org.jivesoftware.smackx.jingle.transports.jingle_ibb.provider.JingleIBBTr
 import org.jivesoftware.smackx.jingle.transports.jingle_s5b.elements.JingleS5BTransport;
 import org.jivesoftware.smackx.jingle.transports.jingle_s5b.provider.JingleS5BTransportProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the JingleContentProviderManager.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/provider/JingleProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/provider/JingleProviderTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.jingle.provider;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -28,7 +28,7 @@ import org.jivesoftware.smackx.jingle.element.Jingle;
 import org.jivesoftware.smackx.jingle.element.JingleContentDescription;
 import org.jivesoftware.smackx.jingle.element.JingleContentTransport;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JingleProviderTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/JingleIBBTransportTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/transports/jingle_ibb/JingleIBBTransportTest.java
@@ -16,10 +16,10 @@
  */
 package org.jivesoftware.smackx.jingle.transports.jingle_ibb;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNotSame;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smack.test.util.TestUtils;
@@ -28,7 +28,7 @@ import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smackx.jingle.transports.jingle_ibb.element.JingleIBBTransport;
 import org.jivesoftware.smackx.jingle.transports.jingle_ibb.provider.JingleIBBTransportProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test JingleIBBTransport provider and element.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/transports/jingle_s5b/JingleS5BTransportTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jingle/transports/jingle_s5b/JingleS5BTransportTest.java
@@ -16,11 +16,12 @@
  */
 package org.jivesoftware.smackx.jingle.transports.jingle_s5b;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.UnknownHostException;
 
@@ -33,7 +34,7 @@ import org.jivesoftware.smackx.jingle.transports.jingle_s5b.elements.JingleS5BTr
 import org.jivesoftware.smackx.jingle.transports.jingle_s5b.elements.JingleS5BTransportInfo;
 import org.jivesoftware.smackx.jingle.transports.jingle_s5b.provider.JingleS5BTransportProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.FullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.stringprep.XmppStringprepException;
@@ -178,30 +179,36 @@ public class JingleS5BTransportTest extends SmackTestSuite {
         assertEquals(candidateActivated, candidateActivatedTransport.toXML().toString());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void candidateBuilderInvalidPortTest() {
-        JingleS5BTransportCandidate.getBuilder().setPort(-5);
+        assertThrows(IllegalArgumentException.class, () -> {
+            JingleS5BTransportCandidate.getBuilder().setPort(-5);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void candidateBuilderInvalidPriorityTest() {
-        JingleS5BTransportCandidate.getBuilder().setPriority(-1000);
+        assertThrows(IllegalArgumentException.class, () -> {
+            JingleS5BTransportCandidate.getBuilder().setPriority(-1000);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void transportCandidateIllegalPriorityTest() throws XmppStringprepException, UnknownHostException {
         FullJid jid = JidCreate.fullFrom("test@test.test/test");
-        @SuppressWarnings("unused")
-        JingleS5BTransportCandidate candidate = new JingleS5BTransportCandidate(
-                "cid", "localhost", jid, 5555, -30, JingleS5BTransportCandidate.Type.proxy);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new JingleS5BTransportCandidate(
+                    "cid", "localhost", jid, 5555, -30, JingleS5BTransportCandidate.Type.proxy);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void transportCandidateIllegalPortTest() throws XmppStringprepException, UnknownHostException {
         FullJid jid = JidCreate.fullFrom("test@test.test/test");
-        @SuppressWarnings("unused")
-        JingleS5BTransportCandidate candidate = new JingleS5BTransportCandidate(
-                "cid", "host", jid, -5555, 30, JingleS5BTransportCandidate.Type.proxy);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new JingleS5BTransportCandidate(
+                    "cid", "host", jid, -5555, 30, JingleS5BTransportCandidate.Type.proxy);
+        });
     }
 
     @Test
@@ -221,8 +228,10 @@ public class JingleS5BTransportTest extends SmackTestSuite {
         assertEquals(streamHost.toXML().toString(), candidate.getStreamHost().toXML().toString());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void typeFromIllegalStringTest() {
-        JingleS5BTransportCandidate.Type.fromString("illegal-type");
+        assertThrows(IllegalArgumentException.class, () -> {
+            JingleS5BTransportCandidate.Type.fromString("illegal-type");
+        });
     }
 }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/jiveproperties/JivePropertiesExtensionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/jiveproperties/JivePropertiesExtensionTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.jiveproperties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.util.PacketParserUtils;
@@ -25,18 +25,18 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.jiveproperties.packet.JivePropertiesExtension;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JivePropertiesExtensionTest extends InitExtensions {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         JivePropertiesManager.setJavaObjectEnabled(true);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         JivePropertiesManager.setJavaObjectEnabled(false);
     }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/last_interaction/IdleTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/last_interaction/IdleTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.last_interaction;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
 import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Date;
 
@@ -31,7 +31,7 @@ import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smackx.last_interaction.element.IdleElement;
 import org.jivesoftware.smackx.last_interaction.provider.IdleProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.util.XmppDateTime;
 
 public class IdleTest extends SmackTestSuite {

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/mediaelement/element/MediaElementTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/mediaelement/element/MediaElementTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.mediaelement.element;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/mediaelement/provider/MediaElementProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/mediaelement/provider/MediaElementProviderTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.mediaelement.provider;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.List;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/message_correct/MessageCorrectExtensionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/message_correct/MessageCorrectExtensionTest.java
@@ -23,7 +23,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 
 import org.jivesoftware.smackx.message_correct.element.MessageCorrectExtension;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MessageCorrectExtensionTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/mood/MoodConcretisationTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/mood/MoodConcretisationTest.java
@@ -16,10 +16,10 @@
  */
 package org.jivesoftware.smackx.mood;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
 import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.provider.ProviderManager;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
@@ -31,7 +31,7 @@ import org.jivesoftware.smackx.mood.element.MoodElement;
 import org.jivesoftware.smackx.mood.provider.MoodProvider;
 import org.jivesoftware.smackx.mood.provider.SimpleMoodConcretisationProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test checks, if extending XEP-0107: User Mood using custom mood concretisations works.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/mood/MoodElementTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/mood/MoodElementTest.java
@@ -16,10 +16,11 @@
  */
 package org.jivesoftware.smackx.mood;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNull;
 import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smack.test.util.TestUtils;
@@ -29,7 +30,7 @@ import org.jivesoftware.smack.xml.XmlPullParserException;
 import org.jivesoftware.smackx.mood.element.MoodElement;
 import org.jivesoftware.smackx.mood.provider.MoodProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MoodElementTest extends SmackTestSuite {
 
@@ -51,9 +52,11 @@ public class MoodElementTest extends SmackTestSuite {
         assertEquals(xml, parsed.toXML().toString());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void illegalArgumentsTest() {
-        new MoodElement(null, "Text alone is not allowed.");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new MoodElement(null, "Text alone is not allowed.");
+        });
     }
 
     @Test
@@ -71,13 +74,15 @@ public class MoodElementTest extends SmackTestSuite {
         assertEquals(empty.toXML().toString(), emptyParsed.toXML().toString());
     }
 
-    @Test(expected = XmlPullParserException.class)
+    @Test
     public void unknownMoodValueExceptionTest() throws Exception {
         String xml =
                 "<mood xmlns='http://jabber.org/protocol/mood'>" +
                     "<unknown/>" +
                 "</mood>";
         XmlPullParser parser = TestUtils.getParser(xml);
-        MoodProvider.INSTANCE.parse(parser);
+        assertThrows(XmlPullParserException.class, () -> {
+            MoodProvider.INSTANCE.parse(parser);
+        });
     }
 }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/mood/MoodManagerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/mood/MoodManagerTest.java
@@ -16,10 +16,10 @@
  */
 package org.jivesoftware.smackx.mood;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.StanzaBuilder;
@@ -27,7 +27,7 @@ import org.jivesoftware.smack.test.util.SmackTestSuite;
 
 import org.jivesoftware.smackx.mood.element.MoodElement;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MoodManagerTest extends SmackTestSuite {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/muc/RoomInfoTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/muc/RoomInfoTest.java
@@ -16,14 +16,14 @@
  */
 package org.jivesoftware.smackx.muc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smackx.disco.packet.DiscoverInfo;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RoomInfoTest {
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/muc/packet/MUCUserTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/muc/packet/MUCUserTest.java
@@ -16,15 +16,15 @@
  */
 package org.jivesoftware.smackx.muc.packet;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import org.jivesoftware.smackx.muc.packet.MUCUser.Status;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MUCUserTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/ping/PingTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/ping/PingTest.java
@@ -18,10 +18,10 @@ package org.jivesoftware.smackx.ping;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jivesoftware.smack.test.util.CharSequenceEquals.equalsCharSequence;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.jxmpp.jid.JidTestUtil.DUMMY_AT_EXAMPLE_ORG;
 
 import java.io.IOException;
@@ -38,7 +38,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.ping.packet.Ping;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PingTest extends InitExtensions {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/privacy/provider/PrivacyProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/privacy/provider/PrivacyProviderTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.privacy.provider;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.privacy.packet.Privacy;
 import org.jivesoftware.smackx.privacy.packet.PrivacyItem;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PrivacyProviderTest extends InitExtensions {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/AffiliationsExtensionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/AffiliationsExtensionTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.jivesoftware.smackx.pubsub.Affiliation.Type;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.JidTestUtil;
 import org.xml.sax.SAXException;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/ConfigureFormTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/ConfigureFormTest.java
@@ -16,8 +16,9 @@
  */
 package org.jivesoftware.smackx.pubsub;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -38,7 +39,7 @@ import org.jivesoftware.smackx.disco.packet.DiscoverInfoBuilder;
 import org.jivesoftware.smackx.pubsub.packet.PubSub;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Configure form test.
@@ -84,8 +85,8 @@ public class ConfigureFormTest extends InitExtensions {
         }
     }
 
-    @Test(expected = SmackException.class)
-    public void getConfigFormWithTimeout() throws XMPPException, SmackException, InterruptedException {
+    @Test
+    public void getConfigFormWithTimeout() throws XMPPException, InterruptedException {
         ThreadedDummyConnection con = new ThreadedDummyConnection();
         PubSubManager mgr = new PubSubManager(con, PubSubManagerTest.DUMMY_PUBSUB_SERVICE);
         DiscoverInfoBuilder info = DiscoverInfo.builder("disco-result");
@@ -95,12 +96,15 @@ public class ConfigureFormTest extends InitExtensions {
         DiscoverInfo discoverInfo = info.build();
         con.addIQReply(discoverInfo);
 
-        Node node = mgr.getNode("princely_musings");
+        assertThrows(SmackException.class, () -> {
+            // TODO: This method should not throw any exception but currently does.
+            Node node = mgr.getNode("princely_musings");
 
-        SmackConfiguration.setDefaultReplyTimeout(100);
-        con.setTimeout();
+            SmackConfiguration.setDefaultReplyTimeout(100);
+            con.setTimeout();
 
-        node.getNodeConfiguration();
+            node.getNodeConfiguration();
+        });
     }
 
     @Test

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/ItemValidationTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/ItemValidationTest.java
@@ -17,8 +17,8 @@
 package org.jivesoftware.smackx.pubsub;
 
 import static org.jivesoftware.smack.test.util.XmlUnitUtils.assertXmlSimilar;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.ThreadedDummyConnection;
 import org.jivesoftware.smack.packet.ExtensionElement;
@@ -30,9 +30,9 @@ import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.pubsub.packet.PubSubNamespace;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Item validation test.
@@ -42,7 +42,7 @@ import org.junit.Test;
 public class ItemValidationTest extends InitExtensions {
     private ThreadedDummyConnection connection;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         // Uncomment this to enable debug output
         // SmackConfiguration.DEBUG = true;
@@ -52,7 +52,7 @@ public class ItemValidationTest extends InitExtensions {
         connection.login();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (connection != null)
             connection.disconnect();

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/PubSubManagerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/PubSubManagerTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.pubsub;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -26,7 +26,7 @@ import org.jivesoftware.smack.XMPPException;
 
 import org.jivesoftware.smackx.pubsub.packet.PubSub;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.stringprep.XmppStringprepException;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/PubSubNodeTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/PubSubNodeTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.pubsub;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -38,7 +38,7 @@ import org.jivesoftware.smackx.pubsub.packet.PubSubNamespace;
 
 import org.jivesoftware.util.ConnectionUtils;
 import org.jivesoftware.util.Protocol;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.JidTestUtil;
 import org.jxmpp.jid.impl.JidCreate;
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/SimplePayloadTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/SimplePayloadTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.pubsub;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SimplePayloadTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/provider/PubSubProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/provider/PubSubProviderTest.java
@@ -18,7 +18,7 @@ package org.jivesoftware.smackx.pubsub.provider;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jivesoftware.smack.test.util.CharSequenceEquals.equalsCharSequence;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -31,7 +31,7 @@ import org.jivesoftware.smackx.pubsub.Subscription;
 import org.jivesoftware.smackx.pubsub.SubscriptionsExtension;
 import org.jivesoftware.smackx.pubsub.packet.PubSub;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PubSubProviderTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/receipts/DeliveryReceiptTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/receipts/DeliveryReceiptTest.java
@@ -18,10 +18,10 @@ package org.jivesoftware.smackx.receipts;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jivesoftware.smack.test.util.CharSequenceEquals.equalsCharSequence;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Properties;
 
@@ -38,7 +38,7 @@ import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.receipts.DeliveryReceiptManager.AutoReceiptMode;
 
 import com.jamesmurty.utils.XMLBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.Jid;
 
 public class DeliveryReceiptTest extends InitExtensions {

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/rsm/provider/RSMSetProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/rsm/provider/RSMSetProviderTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.rsm.provider;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.util.PacketParserUtils;
@@ -25,7 +25,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.rsm.packet.RSMSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RSMSetProviderTest extends InitExtensions {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/shim/provider/HeadersProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/shim/provider/HeadersProviderTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.shim.provider;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.test.util.TestUtils;
@@ -26,7 +26,7 @@ import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smackx.shim.packet.Header;
 import org.jivesoftware.smackx.shim.packet.HeadersExtension;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HeadersProviderTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/time/packet/TimeTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/time/packet/TimeTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.time.packet;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -24,7 +24,7 @@ import java.util.TimeZone;
 
 import org.jivesoftware.smackx.InitExtensions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TimeTest extends InitExtensions {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/time/provider/TimeProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/time/provider/TimeProviderTest.java
@@ -16,15 +16,15 @@
  */
 package org.jivesoftware.smackx.time.provider;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.util.PacketParserUtils;
 
 import org.jivesoftware.smackx.time.packet.Time;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TimeProviderTest {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/usertune/UserTuneElementTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/usertune/UserTuneElementTest.java
@@ -32,7 +32,7 @@ import org.jivesoftware.smack.xml.XmlPullParserException;
 import org.jivesoftware.smackx.usertune.element.UserTuneElement;
 import org.jivesoftware.smackx.usertune.provider.UserTuneProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/usertune/UserTuneManagerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/usertune/UserTuneManagerTest.java
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.usertune;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -29,7 +29,7 @@ import org.jivesoftware.smack.test.util.SmackTestSuite;
 
 import org.jivesoftware.smackx.usertune.element.UserTuneElement;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UserTuneManagerTest extends SmackTestSuite{
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.vcardtemp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
@@ -27,7 +27,7 @@ import org.jivesoftware.smack.util.stringencoder.Base64;
 import org.jivesoftware.smackx.InitExtensions;
 import org.jivesoftware.smackx.vcardtemp.packet.VCard;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VCardTest extends InitExtensions {
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/xdata/packet/DataFormTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/xdata/packet/DataFormTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.xdata.packet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.jivesoftware.smack.packet.Element;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
@@ -34,7 +34,7 @@ import org.jivesoftware.smackx.xdatalayout.packet.DataLayout.Text;
 import org.jivesoftware.smackx.xdatavalidation.packet.ValidateElement;
 import org.jivesoftware.smackx.xdatavalidation.packet.ValidateElement.RangeValidateElement;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for DataForm reading and parsing.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/xdatalayout/packet/DataLayoutTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/xdatalayout/packet/DataLayoutTest.java
@@ -16,8 +16,8 @@
  */
 package org.jivesoftware.smackx.xdatalayout.packet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -34,7 +34,7 @@ import org.jivesoftware.smackx.xdatalayout.packet.DataLayout.Section;
 import org.jivesoftware.smackx.xdatalayout.packet.DataLayout.Text;
 import org.jivesoftware.smackx.xdatalayout.provider.DataLayoutProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for DataForm reading and parsing.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/xdatavalidation/DataValidationHelperTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/xdatavalidation/DataValidationHelperTest.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.smackx.xdatavalidation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jivesoftware.smackx.xdata.FormField;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/xdatavalidation/provider/DataValidationTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/xdatavalidation/provider/DataValidationTest.java
@@ -16,10 +16,10 @@
  */
 package org.jivesoftware.smackx.xdatavalidation.provider;
 
- import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/xhtmlim/provider/XHTMLExtensionProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/xhtmlim/provider/XHTMLExtensionProviderTest.java
@@ -30,7 +30,7 @@ import org.jivesoftware.smack.xml.XmlPullParserException;
 
 import org.jivesoftware.smackx.xhtmlim.packet.XHTMLExtension;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class XHTMLExtensionProviderTest {
     public static final String XHTML_EXTENSION_SAMPLE_RESOURCE_NAME = "xhtml.xml";

--- a/smack-extensions/src/test/java/org/jivesoftware/util/Protocol.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/util/Protocol.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.LinkedList;

--- a/smack-extensions/src/test/java/org/jivesoftware/util/Verification.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/util/Verification.java
@@ -16,7 +16,7 @@
  */
 package org.jivesoftware.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Stanza;


### PR DESCRIPTION
This PR concludes migration of `smack-extensions` module, from JUnit4 to JUnit5.
`mockito2` and `jUnit-vintage-engine` are required by both JUnit4 and JUnit5, hence remove them as `JUnit4` specific dependencies and provide them in project testing dependencies.