### PR TITLE
SINT: wait for notification filter to propagate

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
@@ -23,7 +23,6 @@ import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.SmackException.NotLoggedInException;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
-import org.jivesoftware.smack.packet.Message;
 
 import org.jivesoftware.smackx.geoloc.GeoLocationManager;
 import org.jivesoftware.smackx.geoloc.packet.GeoLocation;
@@ -35,7 +34,6 @@ import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
-import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.util.XmppDateTime;
 
 public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
@@ -78,15 +76,11 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
 
         IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
         final SimpleResultSyncPoint geoLocationReceived = new SimpleResultSyncPoint();
-        final PepEventListener<GeoLocation> geoLocationListener = new PepEventListener<GeoLocation>() {
-
-            @Override
-            public void onPepEvent(EntityBareJid jid, GeoLocation geoLocation, String id, Message message) {
-                if (geoLocation.equals(geoLocation1)) {
-                    geoLocationReceived.signal();
-                } else {
-                    geoLocationReceived.signalFailure("Received non matching GeoLocation");
-                }
+        final PepEventListener<GeoLocation> geoLocationListener = (jid, geoLocation, id, message) -> {
+            if (geoLocation.equals(geoLocation1)) {
+                geoLocationReceived.signal();
+            } else {
+                geoLocationReceived.signalFailure("Received non matching GeoLocation");
             }
         };
 

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
@@ -105,7 +105,10 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
 
             // Wait for the data to be received.
             try {
-                geoLocationReceived.waitForResult(timeout);
+                Object result = geoLocationReceived.waitForResult(timeout);
+
+                // Explicitly assert the success case.
+                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
             } catch (TimeoutException e) {
                 Assertions.fail("Expected to receive a PEP notification, but did not.");
             }
@@ -165,7 +168,10 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
 
             // Wait for the data to be received.
             try {
-                geoLocationReceived.waitForResult(timeout);
+                Object result = geoLocationReceived.waitForResult(timeout);
+
+                // Explicitly assert the success case.
+                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
             } catch (TimeoutException e) {
                 Assertions.fail("Expected to receive a PEP notification, but did not.");
             }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
@@ -58,6 +58,8 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
     /**
      * Verifies that a notification is sent when a publication is received, assuming that notification filtering
      * has been adjusted to allow for the notification to be delivered.
+     *
+     * @throws Exception if the test fails
      */
     @SmackIntegrationTest
     public void testNotification() throws Exception {
@@ -120,6 +122,8 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
     /**
      * Verifies that a notification for a previously sent publication is received as soon as notification filtering
      * has been adjusted to allow for the notification to be delivered.
+     *
+     * @throws Exception if the test fails
      */
     @SmackIntegrationTest
     public void testNotificationAfterFilterChange() throws Exception {
@@ -188,9 +192,10 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
      * @param geoManager The GeoLocationManager instance for the connection that is expected to receive data.
      * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
      * @param listener A listener instance for GeoLocation data that is to be registered.
+     *
+     * @throws Exception if the test fails
      */
-    public void registerListenerAndWait(GeoLocationManager geoManager, ServiceDiscoveryManager discoManager, PepEventListener<GeoLocation> listener) throws Exception
-    {
+    public void registerListenerAndWait(GeoLocationManager geoManager, ServiceDiscoveryManager discoManager, PepEventListener<GeoLocation> listener) throws Exception {
         final SimpleResultSyncPoint notificationFilterReceived = new SimpleResultSyncPoint();
         final EntityCapabilitiesChangedListener notificationFilterReceivedListener = info -> {
             if (info.containsFeature(GeoLocationManager.GEOLOCATION_NODE + "+notify")) {
@@ -214,8 +219,7 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
      * @param geoManager The GeoLocationManager instance for the connection that was expected to receive data.
      * @param listener A listener instance for GeoLocation data that is to be removed.
      */
-    public void unregisterListener(GeoLocationManager geoManager, PepEventListener<GeoLocation> listener)
-    {
+    public void unregisterListener(GeoLocationManager geoManager, PepEventListener<GeoLocation> listener) {
         // Does it make sense to have a method implementation that's one line? This is provided to allow for symmetry in the API.
         geoManager.removeGeoLocationListener(listener);
     }
@@ -226,9 +230,10 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
      * @param geoManager The GeoLocationManager instance for the connection that is expected to publish data.
      * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
      * @param data The data to be published.
+     *
+     * @throws Exception if the test fails
      */
-    public void publishAndWait(GeoLocationManager geoManager, ServiceDiscoveryManager discoManager, GeoLocation data) throws Exception
-    {
+    public void publishAndWait(GeoLocationManager geoManager, ServiceDiscoveryManager discoManager, GeoLocation data) throws Exception {
         final SimpleResultSyncPoint publicationEchoReceived = new SimpleResultSyncPoint();
         final PepEventListener<GeoLocation> publicationEchoListener = (jid, geoLocation, id, message) -> {
             if (geoLocation.equals(data)) {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
@@ -116,7 +116,10 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
 
             // Wait for the data to be received.
             try {
-                moodReceived.waitForResult(timeout);
+                Object result = moodReceived.waitForResult(timeout);
+
+                // Explicitly assert the success case.
+                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
             } catch (TimeoutException e) {
                 Assertions.fail("Expected to receive a PEP notification, but did not.");
             }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
@@ -16,6 +16,8 @@
  */
 package org.jivesoftware.smackx.mood;
 
+import java.util.concurrent.TimeoutException;
+
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
 
@@ -31,8 +33,6 @@ import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.junit.jupiter.api.Assertions;
-
-import java.util.concurrent.TimeoutException;
 
 public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
 
@@ -55,6 +55,8 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
     /**
      * Verifies that a notification is sent when a publication is received, assuming that notification filtering
      * has been adjusted to allow for the notification to be delivered.
+     *
+     * @throws Exception if the test fails
      */
     @SmackIntegrationTest
     public void testNotification() throws Exception {
@@ -91,6 +93,8 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
     /**
      * Verifies that a notification for a previously sent publication is received as soon as notification filtering
      * has been adjusted to allow for the notification to be delivered.
+     *
+     * @throws Exception if the test fails
      */
     @SmackIntegrationTest
     public void testNotificationAfterFilterChange() throws Exception {
@@ -136,9 +140,10 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
      * @param moodManager The MoodManager instance for the connection that is expected to receive data.
      * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
      * @param listener A listener instance for Mood data that is to be registered.
+     *
+     * @throws Exception if the test fails
      */
-    public void registerListenerAndWait(MoodManager moodManager, ServiceDiscoveryManager discoManager, PepEventListener<MoodElement> listener) throws Exception
-    {
+    public void registerListenerAndWait(MoodManager moodManager, ServiceDiscoveryManager discoManager, PepEventListener<MoodElement> listener) throws Exception {
         final SimpleResultSyncPoint notificationFilterReceived = new SimpleResultSyncPoint();
         final EntityCapabilitiesChangedListener notificationFilterReceivedListener = info -> {
             if (info.containsFeature(MoodManager.MOOD_NODE + "+notify")) {
@@ -162,8 +167,7 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
      * @param moodManager The MoodManager instance for the connection that was expected to receive data.
      * @param listener A listener instance for Mood data that is to be removed.
      */
-    public void unregisterListener(MoodManager moodManager, PepEventListener<MoodElement> listener)
-    {
+    public void unregisterListener(MoodManager moodManager, PepEventListener<MoodElement> listener) {
         // Does it make sense to have a method implementation that's one line? This is provided to allow for symmetry in the API.
         moodManager.removeMoodListener(listener);
     }
@@ -174,9 +178,10 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
      * @param moodManager The MoodManager instance for the connection that is expected to publish data.
      * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
      * @param data The data to be published.
+     *
+     * @throws Exception if the test fails
      */
-    public void publishAndWait(MoodManager moodManager, ServiceDiscoveryManager discoManager, Mood data) throws Exception
-    {
+    public void publishAndWait(MoodManager moodManager, ServiceDiscoveryManager discoManager, Mood data) throws Exception {
         final SimpleResultSyncPoint publicationEchoReceived = new SimpleResultSyncPoint();
         final PepEventListener<MoodElement> publicationEchoListener = (jid, moodElement, id, message) -> {
             if (moodElement.getMood().equals(data)) {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
@@ -19,6 +19,7 @@ package org.jivesoftware.smackx.mood;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
 
+import org.jivesoftware.smackx.disco.EntityCapabilitiesChangedListener;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 import org.jivesoftware.smackx.mood.element.MoodElement;
 import org.jivesoftware.smackx.pep.PepEventListener;
@@ -29,6 +30,9 @@ import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.concurrent.TimeoutException;
 
 public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
 
@@ -41,45 +45,147 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
         mm2 = MoodManager.getInstanceFor(conTwo);
     }
 
-    @SmackIntegrationTest
-    public void test() throws Exception {
-        IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
-
-        final SimpleResultSyncPoint moodReceived = new SimpleResultSyncPoint();
-        final SimpleResultSyncPoint notificationFilterReceived = new SimpleResultSyncPoint();
-
-        ServiceDiscoveryManager.getInstanceFor(conTwo).addEntityCapabilitiesChangedListener(info -> {
-            if (info.containsFeature(MoodManager.MOOD_NODE+"+notify")) {
-                notificationFilterReceived.signal();
-            }
-        });
-
-        final PepEventListener<MoodElement> moodListener = (jid, moodElement, id, message) -> {
-            if (moodElement.getMood() == Mood.satisfied) {
-                moodReceived.signal();
-            }
-        };
-
-        // Adds listener, which implicitly publishes a disco/info filter for mood notification.
-        mm2.addMoodListener(moodListener);
-
-        try {
-            // Waits until ConTwo's newly-published interested in receiving mood notifications has been propagated.
-            notificationFilterReceived.waitForResult(timeout);
-
-            // Publish the data, and wait for it to be received.
-            mm1.setMood(Mood.satisfied);
-
-            moodReceived.waitForResult(timeout);
-        } finally {
-            mm2.removeMoodListener(moodListener);
-        }
-    }
-
     @AfterClass
     public void unsubscribe()
             throws SmackException.NotLoggedInException, XMPPException.XMPPErrorException,
             SmackException.NotConnectedException, InterruptedException, SmackException.NoResponseException {
         IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+    }
+
+    /**
+     * Verifies that a notification is sent when a publication is received, assuming that notification filtering
+     * has been adjusted to allow for the notification to be delivered.
+     */
+    @SmackIntegrationTest
+    public void testNotification() throws Exception {
+        Mood data = Mood.satisfied;
+
+        IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
+
+        final SimpleResultSyncPoint moodReceived = new SimpleResultSyncPoint();
+
+        final PepEventListener<MoodElement> moodListener = (jid, moodElement, id, message) -> {
+            if (moodElement.getMood().equals(data)) {
+                moodReceived.signal();
+            }
+        };
+
+        try {
+            // Register ConTwo's interest in receiving mood notifications, and wait for that interest to have been propagated.
+            registerListenerAndWait(mm2, ServiceDiscoveryManager.getInstanceFor(conTwo), moodListener);
+
+            // Publish the data.
+            mm1.setMood(data); // for the purpose of this test, this needs not be blocking/use publishAndWait();
+
+            // Wait for the data to be received.
+            try {
+                moodReceived.waitForResult(timeout);
+            } catch (TimeoutException e) {
+                Assertions.fail("Expected to receive a PEP notification, but did not.");
+            }
+        } finally {
+            unregisterListener(mm2, moodListener);
+        }
+    }
+
+    /**
+     * Verifies that a notification for a previously sent publication is received as soon as notification filtering
+     * has been adjusted to allow for the notification to be delivered.
+     */
+    @SmackIntegrationTest
+    public void testNotificationAfterFilterChange() throws Exception {
+        Mood data = Mood.cautious;
+
+        IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
+
+        final SimpleResultSyncPoint moodReceived = new SimpleResultSyncPoint();
+
+        final PepEventListener<MoodElement> moodListener = (jid, moodElement, id, message) -> {
+            if (moodElement.getMood().equals(data)) {
+                moodReceived.signal();
+            }
+        };
+
+        // TODO Ensure that pre-existing filtering notification excludes mood.
+        try {
+            // Publish the data
+            publishAndWait(mm1, ServiceDiscoveryManager.getInstanceFor(conOne), data);
+
+            // Adds listener, which implicitly publishes a disco/info filter for mood notification.
+            registerListenerAndWait(mm2, ServiceDiscoveryManager.getInstanceFor(conTwo), moodListener);
+
+            // Wait for the data to be received.
+            try {
+                moodReceived.waitForResult(timeout);
+            } catch (TimeoutException e) {
+                Assertions.fail("Expected to receive a PEP notification, but did not.");
+            }
+        } finally {
+            unregisterListener(mm2, moodListener);
+        }
+    }
+
+    /**
+     * Registers a listener for User Tune data. This implicitly publishes a CAPS update to include a notification
+     * filter for the mood node. This method blocks until the server has indicated that this update has been
+     * received.
+     *
+     * @param moodManager The MoodManager instance for the connection that is expected to receive data.
+     * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
+     * @param listener A listener instance for Mood data that is to be registered.
+     */
+    public void registerListenerAndWait(MoodManager moodManager, ServiceDiscoveryManager discoManager, PepEventListener<MoodElement> listener) throws Exception
+    {
+        final SimpleResultSyncPoint notificationFilterReceived = new SimpleResultSyncPoint();
+        final EntityCapabilitiesChangedListener notificationFilterReceivedListener = info -> {
+            if (info.containsFeature(MoodManager.MOOD_NODE + "+notify")) {
+                notificationFilterReceived.signal();
+            }
+        };
+
+        discoManager.addEntityCapabilitiesChangedListener(notificationFilterReceivedListener);
+        try {
+            moodManager.addMoodListener(listener);
+            notificationFilterReceived.waitForResult(timeout);
+        } finally {
+            discoManager.removeEntityCapabilitiesChangedListener(notificationFilterReceivedListener);
+        }
+    }
+
+    /**
+     * The functionally reverse of {@link #registerListenerAndWait(MoodManager, ServiceDiscoveryManager, PepEventListener)}
+     * with the difference of not being a blocking operation.
+     *
+     * @param moodManager The MoodManager instance for the connection that was expected to receive data.
+     * @param listener A listener instance for Mood data that is to be removed.
+     */
+    public void unregisterListener(MoodManager moodManager, PepEventListener<MoodElement> listener)
+    {
+        // Does it make sense to have a method implementation that's one line? This is provided to allow for symmetry in the API.
+        moodManager.removeMoodListener(listener);
+    }
+
+    /**
+     * Publish data using PEP, and block until the server has echoed the publication back to the publishing user.
+     *
+     * @param moodManager The MoodManager instance for the connection that is expected to publish data.
+     * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
+     * @param data The data to be published.
+     */
+    public void publishAndWait(MoodManager moodManager, ServiceDiscoveryManager discoManager, Mood data) throws Exception
+    {
+        final SimpleResultSyncPoint publicationEchoReceived = new SimpleResultSyncPoint();
+        final PepEventListener<MoodElement> publicationEchoListener = (jid, moodElement, id, message) -> {
+            if (moodElement.getMood().equals(data)) {
+                publicationEchoReceived.signal();
+            }
+        };
+        try {
+            registerListenerAndWait(moodManager, discoManager, publicationEchoListener);
+            moodManager.addMoodListener(publicationEchoListener);
+            moodManager.setMood(data);
+        } finally {
+            moodManager.removeMoodListener(publicationEchoListener);
+        }
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
@@ -90,7 +90,10 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
 
             // Wait for the data to be received.
             try {
-                userTuneReceived.waitForResult(timeout);
+                Object result = userTuneReceived.waitForResult(timeout);
+
+                // Explicitly assert the success case.
+                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
             } catch (TimeoutException e) {
                 Assertions.fail("Expected to receive a PEP notification, but did not.");
             }
@@ -136,7 +139,10 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
 
             // Wait for the data to be received.
             try {
-                userTuneReceived.waitForResult(timeout);
+                Object result = userTuneReceived.waitForResult(timeout);
+
+                // Explicitly assert the success case.
+                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
             } catch (TimeoutException e) {
                 Assertions.fail("Expected to receive a PEP notification, but did not.");
             }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
@@ -21,11 +21,8 @@ import java.net.URI;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NotLoggedInException;
 import org.jivesoftware.smack.XMPPException;
-import org.jivesoftware.smack.packet.Message;
 
-import org.jivesoftware.smackx.disco.EntityCapabilitiesChangedListener;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
-import org.jivesoftware.smackx.disco.packet.DiscoverInfo;
 import org.jivesoftware.smackx.pep.PepEventListener;
 import org.jivesoftware.smackx.usertune.element.UserTuneElement;
 
@@ -35,7 +32,6 @@ import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
-import org.jxmpp.jid.EntityBareJid;
 
 public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
 
@@ -66,21 +62,15 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
         final SimpleResultSyncPoint userTuneReceived = new SimpleResultSyncPoint();
         final SimpleResultSyncPoint notificationFilterReceived = new SimpleResultSyncPoint();
 
-        ServiceDiscoveryManager.getInstanceFor(conTwo).addEntityCapabilitiesChangedListener(new EntityCapabilitiesChangedListener() {
-            @Override
-            public void onEntityCapabilitiesChanged(DiscoverInfo info) {
-                if (info.containsFeature(UserTuneManager.USERTUNE_NODE+"+notify")) {
-                    notificationFilterReceived.signal();
-                }
+        ServiceDiscoveryManager.getInstanceFor(conTwo).addEntityCapabilitiesChangedListener(info -> {
+            if (info.containsFeature(UserTuneManager.USERTUNE_NODE+"+notify")) {
+                notificationFilterReceived.signal();
             }
         });
 
-        final PepEventListener<UserTuneElement> userTuneListener = new PepEventListener<UserTuneElement>() {
-            @Override
-            public void onPepEvent(EntityBareJid jid, UserTuneElement userTuneElement, String id, Message message) {
-                if (userTuneElement.equals(userTuneElement1)) {
-                    userTuneReceived.signal();
-                }
+        final PepEventListener<UserTuneElement> userTuneListener = (jid, userTuneElement, id, message) -> {
+            if (userTuneElement.equals(userTuneElement1)) {
+                userTuneReceived.signal();
             }
         };
 

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
@@ -57,19 +57,21 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
     /**
      * Verifies that a notification is sent when a publication is received, assuming that notification filtering
      * has been adjusted to allow for the notification to be delivered.
+     *
+     * @throws Exception if the test fails
      */
     @SmackIntegrationTest
     public void testNotification() throws Exception {
         URI uri = new URI("http://www.yesworld.com/lyrics/Fragile.html#9");
         UserTuneElement.Builder builder = UserTuneElement.getBuilder();
         UserTuneElement data = builder.setArtist("Yes")
-                                                  .setLength(686)
-                                                  .setRating(8)
-                                                  .setSource("Yessongs")
-                                                  .setTitle("Heart of the Sunrise")
-                                                  .setTrack("3")
-                                                  .setUri(uri)
-                                                  .build();
+                .setLength(686)
+                .setRating(8)
+                .setSource("Yessongs")
+                .setTitle("Heart of the Sunrise")
+                .setTrack("3")
+                .setUri(uri)
+                .build();
 
         IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
 
@@ -105,6 +107,8 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
     /**
      * Verifies that a notification for a previously sent publication is received as soon as notification filtering
      * has been adjusted to allow for the notification to be delivered.
+     *
+     * @throws Exception if the test fails
      */
     @SmackIntegrationTest
     public void testNotificationAfterFilterChange() throws Exception {
@@ -159,9 +163,10 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
      * @param userTuneManager The UserTuneManager instance for the connection that is expected to receive data.
      * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
      * @param listener A listener instance for UserTune data that is to be registered.
+     *
+     * @throws Exception if the test fails
      */
-    public void registerListenerAndWait(UserTuneManager userTuneManager, ServiceDiscoveryManager discoManager, PepEventListener<UserTuneElement> listener) throws Exception
-    {
+    public void registerListenerAndWait(UserTuneManager userTuneManager, ServiceDiscoveryManager discoManager, PepEventListener<UserTuneElement> listener) throws Exception {
         final SimpleResultSyncPoint notificationFilterReceived = new SimpleResultSyncPoint();
         final EntityCapabilitiesChangedListener notificationFilterReceivedListener = info -> {
             if (info.containsFeature(UserTuneManager.USERTUNE_NODE + "+notify")) {
@@ -185,8 +190,7 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
      * @param userTuneManager The UserTuneManager instance for the connection that was expected to receive data.
      * @param listener A listener instance for UserTune data that is to be removed.
      */
-    public void unregisterListener(UserTuneManager userTuneManager, PepEventListener<UserTuneElement> listener)
-    {
+    public void unregisterListener(UserTuneManager userTuneManager, PepEventListener<UserTuneElement> listener) {
         // Does it make sense to have a method implementation that's one line? This is provided to allow for symmetry in the API.
         userTuneManager.removeUserTuneListener(listener);
     }
@@ -197,9 +201,10 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
      * @param userTuneManager The UserTuneManager instance for the connection that is expected to publish data.
      * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
      * @param data The data to be published.
+     *
+     * @throws Exception if the test fails
      */
-    public void publishAndWait(UserTuneManager userTuneManager, ServiceDiscoveryManager discoManager, UserTuneElement data) throws Exception
-    {
+    public void publishAndWait(UserTuneManager userTuneManager, ServiceDiscoveryManager discoManager, UserTuneElement data) throws Exception {
         final SimpleResultSyncPoint publicationEchoReceived = new SimpleResultSyncPoint();
         final PepEventListener<UserTuneElement> publicationEchoListener = (jid, userTune, id, message) -> {
             if (userTune.equals(data)) {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
@@ -17,11 +17,13 @@
 package org.jivesoftware.smackx.usertune;
 
 import java.net.URI;
+import java.util.concurrent.TimeoutException;
 
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NotLoggedInException;
 import org.jivesoftware.smack.XMPPException;
 
+import org.jivesoftware.smackx.disco.EntityCapabilitiesChangedListener;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 import org.jivesoftware.smackx.pep.PepEventListener;
 import org.jivesoftware.smackx.usertune.element.UserTuneElement;
@@ -32,6 +34,7 @@ import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.junit.jupiter.api.Assertions;
 
 public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
 
@@ -44,11 +47,22 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
         utm2 = UserTuneManager.getInstanceFor(conTwo);
     }
 
+    @AfterClass
+    public void unsubscribe()
+            throws SmackException.NotLoggedInException, XMPPException.XMPPErrorException,
+            SmackException.NotConnectedException, InterruptedException, SmackException.NoResponseException {
+        IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+    }
+
+    /**
+     * Verifies that a notification is sent when a publication is received, assuming that notification filtering
+     * has been adjusted to allow for the notification to be delivered.
+     */
     @SmackIntegrationTest
-    public void test() throws Exception {
+    public void testNotification() throws Exception {
         URI uri = new URI("http://www.yesworld.com/lyrics/Fragile.html#9");
         UserTuneElement.Builder builder = UserTuneElement.getBuilder();
-        UserTuneElement userTuneElement1 = builder.setArtist("Yes")
+        UserTuneElement data = builder.setArtist("Yes")
                                                   .setLength(686)
                                                   .setRating(8)
                                                   .setSource("Yessongs")
@@ -60,39 +74,138 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
         IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
 
         final SimpleResultSyncPoint userTuneReceived = new SimpleResultSyncPoint();
-        final SimpleResultSyncPoint notificationFilterReceived = new SimpleResultSyncPoint();
 
-        ServiceDiscoveryManager.getInstanceFor(conTwo).addEntityCapabilitiesChangedListener(info -> {
-            if (info.containsFeature(UserTuneManager.USERTUNE_NODE+"+notify")) {
-                notificationFilterReceived.signal();
-            }
-        });
-
-        final PepEventListener<UserTuneElement> userTuneListener = (jid, userTuneElement, id, message) -> {
-            if (userTuneElement.equals(userTuneElement1)) {
+        final PepEventListener<UserTuneElement> userTuneListener = (jid, userTune, id, message) -> {
+            if (userTune.equals(data)) {
                 userTuneReceived.signal();
             }
         };
 
-        // Adds listener, which implicitly publishes a disco/info filter for usertune notification.
-        utm2.addUserTuneListener(userTuneListener);
-
         try {
-            // Waits until ConTwo's newly-published interested in receiving usertune notifications has been propagated.
-            notificationFilterReceived.waitForResult(timeout);
+            // Register ConTwo's interest in receiving user tune notifications, and wait for that interest to have been propagated.
+            registerListenerAndWait(utm2, ServiceDiscoveryManager.getInstanceFor(conTwo), userTuneListener);
 
-            // Publish the data, and wait for it to be received.
-            utm1.publishUserTune(userTuneElement1);
-            userTuneReceived.waitForResult(timeout);
+            // Publish the data.
+            utm1.publishUserTune(data); // for the purpose of this test, this needs not be blocking/use publishAndWait();
+
+            // Wait for the data to be received.
+            try {
+                userTuneReceived.waitForResult(timeout);
+            } catch (TimeoutException e) {
+                Assertions.fail("Expected to receive a PEP notification, but did not.");
+            }
         } finally {
-            utm2.removeUserTuneListener(userTuneListener);
+            unregisterListener(utm2, userTuneListener);
         }
     }
 
-    @AfterClass
-    public void unsubscribe()
-            throws SmackException.NotLoggedInException, XMPPException.XMPPErrorException,
-            SmackException.NotConnectedException, InterruptedException, SmackException.NoResponseException {
-        IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+    /**
+     * Verifies that a notification for a previously sent publication is received as soon as notification filtering
+     * has been adjusted to allow for the notification to be delivered.
+     */
+    @SmackIntegrationTest
+    public void testNotificationAfterFilterChange() throws Exception {
+        URI uri = new URI("http://www.yesworld.com/lyrics/Fragile.html#8");
+        UserTuneElement.Builder builder = UserTuneElement.getBuilder();
+        UserTuneElement data = builder.setArtist("No")
+                .setLength(306)
+                .setRating(3)
+                .setSource("NoSongs")
+                .setTitle("Sunrise of the Heart")
+                .setTrack("2")
+                .setUri(uri)
+                .build();
+
+        IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
+
+        final SimpleResultSyncPoint userTuneReceived = new SimpleResultSyncPoint();
+
+        final PepEventListener<UserTuneElement> userTuneListener = (jid, userTune, id, message) -> {
+            if (userTune.equals(data)) {
+                userTuneReceived.signal();
+            }
+        };
+
+        // TODO Ensure that pre-existing filtering notification excludes userTune.
+        try {
+            // Publish the data
+            publishAndWait(utm1, ServiceDiscoveryManager.getInstanceFor(conOne), data);
+
+            // Adds listener, which implicitly publishes a disco/info filter for userTune notification.
+            registerListenerAndWait(utm2, ServiceDiscoveryManager.getInstanceFor(conTwo), userTuneListener);
+
+            // Wait for the data to be received.
+            try {
+                userTuneReceived.waitForResult(timeout);
+            } catch (TimeoutException e) {
+                Assertions.fail("Expected to receive a PEP notification, but did not.");
+            }
+        } finally {
+            unregisterListener(utm2, userTuneListener);
+        }
+    }
+
+    /**
+     * Registers a listener for User Tune data. This implicitly publishes a CAPS update to include a notification
+     * filter for the usertune node. This method blocks until the server has indicated that this update has been
+     * received.
+     *
+     * @param userTuneManager The UserTuneManager instance for the connection that is expected to receive data.
+     * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
+     * @param listener A listener instance for UserTune data that is to be registered.
+     */
+    public void registerListenerAndWait(UserTuneManager userTuneManager, ServiceDiscoveryManager discoManager, PepEventListener<UserTuneElement> listener) throws Exception
+    {
+        final SimpleResultSyncPoint notificationFilterReceived = new SimpleResultSyncPoint();
+        final EntityCapabilitiesChangedListener notificationFilterReceivedListener = info -> {
+            if (info.containsFeature(UserTuneManager.USERTUNE_NODE + "+notify")) {
+                notificationFilterReceived.signal();
+            }
+        };
+
+        discoManager.addEntityCapabilitiesChangedListener(notificationFilterReceivedListener);
+        try {
+            userTuneManager.addUserTuneListener(listener);
+            notificationFilterReceived.waitForResult(timeout);
+        } finally {
+            discoManager.removeEntityCapabilitiesChangedListener(notificationFilterReceivedListener);
+        }
+    }
+
+    /**
+     * The functionally reverse of {@link #registerListenerAndWait(UserTuneManager, ServiceDiscoveryManager, PepEventListener)}
+     * with the difference of not being a blocking operation.
+     *
+     * @param userTuneManager The UserTuneManager instance for the connection that was expected to receive data.
+     * @param listener A listener instance for UserTune data that is to be removed.
+     */
+    public void unregisterListener(UserTuneManager userTuneManager, PepEventListener<UserTuneElement> listener)
+    {
+        // Does it make sense to have a method implementation that's one line? This is provided to allow for symmetry in the API.
+        userTuneManager.removeUserTuneListener(listener);
+    }
+
+    /**
+     * Publish data using PEP, and block until the server has echoed the publication back to the publishing user.
+     *
+     * @param userTuneManager The UserTuneManager instance for the connection that is expected to publish data.
+     * @param discoManager The ServiceDiscoveryManager instance for the connection that is expected to publish data.
+     * @param data The data to be published.
+     */
+    public void publishAndWait(UserTuneManager userTuneManager, ServiceDiscoveryManager discoManager, UserTuneElement data) throws Exception
+    {
+        final SimpleResultSyncPoint publicationEchoReceived = new SimpleResultSyncPoint();
+        final PepEventListener<UserTuneElement> publicationEchoListener = (jid, userTune, id, message) -> {
+            if (userTune.equals(data)) {
+                publicationEchoReceived.signal();
+            }
+        };
+        try {
+            registerListenerAndWait(userTuneManager, discoManager, publicationEchoListener);
+            userTuneManager.addUserTuneListener(publicationEchoListener);
+            userTuneManager.publishUserTune(data);
+        } finally {
+            userTuneManager.removeUserTuneListener(publicationEchoListener);
+        }
     }
 }


### PR DESCRIPTION
Several PEP-based Smack Integration Test Framework tests have been disabled in the CI pipeline for Openfire, as they frequently, but inconsistently, failed. The changes in this PR address that.

Each of these tests depend on a pubsub notification filter to be in place, to allow the intended recipient to receive a notification. A race condition exists where the setting of that filter competes with the publishing of data.

The changes in this PR add a synchronization point to explicitly wait for the filter to have been set, before proceeding to execute the test.