### PR TITLE
Use AbstractStreamOpen instead of StreamOpen to open stream

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -70,6 +70,7 @@ import org.jivesoftware.smack.filter.StanzaFilter;
 import org.jivesoftware.smack.filter.StanzaIdFilter;
 import org.jivesoftware.smack.internal.SmackTlsContext;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler;
+import org.jivesoftware.smack.packet.AbstractStreamOpen;
 import org.jivesoftware.smack.packet.Bind;
 import org.jivesoftware.smack.packet.ErrorIQ;
 import org.jivesoftware.smack.packet.ExtensionElement;
@@ -2246,7 +2247,7 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
         updateOutgoingStreamXmlEnvironmentOnStreamOpen(streamOpen);
     }
 
-    protected void updateOutgoingStreamXmlEnvironmentOnStreamOpen(StreamOpen streamOpen) {
+    protected void updateOutgoingStreamXmlEnvironmentOnStreamOpen(AbstractStreamOpen streamOpen) {
         XmlEnvironment.Builder xmlEnvironmentBuilder = XmlEnvironment.builder();
         xmlEnvironmentBuilder.with(streamOpen);
         outgoingStreamXmlEnvironment = xmlEnvironmentBuilder.build();

--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
@@ -61,6 +61,7 @@ import org.jivesoftware.smack.fsm.StateTransitionResult;
 import org.jivesoftware.smack.fsm.StateTransitionResult.AttemptResult;
 import org.jivesoftware.smack.internal.AbstractStats;
 import org.jivesoftware.smack.internal.SmackTlsContext;
+import org.jivesoftware.smack.packet.AbstractStreamOpen;
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Nonza;
@@ -68,7 +69,6 @@ import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.packet.StreamClose;
 import org.jivesoftware.smack.packet.StreamError;
-import org.jivesoftware.smack.packet.StreamOpen;
 import org.jivesoftware.smack.packet.TopLevelStreamElement;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
@@ -572,13 +572,13 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         if (localpart != null) {
             from = XmppStringUtils.completeJidFrom(localpart, xmppServiceDomain);
         }
-        StreamOpen streamOpen = streamOpenAndCloseFactory.createStreamOpen(xmppServiceDomain, from, getStreamId(), getConfiguration().getXmlLang());
+        AbstractStreamOpen streamOpen = streamOpenAndCloseFactory.createStreamOpen(xmppServiceDomain, from, getStreamId(), getConfiguration().getXmlLang());
         sendStreamOpen(streamOpen);
 
         waitForFeaturesReceived(waitFor);
     }
 
-    private void sendStreamOpen(StreamOpen streamOpen) throws NotConnectedException, InterruptedException {
+    private void sendStreamOpen(AbstractStreamOpen streamOpen) throws NotConnectedException, InterruptedException {
         sendNonza(streamOpen);
         updateOutgoingStreamXmlEnvironmentOnStreamOpen(streamOpen);
     }

--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/StreamOpenAndCloseFactory.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/StreamOpenAndCloseFactory.java
@@ -16,11 +16,11 @@
  */
 package org.jivesoftware.smack.c2s;
 
-import org.jivesoftware.smack.packet.StreamClose;
-import org.jivesoftware.smack.packet.StreamOpen;
+import org.jivesoftware.smack.packet.AbstractStreamClose;
+import org.jivesoftware.smack.packet.AbstractStreamOpen;
 
 public interface StreamOpenAndCloseFactory {
-    StreamOpen createStreamOpen(CharSequence to, CharSequence from, String id, String lang);
+    AbstractStreamOpen createStreamOpen(CharSequence to, CharSequence from, String id, String lang);
 
-    StreamClose createStreamClose();
+    AbstractStreamClose createStreamClose();
 }

--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/XmlEnvironment.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/XmlEnvironment.java
@@ -162,7 +162,7 @@ public class XmlEnvironment {
             return this;
         }
 
-        public Builder with(StreamOpen streamOpen) {
+        public Builder with(AbstractStreamOpen streamOpen) {
             withNamespace(streamOpen.getNamespace());
             withLanguage(streamOpen.getLanguage());
             return this;


### PR DESCRIPTION
Before the existence of AbstractStreamOpen, StreamOpen sufficed our need
during sending an open stream element. Since the intention behind
introducing AbstractStreamOpen is to allow underlying transports provide
transport specific opening streams, these changes will further support
the cause.

This commit will allow us to send transport specific open element
which should be inherited from AbstractStreamOpen.