### PR TITLE
Remove smack-java8-full dependency on smack-omemo-signal

### DIFF
--- a/smack-java8-full/build.gradle
+++ b/smack-java8-full/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 	api project(':smack-java7')
 	api project(':smack-legacy')
 	api project(':smack-omemo')
-	api project(':smack-omemo-signal')
 	api project(':smack-openpgp')
 	api project(':smack-resolver-minidns')
 	api project(':smack-resolver-minidns-dox')

--- a/smack-repl/build.gradle
+++ b/smack-repl/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	// smack-java*-full and since we may want to use parts of sinttest
 	// in the REPL, we simply depend sinttest.
     api project(':smack-integration-test')
+    api project(':smack-omemo-signal')
 
     compile "org.scala-lang:scala-library:$scalaVersion"
     compile "com.lihaoyi:ammonite_$scalaVersion:1.3.2"


### PR DESCRIPTION
This PR removes the API dependency from smack-java8-full on smack-omemo-signal.