### PR TITLE
In tests, use specific assertion implementation

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatIntegrationTest.java
@@ -16,7 +16,9 @@
  */
 package org.jivesoftware.smackx.muc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -144,9 +146,9 @@ public class MultiUserChatIntegrationTest extends AbstractSmackIntegrationTest {
 
         muc.addUserStatusListener(userStatusListener);
 
-        assertTrue(mucManagerOne.getJoinedRooms().size() == 1);
-        assertTrue(muc.getOccupantsCount() == 1);
-        assertTrue(muc.getNickname() != null);
+        assertEquals(1, mucManagerOne.getJoinedRooms().size());
+        assertEquals(1, muc.getOccupantsCount());
+        assertNotNull(muc.getNickname());
 
         try {
             muc.destroy("Dummy reason", null);
@@ -155,8 +157,8 @@ public class MultiUserChatIntegrationTest extends AbstractSmackIntegrationTest {
             muc.removeUserStatusListener(userStatusListener);
         }
 
-        assertTrue(mucManagerOne.getJoinedRooms().size() == 0);
-        assertTrue(muc.getOccupantsCount() == 0);
-        assertTrue(muc.getNickname() == null);
+        assertEquals(0, mucManagerOne.getJoinedRooms().size());
+        assertEquals(0, muc.getOccupantsCount());
+        assertNull(muc.getNickname());
     }
 }


### PR DESCRIPTION
Although this does not functionally change anything, the error messages that are generated by the more specific assert* methods can be helpful.

Take, for example, this assertion:

    assertTrue(muc.getOccupantsCount()==1);

When this assertion fails (https://github.com/igniterealtime/Openfire/pull/1721#issuecomment-703112496) then the most likely first question that a developer is going to ask is: "what was the count?" The assertion above would have printed something along these lines:

    org.opentest4j.AssertionFailedError: expected: <true> but was: <false>

That is not really helpful here. If, instead, a more specific assertion was used (like what's done in this commit), then someting like this would have been printed:

    org.opentest4j.AssertionFailedError: expected: 1 but was: 2

That provides more helpful information! On top of that, the code argably expresses intent better when using the latter form, especially when the assertions become more complex.
