### PR TITLE
[core] AbstractProvider should also consider TypeVariable

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/AbstractProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/AbstractProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2019-2020 Florian Schmaus
+ * Copyright 2019-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.jivesoftware.smack.provider;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 
 import org.jivesoftware.smack.packet.Element;
 
@@ -42,9 +43,12 @@ public class AbstractProvider<E extends Element> {
         } else if (elementType instanceof ParameterizedType) {
             ParameterizedType parameteriezedElementType = (ParameterizedType) elementType;
             elementClass = (Class<E>) parameteriezedElementType.getRawType();
+        } else if (elementType instanceof TypeVariable) {
+            TypeVariable<?> typeVariableElementType = (TypeVariable<?>) elementType;
+            elementClass = (Class<E>) typeVariableElementType.getClass();
         } else {
-            throw new AssertionError(
-                            "Element type '" + elementType + "' is neither of type Class or ParameterizedType");
+            throw new AssertionError("Element type '" + elementType + "' (" + elementType.getClass()
+                            + ") is neither of type Class, ParameterizedType or TypeVariable");
         }
     }
 


### PR DESCRIPTION
aTalk shows the following exception:

2020-12-14 12:11:13.704 7370-30976/org.atalk.android E/AndroidRuntime: FATAL EXCEPTION: AccountManager.loadStoredAccounts
    Process: org.atalk.android, PID: 7370
    java.lang.AssertionError: Element type 'EE' is neither of type Class or ParameterizedType
        at org.jivesoftware.smack.provider.AbstractProvider.<init>(AbstractProvider.java:46)
        at org.jivesoftware.smack.provider.Provider.<init>(Provider.java:40)
        at org.jivesoftware.smack.provider.ExtensionElementProvider.<init>(ExtensionElementProvider.java:29)
        at org.xmpp.extensions.DefaultExtensionElementProvider.<init>(DefaultExtensionElementProvider.java:43)
        at org.xmpp.extensions.coin.CoinIQProvider.<init>(CoinIQProvider.java:46)
        at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.initialize(ProtocolProviderServiceJabberImpl.java:2091)
        at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderFactoryJabberImpl.createService(ProtocolProviderFactoryJabberImpl.java:121)
        at net.java.sip.communicator.service.protocol.ProtocolProviderFactory.loadAccount(ProtocolProviderFactory.java:934)
        at net.java.sip.communicator.service.protocol.AccountManager.doLoadStoredAccounts(AccountManager.java:139)
        at net.java.sip.communicator.service.protocol.AccountManager.loadStoredAccounts(AccountManager.java:294)
        at net.java.sip.communicator.service.protocol.AccountManager.runInLoadStoredAccountsThread(AccountManager.java:394)
        at net.java.sip.communicator.service.protocol.AccountManager.access$000(AccountManager.java:36)
        at
		net.java.sip.communicator.service.protocol.AccountManager$1.run(AccountManager.java:329)

where CoinIQProvider line 46-47 [1] reads

    private final DefaultExtensionElementProvider<URIsExtension> urisProvider
            = new
			DefaultExtensionElementProvider<>(URIsExtension.class);

This fixes SMACK-898.

1: https://github.com/cmeng-git/atalk-android/blob/f61f264312ed9298b96a132c3000dc1031489a74/aTalk/src/main/java/org/xmpp/extensions/coin/CoinIQProvider.java#L47