### PR TITLE
Prevent premature reading of file transfer data

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransfer.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransfer.java
@@ -209,7 +209,7 @@ public abstract class FileTransfer {
         int count = 0;
         amountWritten = 0;
 
-        while ((count = in.read(b)) > 0 && !getStatus().equals(Status.cancelled)) {
+        while ((count = in.read(b)) > -1 && !getStatus().equals(Status.cancelled)) {
             out.write(b, 0, count);
             amountWritten += count;
         }


### PR DESCRIPTION
When reading from an inputstream, reading 0 bytes does not signal EOF.

I suspect that this is causing an issue where a file is (partially)
transferred, before being marked as 'cancelled'. Spark suffers from
this (SPARK-2200). Potentially affects files that contain multi-byte
characters more than others.
