### PR TITLE
NoEndpointDiscoveredException: s/Not/No

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackException.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackException.java
@@ -364,7 +364,7 @@ public abstract class SmackException extends Exception {
             if (lookupFailures.isEmpty()) {
                 sb.append("No endpoint lookup finished within the timeout");
             } else {
-                sb.append("Not endpoints could be discovered due the following lookup failures: ");
+                sb.append("No endpoints could be discovered due the following lookup failures: ");
                 StringUtils.appendTo(lookupFailures, sb);
             }
 


### PR DESCRIPTION
Just a small typo in the exception message.
