### PR TITLE
waitForCondition() → waitForConditionOrThrowConnectionException()

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
@@ -199,7 +199,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
             }
 
             @Override
-            public void waitForCondition(Supplier<Boolean> condition, String waitFor)
+            public void waitForConditionOrThrowConnectionException(Supplier<Boolean> condition, String waitFor)
                             throws InterruptedException, SmackException, XMPPException {
                 ModularXmppClientToServerConnection.this.waitForConditionOrThrowConnectionException(condition, waitFor);
             }

--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/internal/ModularXmppClientToServerConnectionInternal.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/internal/ModularXmppClientToServerConnectionInternal.java
@@ -110,7 +110,7 @@ public abstract class ModularXmppClientToServerConnectionInternal {
 
     public abstract void asyncGo(Runnable runnable);
 
-    public abstract void waitForCondition(Supplier<Boolean> condition, String waitFor) throws InterruptedException, SmackException, XMPPException;
+    public abstract void waitForConditionOrThrowConnectionException(Supplier<Boolean> condition, String waitFor) throws InterruptedException, SmackException, XMPPException;
 
     public abstract void notifyWaitingThreads();
 

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XmppTcpTransportModule.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XmppTcpTransportModule.java
@@ -1165,7 +1165,7 @@ public class XmppTcpTransportModule extends ModularXmppClientToServerConnectionM
         }
 
         private void waitForHandshakeFinished() throws InterruptedException, CertificateException, SSLException, SmackException, XMPPException {
-            connectionInternal.waitForCondition(() -> isHandshakeFinished(), "TLS handshake to finish");
+            connectionInternal.waitForConditionOrThrowConnectionException(() -> isHandshakeFinished(), "TLS handshake to finish");
 
             if (handshakeStatus == TlsHandshakeStatus.failed) {
                 throw handshakeException;


### PR DESCRIPTION
The method was already renamed, but not in
ModularXmppClientToServerConnectionInternal.