### PR TITLE
HttpLookupMethod: Position parser at START_ELEMENT before parsing

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/altconnections/HttpLookupMethod.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/altconnections/HttpLookupMethod.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jivesoftware.smack.util.PacketParserUtils;
+import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -132,6 +133,7 @@ public final class HttpLookupMethod {
      * @throws URISyntaxException exception to indicate that a string could not be parsed as a URI reference
      */
     public static List<URI> parseXrdLinkReferencesFor(XmlPullParser parser, String relation) throws IOException, XmlPullParserException, URISyntaxException {
+        ParserUtils.forwardToStartElement(parser);
         List<URI> uriList = new ArrayList<>();
         int initialDepth = parser.getDepth();
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/PacketParserUtils.java
@@ -82,14 +82,7 @@ public class PacketParserUtils {
 
     public static XmlPullParser getParserFor(Reader reader) throws XmlPullParserException, IOException {
         XmlPullParser parser = SmackXmlParser.newXmlParser(reader);
-        // Wind the parser forward to the first start tag
-        XmlPullParser.Event event = parser.getEventType();
-        while (event != XmlPullParser.Event.START_ELEMENT) {
-            if (event == XmlPullParser.Event.END_DOCUMENT) {
-                throw new IllegalArgumentException("Document contains no start tag");
-            }
-            event = parser.next();
-        }
+        ParserUtils.forwardToStartElement(parser);
         return parser;
     }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/ParserUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/ParserUtils.java
@@ -63,6 +63,17 @@ public class ParserUtils {
         assert parser.getEventType() == XmlPullParser.Event.END_ELEMENT;
     }
 
+    public static void forwardToStartElement(XmlPullParser parser) throws XmlPullParserException, IOException {
+         // Wind the parser forward to the first start tag
+        XmlPullParser.Event event = parser.getEventType();
+        while (event != XmlPullParser.Event.START_ELEMENT) {
+            if (event == XmlPullParser.Event.END_DOCUMENT) {
+                throw new IllegalArgumentException("Document contains no start tag");
+            }
+            event = parser.next();
+        }
+    }
+
     public static void forwardToEndTagOfDepth(XmlPullParser parser, int depth)
                     throws XmlPullParserException, IOException {
         XmlPullParser.Event event = parser.getEventType();


### PR DESCRIPTION
This PR aims to provide `HttpLookupMethod.lookp(..)` method the ability to parse forward to the first `START_ELEMENT` tag. The `HttpLookupMethodTest` tests the `HttpLookupMethod` class by parsing `String`. This makes use of `PacketParserUtils.getParserFor(String)`, which already does forward winding to reach `START_ELEMENT`. However when fetching endpoints from a remote host meta data, `PacketParserUtils.getParserFor(InputStream)` is used which doesn't do winding in any form. And thus, even though `HttpLookupMethodTest` tests pass, this implementation would crash.

I feel that the change should be incorporated inside `PacketParserUtils` but it would correspond to changes in other modules as well making the change a bit more involved. Hence putting this PR to have feedback on the issue.