### PR TITLE
SINT: MAM test does not require XEP-0441

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mam/MamIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mam/MamIntegrationTest.java
@@ -59,7 +59,11 @@ public class MamIntegrationTest extends AbstractSmackIntegrationTest {
         }
 
         // Make sure MAM is archiving messages.
-        mamManagerConTwo.enableMamForAllMessages();
+        try {
+            mamManagerConTwo.enableMamForAllMessages();
+        } catch ( XMPPErrorException e ) {
+            // Server doesn't support XEP-0441.
+        }
     }
 
     @SmackIntegrationTest


### PR DESCRIPTION
The MAM integration test setup attepts to set MAM preferences (XEP-0441).
When a server does not support this XEP, the setup phase errors out, preventing
the tests from being executed.

There is no functional reason why tests shouldn't be run when XEP-0441 is not
supported: the tests can run against the default configuration of the MAM
service.

This commit ignores any errors that occur when MAM preferences are set.