### PR TITLE
XMPPTCPConnectionConfiguration: Remove setCompression() from javadoc

### DIFF
--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnectionConfiguration.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnectionConfiguration.java
@@ -28,7 +28,6 @@ import org.jivesoftware.smack.ConnectionConfiguration;
  * {@code
  * XMPPTCPConnectionConfiguration conf = XMPPTCPConnectionConfiguration.builder()
  *     .setXmppDomain("example.org").setUsernameAndPassword("user", "password")
- *     .setCompressionEnabled(false).build();
  * XMPPTCPConnection connection = new XMPPTCPConnection(conf);
  * }
  * </pre>


### PR DESCRIPTION
The method is no longer part of `XMPPTCPConnectionConfiguration` and has been moved to `ConnectionConfiguration` under commit 1ea1083.