### PR TITLE
Bouncy Castle 1.65 instead of 1.64

### DIFF
--- a/smack-core/build.gradle
+++ b/smack-core/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 	testCompile "org.assertj:assertj-core:3.11.1"
 	testCompile "org.xmlunit:xmlunit-assertj:$xmlUnitVersion"
 	testCompile 'com.jamesmurty.utils:java-xmlbuilder:1.2'
-	testCompile 'org.bouncycastle:bcprov-jdk15on:1.64'
+	testCompile 'org.bouncycastle:bcprov-jdk15on:1.65'
 	testCompile 'com.google.guava:guava:28.2-jre'
 	testCompile 'org.jgrapht:jgrapht-io:1.3.1'
 }


### PR DESCRIPTION
Bouncy Castle 1.65 instead of 1.64: https://www.bouncycastle.org/releasenotes.html
- http://www.bouncycastle.org/latest_releases.html