### PR TITLE
OX: Make secret key backup code generator implementation replacable

### DIFF
--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/util/OfflineAttackSafeBackupCodeGenerator.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/util/OfflineAttackSafeBackupCodeGenerator.java
@@ -1,0 +1,27 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.ox.util;
+
+import org.jivesoftware.smack.util.StringUtils;
+
+public class OfflineAttackSafeBackupCodeGenerator implements SecretKeyBackupCodeGenerator {
+
+    @Override
+    public String generateSecretKeyBackupCode() {
+        return StringUtils.secureOfflineAttackSafeRandomString();
+    }
+}

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/util/SecretKeyBackupCodeGenerator.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/util/SecretKeyBackupCodeGenerator.java
@@ -1,0 +1,29 @@
+/**
+ *
+ * Copyright 2020 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.ox.util;
+
+public interface SecretKeyBackupCodeGenerator {
+
+    /**
+     * Generate a secret key backup code.
+     * The code will be used to encrypt the secret key backup which is uploaded to the server and
+     * should therefore be secure against offline attacks.
+     *
+     * @return secret key backup code. MUST NOT be null.
+     */
+    String generateSecretKeyBackupCode();
+}

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/util/SecretKeyBackupHelper.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/util/SecretKeyBackupHelper.java
@@ -20,7 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Set;
 
-import org.jivesoftware.smack.util.StringUtils;
+import org.jivesoftware.smack.util.Objects;
 import org.jivesoftware.smack.util.stringencoder.Base64;
 
 import org.jivesoftware.smackx.ox.crypto.OpenPgpProvider;
@@ -42,6 +42,8 @@ import org.pgpainless.util.Passphrase;
  */
 public class SecretKeyBackupHelper {
 
+    private static SecretKeyBackupCodeGenerator BACKUP_CODE_GENERATOR = new OfflineAttackSafeBackupCodeGenerator();
+
     /**
      * Generate a secure backup code.
      * This code can be used to encrypt a secret key backup and follows the form described in XEP-0373 §5.3.
@@ -52,7 +54,7 @@ public class SecretKeyBackupHelper {
      * @return backup code
      */
     public static String generateBackupPassword() {
-        return StringUtils.secureOfflineAttackSafeRandomString();
+        return BACKUP_CODE_GENERATOR.generateSecretKeyBackupCode();
     }
 
     /**
@@ -135,5 +137,14 @@ public class SecretKeyBackupHelper {
         }
 
         return PGPainless.readKeyRing().secretKeyRing(decrypted);
+    }
+
+    /**
+     * Overwrite the default {@link SecretKeyBackupCodeGenerator} with a custom implementation.
+     *
+     * @param generator backup key generator.
+     */
+    public static void setBackupCodeGenerator(SecretKeyBackupCodeGenerator generator) {
+        BACKUP_CODE_GENERATOR = Objects.requireNonNull(generator);
     }
 }

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-4.4.0-alpha5-SNAPSHOT
+4.4.0-alpha5

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-4.4.0-alpha5
+4.4.0-alpha6-SNAPSHOT


### PR DESCRIPTION
This PR moves the secret key backup code generation code into the implementation of an interface to allow substitution with a custom implementation.