### PR TITLE
Add missing rightangle bracket to FormNode addXml()

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/FormNode.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/FormNode.java
@@ -77,6 +77,7 @@ public class FormNode extends NodeExtension {
             return;
         }
 
+        xml.rightAngleBracket();
         xml.append(configForm);
         xml.closeElement(this);
     }


### PR DESCRIPTION
I noticed that Smack was generating invalid XML when I tried to modify the access model of a PubSub node. This is for example done in `OpenPgpManager.backupSecretKeyToServer()`.

The XML that was sent looks like this:
```xml
    <iq id='KNWBF-16' type='set'>
      <pubsub xmlns='http://jabber.org/protocol/pubsub#owner'>
        <configure node='urn:xmpp:openpgp:0:secret-key'<x xmlns='jabber:x:data' type='submit'>
          <field var='FORM_TYPE'>
            <value>
              http://jabber.org/protocol/pubsub#node_config
            </value>
          </field>
          <field var='pubsub#access_model'>
            <value>
              whitelist
            </value>
          </field>
        </x>
      </configure>
    </pubsub>
    </iq>
```
Note the missing rightangle bracket after `<configure node='urn:xmpp:openpgp:0:secret-key'`.

I fixed the issue by adding the missing bracket in FormNode's `addXml()` method and now the XML looks the way it should.