### PR TITLE
ConnectionListener: Add connecting(XMPPConnection) method.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -514,6 +514,9 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         // Check if not already connected
         throwAlreadyConnectedExceptionIfAppropriate();
 
+        // Notify connection listeners that we are trying to connect
+        callConnectionConnectingListener();
+
         // Reset the connection state
         initState();
         closingStreamReceived = false;
@@ -1677,6 +1680,12 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         // Never reset the flag if the connection has ever been authenticated
         if (!wasAuthenticated) {
             wasAuthenticated = authenticated;
+        }
+    }
+
+    protected void callConnectionConnectingListener() {
+        for (ConnectionListener listener : connectionListeners) {
+            listener.connecting(this);
         }
     }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/ConnectionListener.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/ConnectionListener.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2003-2007 Jive Software.
+ * Copyright 2003-2007 Jive Software, 2020 Paul Schaub
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,16 @@ package org.jivesoftware.smack;
  * @author Matt Tucker
  */
 public interface ConnectionListener {
+
+    /**
+     * Notification that the connection is in the process of connecting.
+     * This method is called when {@link AbstractXMPPConnection#connect()} is executed.
+     *
+     * @param connection connection
+     * @since 4.4
+     */
+    default void connecting(XMPPConnection connection) {
+    }
 
     /**
      * Notification that the connection has been successfully connected to the remote endpoint (e.g. the XMPP server).


### PR DESCRIPTION
This PR adds a callback method `connecting(XMPPConnection)` to Smacks `ConnectionListener`.
This method is called whenever the connection starts the process of connecting.

I find this functionality was missing as the existing methods were not enough to accurately determine the exact state of the connection.