### PR TITLE
Make ModularXmppClientToServerConnectionConfiguration.addModule() public

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnectionConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnectionConfiguration.java
@@ -96,7 +96,7 @@ public final class ModularXmppClientToServerConnectionConfiguration extends Conn
             return new ModularXmppClientToServerConnectionConfiguration(this);
         }
 
-        void addModule(ModularXmppClientToServerConnectionModuleDescriptor connectionModule) {
+        public void addModule(ModularXmppClientToServerConnectionModuleDescriptor connectionModule) {
             Class<? extends ModularXmppClientToServerConnectionModuleDescriptor> moduleDescriptorClass = connectionModule.getClass();
             if (modulesDescriptors.containsKey(moduleDescriptorClass)) {
                 throw new IllegalArgumentException("A connection module for " + moduleDescriptorClass + " is already configured");


### PR DESCRIPTION
This commit will allow users to plug their module descriptors inside
modular architecture.