### PR TITLE
Bump pgpainless to 0.0.1-alpha11 and test-depend on bcprov

### DIFF
--- a/smack-openpgp/build.gradle
+++ b/smack-openpgp/build.gradle
@@ -8,7 +8,9 @@ dependencies {
 	compile project(':smack-extensions')
 	compile project(':smack-experimental')
 
-	compile 'org.pgpainless:pgpainless-core:0.0.1-alpha7'
+	api 'org.pgpainless:pgpainless-core:0.0.1-alpha11'
+
+	testImplementation "org.bouncycastle:bcprov-jdk15on:1.65"
 
 	testCompile project(path: ":smack-core", configuration: "testRuntime")
 	testCompile group: 'commons-io', name: 'commons-io', version: "$commonsIoVersion"

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
@@ -138,7 +138,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
 
         OpenPgpV4Fingerprint decryptionFingerprint = decrypted.getMetadata().getDecryptionFingerprint();
         assertTrue(bobSelf.getSecretKeys().contains(decryptionFingerprint.getKeyId()));
-        assertTrue(decrypted.getMetadata().getVerifiedSignaturesFingerprints().contains(aliceFingerprint));
+        assertTrue(decrypted.getMetadata().getVerifiedSignatureKeyFingerprints().contains(aliceFingerprint));
 
         assertEquals(OpenPgpMessage.State.signcrypt, decrypted.getState());
         SigncryptElement decryptedSignCrypt = (SigncryptElement) decrypted.getOpenPgpContentElement();
@@ -158,7 +158,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
 
         decryptionFingerprint = decrypted.getMetadata().getDecryptionFingerprint();
         assertTrue(bobSelf.getSecretKeys().contains(decryptionFingerprint.getKeyId()));
-        assertTrue(decrypted.getMetadata().getVerifiedSignaturesFingerprints().isEmpty());
+        assertTrue(decrypted.getMetadata().getVerifiedSignatureKeyFingerprints().isEmpty());
 
         assertEquals(OpenPgpMessage.State.crypt, decrypted.getState());
         CryptElement decryptedCrypt = (CryptElement) decrypted.getOpenPgpContentElement();
@@ -177,7 +177,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
         decrypted = bobProvider.decryptAndOrVerify(encrypted.getElement(), bobSelf, aliceForBob);
 
         assertNull(decrypted.getMetadata().getDecryptionFingerprint());
-        assertTrue(decrypted.getMetadata().getVerifiedSignaturesFingerprints().contains(aliceFingerprint));
+        assertTrue(decrypted.getMetadata().getVerifiedSignatureKeyFingerprints().contains(aliceFingerprint));
 
         assertEquals(OpenPgpMessage.State.sign, decrypted.getState());
         SignElement decryptedSign = (SignElement) decrypted.getOpenPgpContentElement();


### PR DESCRIPTION
smack-openpgp is now transitively depending on bcpg through pgpainless 0.0.1-alpha9 (alpha11).
That means that only bcprov needs to be declared as a dependency in smack-openpgp's build file.