### PR TITLE
Remove one subproject from the nonStrictJavadocProjects list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,6 @@ allprojects {
 			':smack-jingle-old',
 			':smack-legacy',
 			':smack-omemo',
-			':smack-tcp',
 		].collect{ project(it) }
 		// Lazily evaluate the Android bootClasspath and offline
 		// Javadoc using a closure, so that targets which do not


### PR DESCRIPTION
The purpose of nonStrictJavadocProjects inside build.gradle is to allow the constituted subprojects to be exempted from `Xwerror`s.
However removing `smack-tcp` from the list has produced no warnings or errors on `gradle build`.