### PR TITLE
Fix MUC enter race condition

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -385,7 +385,7 @@ public class MultiUserChat {
         // occupant (eg: #getOccupantsCount might return an incorrect number). To prevent this, this 'enter' method does
         // not return until after the internal state of this class has been updated to reflect that the user joined the muc.
         final ArrayDeque<EntityFullJid> queue = new ArrayDeque<>();
-        final ParticipantStatusListener internalStateUpdateListener = new DefaultParticipantStatusListener() {
+        final ParticipantStatusListener internalStateUpdateListener = new ParticipantStatusListener() {
             @Override
             public void joined(EntityFullJid participant) {
                 synchronized (this) {


### PR DESCRIPTION
When joining/entering a Multi User Chat, the 'enter' method should not return before the internal state of the instance has been updated to reflect the join.

The internal state of `MultiUserChat` is managed b[y a listener that triggers on presence stanzas](https://github.com/igniterealtime/Smack/blob/5782fff2a48f4f58acd8e2c81ea9921ffe31351f/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java#L188). A stanza filter, triggered by the same presence stanza, is used in `enter()` to detect a successful join. This introduces a race condition.

The race condition manifests itself in scenarios like these:

        int before = muc.getOccupantsCount();
        MultiUserChat muc = mucManager.getMultiUserChat(mucAddress);
        muc.join(Resourcepart.from("nick"));
        int after = muc.getOccupantsCount();

Although the `join` on the third line is blocking, the `after` and `before` count can be equal. Assuming no other occupant changes occur, you would expect the count to have increased with one.

The race condition can be verified by adding a delay in the processing of presence updates, somewhere in this code: https://github.com/igniterealtime/Smack/blob/5782fff2a48f4f58acd8e2c81ea9921ffe31351f/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java#L188

The commit in this PR prevents the race condition by modifying `enter`, registering a listener that is triggered only after the presence update has been processed.

