### PR TITLE
Remove constructor dependency on XMPPConnection from OpenPgpProvider

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox/OXSecretKeyBackupIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox/OXSecretKeyBackupIntegrationTest.java
@@ -122,7 +122,7 @@ public class OXSecretKeyBackupIntegrationTest extends AbstractOpenPgpIntegration
 
         OpenPgpStore beforeStore = new FileBasedOpenPgpStore(beforePath);
         beforeStore.setKeyRingProtector(new UnprotectedKeysProtector());
-        PainlessOpenPgpProvider beforeProvider = new PainlessOpenPgpProvider(aliceConnection, beforeStore);
+        PainlessOpenPgpProvider beforeProvider = new PainlessOpenPgpProvider(beforeStore);
         openPgpManager = OpenPgpManager.getInstanceFor(aliceConnection);
         openPgpManager.setOpenPgpProvider(beforeProvider);
 
@@ -155,7 +155,7 @@ public class OXSecretKeyBackupIntegrationTest extends AbstractOpenPgpIntegration
 
         FileBasedOpenPgpStore afterStore = new FileBasedOpenPgpStore(afterPath);
         afterStore.setKeyRingProtector(new UnprotectedKeysProtector());
-        PainlessOpenPgpProvider afterProvider = new PainlessOpenPgpProvider(aliceConnection, afterStore);
+        PainlessOpenPgpProvider afterProvider = new PainlessOpenPgpProvider(afterStore);
         openPgpManager.setOpenPgpProvider(afterProvider);
 
         OpenPgpV4Fingerprint fingerprint = openPgpManager.restoreSecretKeyServerBackup(new AskForBackupCodeCallback() {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingIntegrationTest.java
@@ -114,8 +114,8 @@ public class OXInstantMessagingIntegrationTest extends AbstractOpenPgpIntegratio
         FileBasedOpenPgpStore bobStore = new FileBasedOpenPgpStore(bobStorePath);
         bobStore.setKeyRingProtector(new UnprotectedKeysProtector());
 
-        PainlessOpenPgpProvider aliceProvider = new PainlessOpenPgpProvider(aliceConnection, aliceStore);
-        PainlessOpenPgpProvider bobProvider = new PainlessOpenPgpProvider(bobConnection, bobStore);
+        PainlessOpenPgpProvider aliceProvider = new PainlessOpenPgpProvider(aliceStore);
+        PainlessOpenPgpProvider bobProvider = new PainlessOpenPgpProvider(bobStore);
 
         aliceOpenPgp = OpenPgpManager.getInstanceFor(aliceConnection);
         bobOpenPgp = OpenPgpManager.getInstanceFor(bobConnection);

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/OpenPgpManager.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/OpenPgpManager.java
@@ -520,7 +520,7 @@ public final class OpenPgpManager extends Manager {
      */
     public OpenPgpMessage decryptOpenPgpElement(OpenPgpElement element, OpenPgpContact sender)
             throws SmackException.NotLoggedInException, IOException, PGPException {
-        return provider.decryptAndOrVerify(element, getOpenPgpSelf(), sender);
+        return provider.decryptAndOrVerify(getAuthenticatedConnectionOrThrow(), element, getOpenPgpSelf(), sender);
     }
 
     private void incomingChatMessageListener(final EntityBareJid from, final Message message, Chat chat) {

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/OpenPgpProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/OpenPgpProvider.java
@@ -19,6 +19,7 @@ package org.jivesoftware.smackx.ox.crypto;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smackx.ox.OpenPgpContact;
 import org.jivesoftware.smackx.ox.OpenPgpMessage;
 import org.jivesoftware.smackx.ox.OpenPgpSelf;
@@ -96,12 +97,13 @@ public interface OpenPgpProvider {
      * @param element signed and or encrypted {@link OpenPgpElement}.
      * @param self our OpenPGP identity.
      * @param sender OpenPGP identity of the sender.
+     * @param connection XMPP connection used to fetch any missing keys.
      *
      * @return decrypted message as {@link OpenPgpMessage}.
      *
      * @throws IOException IO is dangerous
      * @throws PGPException PGP is brittle
      */
-    OpenPgpMessage decryptAndOrVerify(OpenPgpElement element, OpenPgpSelf self, OpenPgpContact sender)
+    OpenPgpMessage decryptAndOrVerify(XMPPConnection connection, OpenPgpElement element, OpenPgpSelf self, OpenPgpContact sender)
             throws IOException, PGPException;
 }

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/PainlessOpenPgpProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/PainlessOpenPgpProvider.java
@@ -51,11 +51,9 @@ public class PainlessOpenPgpProvider implements OpenPgpProvider {
 
     private static final Logger LOGGER = Logger.getLogger(PainlessOpenPgpProvider.class.getName());
 
-    private final XMPPConnection connection;
     private final OpenPgpStore store;
 
-    public PainlessOpenPgpProvider(XMPPConnection connection, OpenPgpStore store) {
-        this.connection = Objects.requireNonNull(connection);
+    public PainlessOpenPgpProvider(OpenPgpStore store) {
         this.store = Objects.requireNonNull(store);
     }
 
@@ -158,7 +156,7 @@ public class PainlessOpenPgpProvider implements OpenPgpProvider {
     }
 
     @Override
-    public OpenPgpMessage decryptAndOrVerify(OpenPgpElement element, final OpenPgpSelf self, final OpenPgpContact sender) throws IOException, PGPException {
+    public OpenPgpMessage decryptAndOrVerify(XMPPConnection connection, OpenPgpElement element, final OpenPgpSelf self, final OpenPgpContact sender) throws IOException, PGPException {
         ByteArrayOutputStream plainText = new ByteArrayOutputStream();
         InputStream cipherText = element.toInputStream();
 

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.jivesoftware.smack.DummyConnection;
+import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
@@ -82,8 +83,10 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
         aliceStore.setKeyRingProtector(new UnprotectedKeysProtector());
         bobStore.setKeyRingProtector(new UnprotectedKeysProtector());
 
-        PainlessOpenPgpProvider aliceProvider = new PainlessOpenPgpProvider(new DummyConnection(), aliceStore);
-        PainlessOpenPgpProvider bobProvider = new PainlessOpenPgpProvider(new DummyConnection(), bobStore);
+        XMPPConnection bobConnection = new DummyConnection();
+
+        PainlessOpenPgpProvider aliceProvider = new PainlessOpenPgpProvider(aliceStore);
+        PainlessOpenPgpProvider bobProvider = new PainlessOpenPgpProvider(bobStore);
 
         PGPKeyRing aliceKeys = aliceStore.generateKeyRing(alice);
         PGPKeyRing bobKeys = bobStore.generateKeyRing(bob);
@@ -134,7 +137,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
         encrypted = aliceProvider.signAndEncrypt(signcryptElement, aliceSelf, Collections.singleton(bobForAlice));
 
         // Decrypt and Verify
-        decrypted = bobProvider.decryptAndOrVerify(encrypted.getElement(), bobSelf, aliceForBob);
+        decrypted = bobProvider.decryptAndOrVerify(bobConnection, encrypted.getElement(), bobSelf, aliceForBob);
 
         OpenPgpV4Fingerprint decryptionFingerprint = decrypted.getMetadata().getDecryptionFingerprint();
         assertTrue(bobSelf.getSecretKeys().contains(decryptionFingerprint.getKeyId()));
@@ -154,7 +157,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
         // Encrypt
         encrypted = aliceProvider.encrypt(cryptElement, aliceSelf, Collections.singleton(bobForAlice));
 
-        decrypted = bobProvider.decryptAndOrVerify(encrypted.getElement(), bobSelf, aliceForBob);
+        decrypted = bobProvider.decryptAndOrVerify(bobConnection, encrypted.getElement(), bobSelf, aliceForBob);
 
         decryptionFingerprint = decrypted.getMetadata().getDecryptionFingerprint();
         assertTrue(bobSelf.getSecretKeys().contains(decryptionFingerprint.getKeyId()));
@@ -174,7 +177,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
         // Sign
         encrypted = aliceProvider.sign(signElement, aliceSelf);
 
-        decrypted = bobProvider.decryptAndOrVerify(encrypted.getElement(), bobSelf, aliceForBob);
+        decrypted = bobProvider.decryptAndOrVerify(bobConnection, encrypted.getElement(), bobSelf, aliceForBob);
 
         assertNull(decrypted.getMetadata().getDecryptionFingerprint());
         assertTrue(decrypted.getMetadata().getVerifiedSignatureKeyFingerprints().contains(aliceFingerprint));

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/SecretKeyBackupHelperTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/SecretKeyBackupHelperTest.java
@@ -27,7 +27,6 @@ import java.security.NoSuchProviderException;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 
 import org.jivesoftware.smackx.ox.crypto.PainlessOpenPgpProvider;
@@ -79,7 +78,7 @@ public class SecretKeyBackupHelperTest extends SmackTestSuite {
 
         // Prepare store and provider and so on...
         FileBasedOpenPgpStore store = new FileBasedOpenPgpStore(basePath);
-        PainlessOpenPgpProvider provider = new PainlessOpenPgpProvider(new DummyConnection(), store);
+        PainlessOpenPgpProvider provider = new PainlessOpenPgpProvider(store);
 
         // Generate and import key
         PGPKeyRing keyRing = PGPainless.generateKeyRing().simpleEcKeyRing("xmpp:alice@wonderland.lit");

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingManagerTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingManagerTest.java
@@ -86,8 +86,8 @@ public class OXInstantMessagingManagerTest extends SmackTestSuite {
         FileBasedOpenPgpStore aliceStore = new FileBasedOpenPgpStore(new File(basePath, "alice"));
         FileBasedOpenPgpStore bobStore = new FileBasedOpenPgpStore(new File(basePath, "bob"));
 
-        PainlessOpenPgpProvider aliceProvider = new PainlessOpenPgpProvider(aliceCon, aliceStore);
-        PainlessOpenPgpProvider bobProvider = new PainlessOpenPgpProvider(bobCon, bobStore);
+        PainlessOpenPgpProvider aliceProvider = new PainlessOpenPgpProvider(aliceStore);
+        PainlessOpenPgpProvider bobProvider = new PainlessOpenPgpProvider(bobStore);
 
         OpenPgpManager aliceOpenPgp = OpenPgpManager.getInstanceFor(aliceCon);
         OpenPgpManager bobOpenPgp = OpenPgpManager.getInstanceFor(bobCon);


### PR DESCRIPTION
While playing with dependency injection, I noticed that the OpenPgpProvider class takes an XMPPConnection as constructor argument, which prevents instantiation via DI frameworks.

I decided to remove the XMPPConnection as an constructor argument and instead require it as a method argument in the only place it is needed.