### PR TITLE
fix: Minimizes the number of disco-info on join room.

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -18,9 +18,7 @@
 package org.jivesoftware.smackx.muc;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -88,7 +86,6 @@ import org.jxmpp.jid.EntityJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
-import org.jxmpp.util.cache.ExpirationCache;
 
 /**
  * A MultiUserChat room (XEP-45), created with {@link MultiUserChatManager#getMultiUserChat(EntityBareJid)}.
@@ -111,9 +108,6 @@ import org.jxmpp.util.cache.ExpirationCache;
  */
 public class MultiUserChat {
     private static final Logger LOGGER = Logger.getLogger(MultiUserChat.class.getName());
-
-    private static final ExpirationCache<DomainBareJid, Void> KNOWN_MUC_SERVICES = new ExpirationCache<>(
-                    100, 1000 * 60 * 60 * 24);
 
     private final XMPPConnection connection;
     private final EntityBareJid room;
@@ -340,12 +334,8 @@ public class MultiUserChat {
     private Presence enter(MucEnterConfiguration conf) throws NotConnectedException, NoResponseException,
                     XMPPErrorException, InterruptedException, NotAMucServiceException {
         final DomainBareJid mucService = room.asDomainBareJid();
-        if (!KNOWN_MUC_SERVICES.containsKey(mucService)) {
-            if (multiUserChatManager.providesMucService(mucService)) {
-                KNOWN_MUC_SERVICES.put(mucService, null);
-            } else {
-                throw new NotAMucServiceException(this);
-            }
+        if (!multiUserChatManager.providesMucService(mucService)) {
+            throw new NotAMucServiceException(this);
         }
         // We enter a room by sending a presence packet where the "to"
         // field is in the form "roomName@service/nickname"

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -18,7 +18,9 @@
 package org.jivesoftware.smackx.muc;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;


### PR DESCRIPTION
Moves the known muc services to common place to avoid disco-info on every created MultiUserChat.

I cannot run gradle check because of having the same filename twice (ignorecase).
