### PR TITLE
Bump pgpainless version to 0.1.0

### DIFF
--- a/smack-openpgp/build.gradle
+++ b/smack-openpgp/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	compile project(':smack-extensions')
 	compile project(':smack-experimental')
 
-	api 'org.pgpainless:pgpainless-core:0.0.1-alpha11'
+	api 'org.pgpainless:pgpainless-core:0.1.0'
 
 	testImplementation "org.bouncycastle:bcprov-jdk15on:${bouncyCastleVersion}"
 


### PR DESCRIPTION
This PR bumps Smacks PGPainless dependency to version 0.1.0!

The latest PGPainless version got support for creating and verifying detached signatures which may come in handy in future additions to smack-openpgp.