### PR TITLE
Add missing right parenthesis in SINT output

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -457,7 +457,7 @@ public class SmackIntegrationTestFramework {
         sb.append("Available tests: ").append(numberOfAvailableTests);
         if (!testRunResult.disabledTestClasses.isEmpty() || !testRunResult.disabledTests.isEmpty()) {
             sb.append(" (Disabled ").append(testRunResult.disabledTestClasses.size()).append(" classes")
-              .append(" and ").append(testRunResult.disabledTests.size()).append(" tests");
+              .append(" and ").append(testRunResult.disabledTests.size()).append(" tests)");
         }
         sb.append('\n');
         LOGGER.info(sb.toString());


### PR DESCRIPTION
While running the Smack integration tests, a line like this is printed to std-out somewhere

    Available tests: 21 (Disabled 12 classes and 6 tests

There's a missing character on the end of that line, which makes the author of this commit twitch.
This commit adds the missing character, resulting in a line like this:

    Available tests: 21 (Disabled 12 classes and 6 tests)