### PR TITLE
Remove unrequired assignment of value to connectionEndpoint variable

### DIFF
--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/ConnectionAttemptState.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/ConnectionAttemptState.java
@@ -69,7 +69,6 @@ public final class ConnectionAttemptState {
 
         List<Rfc6120TcpRemoteConnectionEndpoint> endpoints = discoveredEndpoints.result.discoveredRemoteConnectionEndpoints;
         connectionEndpointIterator = endpoints.iterator();
-        connectionEndpoint = connectionEndpointIterator.next();
         connectionExceptions = new ArrayList<>(endpoints.size());
     }
 


### PR DESCRIPTION
The current code would work just fine for a connection having multiple endpoints. However, when there is only one endpoint `ConnectionAttemptState.nextAddress()` would return `null`, since `connectionEndpointIterator` has already iterated over the only possible value in the contructor leading to a `NullPointerException`. This means that during establishment of a connection having multiple endpoints, the first value inside `connectionEndpointIterator` would always be overlooked.

