### PR TITLE
Set 'connected' to 'true' as early as possible

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -522,6 +522,9 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         closingStreamReceived = false;
         streamId = null;
 
+        // The connection should not be connected nor marked as such prior calling connectInternal().
+        assert !connected;
+
         try {
             // Perform the actual connection to the XMPP service
             connectInternal();
@@ -537,8 +540,9 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
             throw e;
         }
 
-        // Make note of the fact that we're now connected.
-        connected = true;
+        // If connectInternal() did not throw, then this connection must now be marked as connected.
+        assert connected;
+
         callConnectionConnectedListener();
 
         return this;

--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
@@ -217,6 +217,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
             @Override
             public void setTransport(XmppClientToServerTransport xmppTransport) {
                 ModularXmppClientToServerConnection.this.activeTransport = xmppTransport;
+                ModularXmppClientToServerConnection.this.connected = true;
             }
 
         };

--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/internal/ModularXmppClientToServerConnectionInternal.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/internal/ModularXmppClientToServerConnectionInternal.java
@@ -116,5 +116,11 @@ public abstract class ModularXmppClientToServerConnectionInternal {
 
     public abstract void setCompressionEnabled(boolean compressionEnabled);
 
+    /**
+     * Set the active transport (TCP, BOSH, WebSocket, …) to be used for the XMPP connection. Also marks the connection
+     * as connected.
+     *
+     * @param xmppTransport the active transport.
+     */
     public abstract void setTransport(XmppClientToServerTransport xmppTransport);
 }

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -836,6 +836,8 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         // there is an error establishing the connection
         connectUsingConfiguration();
 
+        connected = true;
+
         // We connected successfully to the servers TCP port
         initConnection();
 


### PR DESCRIPTION
We previously only set 'connected' after connectInternal()
returned. This could lead to notifyConnectionError() ignoring stream
error exceptions, e.g. when establishing TLS which happens also in
connectInternal(), because 'connected' was still 'false'.

We now set 'connected' to 'true' as soon as the transport (e.g. TCP,
BOSH, …) is connected. While this is in other ways also sensible, it
also allows notifyConnectionError() to handle exceptions in the early
connection stage.

Thanks to Cheng Mong for reporting this.