### PR TITLE
Add method to remove registered CAPS listener

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/ServiceDiscoveryManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/ServiceDiscoveryManager.java
@@ -921,6 +921,10 @@ public final class ServiceDiscoveryManager extends Manager {
         return entityCapabilitiesChangedListeners.add(entityCapabilitiesChangedListener);
     }
 
+    public boolean removeEntityCapabilitiesChangedListener(EntityCapabilitiesChangedListener entityCapabilitiesChangedListener) {
+        return entityCapabilitiesChangedListeners.remove(entityCapabilitiesChangedListener);
+    }
+
     private static final int RENEW_ENTITY_CAPS_DELAY_MILLIS = 25;
 
     private ScheduledAction renewEntityCapsScheduledAction;


### PR DESCRIPTION
ServiceDiscoveryManager allows a listener for CAPS changes to be
registered. It should also allow to remove a previously registered
listener.