### PR TITLE
Fix pubsub options rendering

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/OptionsExtension.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/OptionsExtension.java
@@ -51,14 +51,9 @@ public class OptionsExtension extends NodeExtension {
 
     @Override
     protected void addXml(XmlStringBuilder xml) {
-        xml.rightAngleBracket();
-
-        xml.halfOpenElement(getElementName());
         xml.attribute("jid", jid);
-        xml.optAttribute("node", getNode());
         xml.optAttribute("subid", id);
 
         xml.closeEmptyElement();
-        xml.closeElement(this);
     }
 }


### PR DESCRIPTION
The exiting code generates an unintentional nested 'options' child element:

```
<iq to='pubsub.example.org' id='FQTHU-126' type='get'>
  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
    <options node='sinttest-multisubscribe-nodename-13pnc'>
      <options jid='smack-inttest-two-13pnc@example.org'
               node='sinttest-multisubscribe-nodename-13pnc'/>
    </options>
  </pubsub>
</iq>
```

This commit removes the undesired nesting, resulting in:

```
<iq to='pubsub.example.org' id='FQTHU-126' type='get'>
  <pubsub xmlns='http://jabber.org/protocol/pubsub'>
    <options jid='smack-inttest-two-13pnc@example.org'
             node='sinttest-multisubscribe-nodename-13pnc'/>
  </pubsub>
</iq>
```