### PR TITLE
Bump ErrorProne to 2.5.1 and refactor Providers a bit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id 'ru.vyarus.animalsniffer' version '1.5.0'
-	id 'net.ltgt.errorprone' version '1.1.1'
+	id 'net.ltgt.errorprone' version '1.3.0'
 	// Use e.g. "gradle <task> taskTree" to show its dependency tree.
 	id 'com.dorongold.task-tree' version '1.5'
 	id 'com.github.kt3k.coveralls' version '2.10.2'
@@ -218,6 +218,8 @@ allprojects {
 				// Disabled but should be re-enabled at some point
 				//'-Xep:InconsistentCapitalization:OFF',
 				'-Xep:MixedMutabilityReturnType:OFF',
+				// TODO: Re-enable once Smack's minimum Android SDK level is 26 or higher.
+				'-Xep:JavaUtilDate:OFF',
 			]
 		}
 	}
@@ -293,7 +295,7 @@ tasks.withType(Javadoc) {
 		testImplementation 'org.mockito:mockito-inline:3.3.3'
 		testImplementation 'com.jamesmurty.utils:java-xmlbuilder:1.2'
 
-		errorprone 'com.google.errorprone:error_prone_core:2.3.4'
+		errorprone 'com.google.errorprone:error_prone_core:2.5.1'
 		errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
 	}
 

--- a/smack-android-extensions/src/main/java/org/jivesoftware/smackx/ping/android/ServerPingWithAlarmManager.java
+++ b/smack-android-extensions/src/main/java/org/jivesoftware/smackx/ping/android/ServerPingWithAlarmManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2014-2017 Florian Schmaus
+ * Copyright © 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.jivesoftware.smackx.ping.android;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
@@ -113,14 +112,14 @@ public final class ServerPingWithAlarmManager extends Manager {
         @Override
         public void onReceive(Context context, Intent intent) {
             LOGGER.fine("Ping Alarm broadcast received");
-            Set<Entry<XMPPConnection, ServerPingWithAlarmManager>> managers;
+            Set<Map.Entry<XMPPConnection, ServerPingWithAlarmManager>> managers;
             synchronized (ServerPingWithAlarmManager.class) {
                 // Make a copy to avoid ConcurrentModificationException when
                 // iterating directly over INSTANCES and the Set is modified
                 // concurrently by creating a new ServerPingWithAlarmManager.
                 managers = new HashSet<>(INSTANCES.entrySet());
             }
-            for (Entry<XMPPConnection, ServerPingWithAlarmManager> entry : managers) {
+            for (Map.Entry<XMPPConnection, ServerPingWithAlarmManager> entry : managers) {
                 XMPPConnection connection = entry.getKey();
                 if (entry.getValue().isEnabled()) {
                     LOGGER.fine("Calling pingServerIfNecessary for connection "

--- a/smack-core/src/main/java/org/jivesoftware/smack/SASLAuthentication.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SASLAuthentication.java
@@ -249,7 +249,6 @@ public final class SASLAuthentication {
      * Notification message saying that SASL authentication was successful. The next step
      * would be to bind the resource.
      * @param success result of the authentication.
-     * @throws SmackException if Smack detected an exceptional situation.
      * @throws InterruptedException if the calling thread was interrupted.
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws SmackSaslException if a SASL specific error occurred.

--- a/smack-core/src/main/java/org/jivesoftware/smack/StanzaCollector.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/StanzaCollector.java
@@ -343,7 +343,7 @@ public final class StanzaCollector implements AutoCloseable {
      *
      * @param packet the stanza to process.
      */
-    protected void processStanza(Stanza packet) {
+    void processStanza(Stanza packet) {
         if (packetFilter == null || packetFilter.accept(packet)) {
             synchronized (this) {
                 if (resultQueue.size() == maxQueueSize) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
@@ -99,7 +99,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
 
     private boolean featuresReceived;
 
-    protected boolean streamResumed;
+    private boolean streamResumed;
 
     private GraphVertex<State> currentStateVertex;
 
@@ -264,7 +264,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         walkStateGraph(walkStateGraphContext);
     }
 
-    protected WalkStateGraphContext.Builder buildNewWalkTo(Class<? extends StateDescriptor> finalStateClass) {
+    private WalkStateGraphContext.Builder buildNewWalkTo(Class<? extends StateDescriptor> finalStateClass) {
         return WalkStateGraphContext.builder(currentStateVertex.getElement().getStateDescriptor().getClass(), finalStateClass);
     }
 
@@ -279,7 +279,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         revertedState.resetState();
     }
 
-    protected void walkStateGraph(WalkStateGraphContext walkStateGraphContext)
+    private void walkStateGraph(WalkStateGraphContext walkStateGraphContext)
                     throws XMPPException, IOException, SmackException, InterruptedException {
         // Save a copy of the current state
         GraphVertex<State> previousStateVertex = currentStateVertex;
@@ -491,7 +491,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         }
     }
 
-    protected SSLSession getSSLSession() {
+    private SSLSession getSSLSession() {
         final XmppClientToServerTransport transport = activeTransport;
         if (transport == null) {
             return null;
@@ -505,7 +505,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         notifyWaitingThreads();
     }
 
-    protected void parseAndProcessElement(String element) {
+    private void parseAndProcessElement(String element) {
         try {
             XmlPullParser parser = PacketParserUtils.getParserFor(element);
 
@@ -556,11 +556,11 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         }
     }
 
-    protected synchronized void prepareToWaitForFeaturesReceived() {
+    private synchronized void prepareToWaitForFeaturesReceived() {
         featuresReceived = false;
     }
 
-    protected void waitForFeaturesReceived(String waitFor)
+    private void waitForFeaturesReceived(String waitFor)
                     throws InterruptedException, SmackException, XMPPException {
         waitForConditionOrThrowConnectionException(() -> featuresReceived, waitFor);
     }
@@ -571,7 +571,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         return streamOpenAndCloseFactory.createStreamOpen(to, from, id, lang);
     }
 
-    protected void newStreamOpenWaitForFeaturesSequence(String waitFor) throws InterruptedException,
+    private void newStreamOpenWaitForFeaturesSequence(String waitFor) throws InterruptedException,
                     SmackException, XMPPException {
         prepareToWaitForFeaturesReceived();
 
@@ -1028,7 +1028,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         return connectionStateMachineListeners.remove(connectionStateMachineListener);
     }
 
-    protected void invokeConnectionStateMachineListener(ConnectionStateEvent connectionStateEvent) {
+    private void invokeConnectionStateMachineListener(ConnectionStateEvent connectionStateEvent) {
         if (connectionStateMachineListeners.isEmpty()) {
             return;
         }
@@ -1056,7 +1056,7 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         walkStateGraph(walkStateGraphContext);
     }
 
-    protected Map<String, Object> getFilterStats() {
+    private Map<String, Object> getFilterStats() {
         Collection<XmppInputOutputFilter> filters;
         synchronized (this) {
             if (inputOutputFilters.isEmpty() && previousInputOutputFilters != null) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/IQTypeFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/IQTypeFilter.java
@@ -27,6 +27,7 @@ import org.jivesoftware.smack.util.Objects;
  * @author Alexander Wenckus
  *
  */
+@SuppressWarnings("BadImport")
 public final class IQTypeFilter extends FlexibleStanzaTypeFilter<IQ> {
 
     public static final StanzaFilter GET = new IQTypeFilter(Type.get);

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/MessageTypeFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/MessageTypeFilter.java
@@ -27,6 +27,7 @@ import org.jivesoftware.smack.packet.Message.Type;
  * @see org.jivesoftware.smack.packet.Message.Type
  * @author Ward Harold
  */
+@SuppressWarnings("BadImport")
 public final class MessageTypeFilter extends FlexibleStanzaTypeFilter<Message> {
 
     public static final StanzaFilter NORMAL = new MessageTypeFilter(Type.normal);

--- a/smack-core/src/main/java/org/jivesoftware/smack/filter/PresenceTypeFilter.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/filter/PresenceTypeFilter.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2014 Florian Schmaus
+ * Copyright 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.jivesoftware.smack.util.Objects;
  * A filter for Presence types. Returns true only if the stanza is an Presence stanza and it matches the type provided in the
  * constructor.
  */
+@SuppressWarnings("BadImport")
 public final class PresenceTypeFilter extends FlexibleStanzaTypeFilter<Presence> {
 
     public static final PresenceTypeFilter AVAILABLE = new PresenceTypeFilter(Type.available);

--- a/smack-core/src/main/java/org/jivesoftware/smack/iqrequest/AbstractIqRequestHandler.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/iqrequest/AbstractIqRequestHandler.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2015 Florian Schmaus
+ * Copyright 2015-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.jivesoftware.smack.iqrequest;
 
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 
 /**
  * Convenience class to create IQ requests handlers.
@@ -26,10 +25,10 @@ public abstract class AbstractIqRequestHandler implements IQRequestHandler {
 
     private final String element;
     private final String namespace;
-    private final Type type;
+    private final IQ.Type type;
     private final Mode mode;
 
-    protected AbstractIqRequestHandler(String element, String namespace, Type type, Mode mode) {
+    protected AbstractIqRequestHandler(String element, String namespace, IQ.Type type, Mode mode) {
         switch (type) {
         case set:
         case get:
@@ -52,7 +51,7 @@ public abstract class AbstractIqRequestHandler implements IQRequestHandler {
     }
 
     @Override
-    public Type getType() {
+    public IQ.Type getType() {
         return type;
     }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/parsing/SmackParsingException.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/parsing/SmackParsingException.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2019-2020 Florian Schmaus
+ * Copyright 2019-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,24 @@ public class SmackParsingException extends Exception {
         super(message);
     }
 
+    /**
+     * Deprecated, do not import.
+     * @deprecated do not import.
+     */
+    @Deprecated
+    // TODO: Remove in Smack 4.6.
     public static class SmackTextParseException extends SmackParsingException {
         /**
          *
          */
         private static final long serialVersionUID = 1L;
 
+        /**
+         * Deprecated, do not use.
+         * @param parsingException the exception.
+         * @deprecated do not use, simply throw ParseException.
+         */
+        @Deprecated
         public SmackTextParseException(ParseException parsingException) {
             super(parsingException);
         }

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/AbstractProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/AbstractProvider.java
@@ -16,11 +16,15 @@
  */
 package org.jivesoftware.smack.provider;
 
+import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.Element;
+import org.jivesoftware.smack.parsing.SmackParsingException;
+import org.jivesoftware.smack.xml.XmlPullParserException;
 
 public class AbstractProvider<E extends Element> {
 
@@ -54,5 +58,52 @@ public class AbstractProvider<E extends Element> {
 
     public final Class<E> getElementClass() {
         return elementClass;
+    }
+
+    public static final class TextParseException extends SmackParsingException {
+        /**
+         *
+         */
+        private static final long serialVersionUID = 1L;
+
+        private final ParseException parseException;
+
+        private TextParseException(ParseException parseException) {
+            super(parseException);
+            this.parseException = parseException;
+        }
+
+        public ParseException getParseException() {
+            return parseException;
+        }
+    }
+
+    public static final class NumberFormatParseException extends SmackParsingException {
+        /**
+         *
+         */
+        private static final long serialVersionUID = 1L;
+
+        private NumberFormatParseException(NumberFormatException numberFormatException) {
+            super(numberFormatException);
+        }
+    }
+
+    protected interface WrappableParser<E> {
+        E parse() throws XmlPullParserException, IOException, SmackParsingException, ParseException;
+    }
+
+    protected static <E> E wrapExceptions(WrappableParser<E> parser)
+                    throws XmlPullParserException, IOException, SmackParsingException {
+        E e;
+        try {
+            e = parser.parse();
+        } catch (ParseException parseException) {
+            throw new TextParseException(parseException);
+        } catch (NumberFormatException numberFormatException) {
+            throw new NumberFormatParseException(numberFormatException);
+        }
+
+        return e;
     }
 }

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/IQProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/IQProvider.java
@@ -18,6 +18,7 @@
 package org.jivesoftware.smack.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.IqData;
@@ -50,7 +51,7 @@ public abstract class IQProvider<I extends IQ> extends IqProvider<I> {
         final int initialDepth = parser.getDepth();
         final XmlEnvironment xmlEnvironment = XmlEnvironment.from(parser, outerXmlEnvironment);
 
-        I e = parse(parser, initialDepth, xmlEnvironment);
+        I e = wrapExceptions(() -> parse(parser, initialDepth, xmlEnvironment));
 
         // XPP3 calling convention assert: Parser should be at end tag of the consumed/parsed element
         ParserUtils.forwardToEndTagOfDepth(parser, initialDepth);
@@ -59,11 +60,12 @@ public abstract class IQProvider<I extends IQ> extends IqProvider<I> {
 
     @Override
     public final I parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
-                    throws XmlPullParserException, IOException, SmackParsingException {
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         // Old-style IQ parsers do not need IqData.
         return parse(parser, initialDepth, xmlEnvironment);
     }
 
-    public abstract I parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException;
+    public abstract I parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException;
 
 }

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/IntrospectionProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/IntrospectionProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2014-2019 Florian Schmaus
+ * Copyright © 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ public class IntrospectionProvider{
      * @param type the type of the property.
      * @param value the encode String value to decode.
      * @return the String value decoded into the specified type.
-     * @throws ClassNotFoundException
+     * @throws ClassNotFoundException if the provided class was not found.
      */
     private static Object decode(Class<?> type, String value) throws ClassNotFoundException {
         String name = type.getName();

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/IqProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/IqProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2019 Florian Schmaus
+ * Copyright 2019-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smack.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.IqData;
@@ -37,10 +38,12 @@ public abstract class IqProvider<I extends IQ> extends AbstractProvider<I> {
         final int initialDepth = parser.getDepth();
         final XmlEnvironment xmlEnvironment = XmlEnvironment.from(parser, outerXmlEnvironment);
 
-        return parse(parser, initialDepth, iqData, xmlEnvironment);
+        I i = wrapExceptions(() -> parse(parser, initialDepth, iqData, xmlEnvironment));
+
+        return i;
     }
 
     public abstract I parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
-                    throws XmlPullParserException, IOException, SmackParsingException;
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException;
 
 }

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/Provider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/Provider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2014-2019 Florian Schmaus
+ * Copyright © 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 package org.jivesoftware.smack.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.Element;
 import org.jivesoftware.smack.packet.XmlEnvironment;
@@ -50,12 +51,13 @@ public abstract class Provider<E extends Element> extends AbstractProvider<E> {
         final int initialDepth = parser.getDepth();
         final XmlEnvironment xmlEnvironment = XmlEnvironment.from(parser, outerXmlEnvironment);
 
-        E e = parse(parser, initialDepth, xmlEnvironment);
+        E e = wrapExceptions(() -> parse(parser, initialDepth, xmlEnvironment));
 
         // XPP3 calling convention assert: Parser should be at end tag of the consumed/parsed element
         ParserUtils.forwardToEndTagOfDepth(parser, initialDepth);
         return e;
     }
 
-    public abstract E parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException;
+    public abstract E parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException;
 }

--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/ScramMechanism.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/ScramMechanism.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2014-2020 Florian Schmaus
+ * Copyright 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import java.util.Random;
 
 import javax.security.auth.callback.CallbackHandler;
 
-import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.SmackSaslException;
 import org.jivesoftware.smack.sasl.SASLMechanism;
 import org.jivesoftware.smack.util.ByteUtils;
@@ -263,6 +262,7 @@ public abstract class ScramMechanism extends SASLMechanism {
     }
 
     /**
+     * Get the channel binding data.
      *
      * @return the Channel Binding data.
      * @throws SmackSaslException if a SASL specific error occurred.
@@ -361,7 +361,7 @@ public abstract class ScramMechanism extends SASLMechanism {
      * @param key TODO javadoc me please
      * @param str TODO javadoc me please
      * @return the HMAC-SHA1 value of the input.
-     * @throws SmackException if Smack detected an exceptional situation.
+     * @throws SmackSaslException if Smack detected an exceptional situation.
      */
     private byte[] hmac(byte[] key, byte[] str) throws SmackSaslException {
         try {

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/MultiMap.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/MultiMap.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2015-2020 Florian Schmaus
+ * Copyright © 2015-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 /**
@@ -251,7 +250,7 @@ public class MultiMap<K, V> {
 
     public MultiMap<K, V> asUnmodifiableMultiMap() {
         LinkedHashMap<K, List<V>> mapCopy = new LinkedHashMap<>(map.size());
-        for (Entry<K, List<V>> entry : map.entrySet()) {
+        for (Map.Entry<K, List<V>> entry : map.entrySet()) {
             K key = entry.getKey();
             List<V> values = entry.getValue();
 
@@ -266,7 +265,7 @@ public class MultiMap<K, V> {
         Map<K, List<V>> clonedMap = new LinkedHashMap<>(map.size());
 
         // TODO: Use Map.forEach() once Smack's minimum Android API is 24 or higher.
-        for (Entry<K, List<V>> entry : map.entrySet()) {
+        for (Map.Entry<K, List<V>> entry : map.entrySet()) {
             List<V> clonedList = CollectionUtil.newListWith(entry.getValue());
             clonedMap.put(entry.getKey(), clonedList);
         }

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/ParserUtils.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/ParserUtils.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2014-2019 Florian Schmaus
+ * Copyright © 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.jivesoftware.smack.datatypes.UInt32;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.parsing.SmackParsingException.RequiredAttributeMissingException;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.parsing.SmackParsingException.SmackUriSyntaxParsingException;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -308,30 +307,23 @@ public class ParserUtils {
         return s;
     }
 
-    public static Date getDateFromOptionalXep82String(String dateString) throws SmackTextParseException {
+    public static Date getDateFromOptionalXep82String(String dateString) throws ParseException {
         if (dateString == null) {
             return null;
         }
         return getDateFromXep82String(dateString);
     }
 
-    public static Date getDateFromXep82String(String dateString) throws SmackTextParseException {
-        try {
-            return XmppDateTime.parseXEP0082Date(dateString);
-        } catch (ParseException e) {
-            throw new SmackParsingException.SmackTextParseException(e);
-        }
+    public static Date getDateFromXep82String(String dateString) throws ParseException {
+        return XmppDateTime.parseXEP0082Date(dateString);
     }
 
-    public static Date getDateFromString(String dateString) throws SmackTextParseException {
-        try {
-            return XmppDateTime.parseDate(dateString);
-        } catch (ParseException e) {
-            throw new SmackParsingException.SmackTextParseException(e);
-        }
+    public static Date getDateFromString(String dateString) throws ParseException {
+        return XmppDateTime.parseDate(dateString);
     }
 
-    public static Date getDateFromNextText(XmlPullParser parser) throws XmlPullParserException, IOException, SmackTextParseException {
+    public static Date getDateFromNextText(XmlPullParser parser)
+                    throws XmlPullParserException, IOException, ParseException {
         String dateString = parser.nextText();
         return getDateFromString(dateString);
     }

--- a/smack-core/src/main/java/org/jivesoftware/smack/util/stringencoder/Base32.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/stringencoder/Base32.java
@@ -104,6 +104,8 @@ public class Base32 {
                 for (int j = 0; j < blocklen; j++)
                     ds.writeByte((byte) (t[j] & 0xFF));
             } catch (IOException e) {
+                // This should not happen.
+                throw new AssertionError(e);
             }
         }
 

--- a/smack-core/src/test/java/org/jivesoftware/smack/ConnectionConfigurationTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/ConnectionConfigurationTest.java
@@ -53,7 +53,7 @@ public class ConnectionConfigurationTest {
 
     private static final class DummyConnectionConfiguration extends ConnectionConfiguration {
 
-        protected DummyConnectionConfiguration(Builder builder) {
+        DummyConnectionConfiguration(Builder builder) {
             super(builder);
         }
 

--- a/smack-core/src/test/java/org/jivesoftware/smack/packet/XMPPErrorTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/packet/XMPPErrorTest.java
@@ -20,17 +20,14 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 
-import org.jivesoftware.smack.packet.StanzaError.Condition;
-import org.jivesoftware.smack.packet.StanzaError.Type;
-
 import org.junit.Test;
 
 public class XMPPErrorTest {
     @Test
     public void testConditionHasDefaultTypeMapping() throws NoSuchFieldException, IllegalAccessException {
-        Map<Condition, Type> conditionToTypeMap = StanzaError.CONDITION_TO_TYPE;
+        Map<StanzaError.Condition, StanzaError.Type> conditionToTypeMap = StanzaError.CONDITION_TO_TYPE;
         assertEquals("CONDITION_TO_TYPE map is likely out of sync with Condition enum",
-                Condition.values().length,
+                StanzaError.Condition.values().length,
                 conditionToTypeMap.size());
     }
 }

--- a/smack-core/src/test/java/org/jivesoftware/smack/provider/AbstractProviderTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/provider/AbstractProviderTest.java
@@ -1,0 +1,70 @@
+/**
+ *
+ * Copyright 2021 Florian Schmaus.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smack.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.parsing.SmackParsingException;
+import org.jivesoftware.smack.test.util.SmackTestUtil;
+import org.jivesoftware.smack.xml.XmlPullParser;
+import org.jivesoftware.smack.xml.XmlPullParserException;
+
+import org.junit.jupiter.api.Test;
+
+public class AbstractProviderTest {
+
+    private static final ExtensionElementProvider<ExtensionElement> NUMBER_FORMAT_THROWING_PROVIDER = new ExtensionElementProvider<ExtensionElement>() {
+        @Override
+        public ExtensionElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                        throws XmlPullParserException, IOException, SmackParsingException, ParseException {
+            throw new NumberFormatException();
+        }
+    };
+
+    private static final String MESSAGE = "dummy message";
+    private static final int VALUE = 14768234;
+    private static final ExtensionElementProvider<ExtensionElement> PARSE_EXCEPTION_THROWING_PROVIDER = new ExtensionElementProvider<ExtensionElement>() {
+        @Override
+        public ExtensionElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                        throws XmlPullParserException, IOException, SmackParsingException, ParseException {
+            throw new ParseException(MESSAGE, VALUE);
+        }
+    };
+
+    @Test
+    public void testWrapsNumberFormatException() throws XmlPullParserException, IOException {
+        XmlPullParser parser = SmackTestUtil.createDummyParser();
+        assertThrows(AbstractProvider.NumberFormatParseException.class,
+                        () -> NUMBER_FORMAT_THROWING_PROVIDER.parse(parser));
+    }
+
+    @Test
+    public void testWrapsParseException() throws XmlPullParserException, IOException {
+        XmlPullParser parser = SmackTestUtil.createDummyParser();
+        AbstractProvider.TextParseException testParseException = assertThrows(AbstractProvider.TextParseException.class,
+                        () -> PARSE_EXCEPTION_THROWING_PROVIDER.parse(parser));
+        ParseException parseException = testParseException.getParseException();
+        assertEquals(MESSAGE, parseException.getMessage());
+        assertEquals(VALUE, parseException.getErrorOffset());
+    }
+}

--- a/smack-core/src/testFixtures/java/org/jivesoftware/smack/ThreadedDummyConnection.java
+++ b/smack-core/src/testFixtures/java/org/jivesoftware/smack/ThreadedDummyConnection.java
@@ -24,7 +24,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Stanza;
 
@@ -58,7 +57,7 @@ public class ThreadedDummyConnection extends DummyConnection {
             replyPacket.setStanzaId(packet.getStanzaId());
             replyPacket.setTo(packet.getFrom());
             if (replyPacket.getType() == null) {
-                replyPacket.setType(Type.result);
+                replyPacket.setType(IQ.Type.result);
             }
 
             new ProcessQueue(replyQ).start();

--- a/smack-core/src/testFixtures/java/org/jivesoftware/smack/test/util/SmackTestUtil.java
+++ b/smack-core/src/testFixtures/java/org/jivesoftware/smack/test/util/SmackTestUtil.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2019 Florian Schmaus
+ * Copyright 2019-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import javax.xml.namespace.QName;
 import org.jivesoftware.smack.packet.Element;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.provider.Provider;
+import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 import org.jivesoftware.smack.xml.XmlPullParserFactory;
@@ -123,6 +124,11 @@ public class SmackTestUtil {
         XmlPullParser parser = getParserFor(xml, parserKind);
         forwardParserToStartElement(parser, p -> p.getName().equals(startTagLocalpart));
         return parser;
+    }
+
+    public static XmlPullParser createDummyParser() throws XmlPullParserException, IOException {
+        String dummyElement = "<empty-element/>";
+        return PacketParserUtils.getParserFor(dummyElement);
     }
 
     @SuppressWarnings("unchecked")

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/carbons/provider/CarbonManagerProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/carbons/provider/CarbonManagerProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2013-2014 Georg Lukas, 2020 Florian Schmaus.
+ * Copyright 2013-2014 Georg Lukas, 2020-2021 Florian Schmaus.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.carbons.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.XmlEnvironment;
@@ -40,7 +41,8 @@ import org.jivesoftware.smackx.forward.provider.ForwardedProvider;
 public class CarbonManagerProvider extends ExtensionElementProvider<CarbonExtension> {
 
     @Override
-    public CarbonExtension parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public CarbonExtension parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         Direction dir = Direction.valueOf(parser.getName());
         Forwarded<Message> fwd = null;
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/dox/DnsOverXmppManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/dox/DnsOverXmppManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2019 Florian Schmaus
+ * Copyright 2019-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.jivesoftware.smack.iqrequest.IQRequestHandler.Mode;
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smack.packet.StanzaError.Condition;
-import org.jivesoftware.smack.packet.StanzaError.Type;
 import org.jivesoftware.smack.util.RandomUtil;
 
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
@@ -89,7 +88,7 @@ public final class DnsOverXmppManager extends Manager {
                 response = resolver.resolve(query);
             } catch (IOException exception) {
                 StanzaError errorBuilder = StanzaError.getBuilder()
-                        .setType(Type.CANCEL)
+                        .setType(StanzaError.Type.CANCEL)
                         .setCondition(Condition.internal_server_error)
                         .setDescriptiveEnText("Exception while resolving your DNS query", exception)
                         .build()

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadManager.java
@@ -27,7 +27,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
@@ -437,7 +436,7 @@ public final class HttpFileUploadManager extends Manager {
         urlConnection.setDoOutput(true);
         urlConnection.setFixedLengthStreamingMode(fileSize);
         urlConnection.setRequestProperty("Content-Type", "application/octet-stream");
-        for (Entry<String, String> header : slot.getHeaders().entrySet()) {
+        for (Map.Entry<String, String> header : slot.getHeaders().entrySet()) {
             urlConnection.setRequestProperty(header.getKey(), header.getValue());
         }
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/IoTManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/IoTManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2016 Florian Schmaus
+ * Copyright 2016-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import org.jivesoftware.smack.Manager;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 
 import org.jivesoftware.smackx.iot.provisioning.IoTProvisioningManager;
 
@@ -70,7 +69,7 @@ public abstract class IoTManager extends Manager {
 
     protected abstract class IoTIqRequestHandler extends AbstractIqRequestHandler {
 
-        protected IoTIqRequestHandler(String element, String namespace, Type type, Mode mode) {
+        protected IoTIqRequestHandler(String element, String namespace, IQ.Type type, Mode mode) {
             super(element, namespace, type, mode);
         }
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/Thing.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/Thing.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import org.jivesoftware.smackx.iot.control.ThingControlRequest;
 import org.jivesoftware.smackx.iot.data.ThingMomentaryReadOutRequest;
 import org.jivesoftware.smackx.iot.discovery.element.Tag;
-import org.jivesoftware.smackx.iot.discovery.element.Tag.Type;
 import org.jivesoftware.smackx.iot.element.NodeInfo;
 
 public final class Thing {
@@ -112,35 +111,35 @@ public final class Thing {
 
         public Builder setSerialNumber(String sn) {
             final String name = "SN";
-            Tag tag = new Tag(name, Type.str, sn);
+            Tag tag = new Tag(name, Tag.Type.str, sn);
             metaTags.put(name, tag);
             return this;
         }
 
         public Builder setKey(String key) {
             final String name = "KEY";
-            Tag tag = new Tag(name, Type.str, key);
+            Tag tag = new Tag(name, Tag.Type.str, key);
             metaTags.put(name, tag);
             return this;
         }
 
         public Builder setManufacturer(String manufacturer) {
             final String name = "MAN";
-            Tag tag = new Tag(name, Type.str, manufacturer);
+            Tag tag = new Tag(name, Tag.Type.str, manufacturer);
             metaTags.put(name, tag);
             return this;
         }
 
         public Builder setModel(String model) {
             final String name = "MODEL";
-            Tag tag = new Tag(name, Type.str, model);
+            Tag tag = new Tag(name, Tag.Type.str, model);
             metaTags.put(name, tag);
             return this;
         }
 
         public Builder setVersion(String version) {
             final String name = "V";
-            Tag tag = new Tag(name, Type.num, version);
+            Tag tag = new Tag(name, Tag.Type.num, version);
             metaTags.put(name, tag);
             return this;
         }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/data/provider/IoTFieldsExtensionProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/data/provider/IoTFieldsExtensionProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2016-2019 Florian Schmaus
+ * Copyright © 2016-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -45,7 +43,8 @@ public class IoTFieldsExtensionProvider extends ExtensionElementProvider<IoTFiel
     private static final Logger LOGGER = Logger.getLogger(IoTFieldsExtensionProvider.class.getName());
 
     @Override
-    public IoTFieldsExtension parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws IOException, XmlPullParserException, SmackTextParseException {
+    public IoTFieldsExtension parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws IOException, XmlPullParserException, ParseException {
         int seqNr = ParserUtils.getIntegerAttributeOrThrow(parser, "seqnr", "IoT data request <accepted/> without sequence number");
         boolean done = ParserUtils.getBooleanAttribute(parser, "done", false);
         List<NodeElement> nodes = new ArrayList<>();
@@ -74,7 +73,7 @@ public class IoTFieldsExtensionProvider extends ExtensionElementProvider<IoTFiel
         return new IoTFieldsExtension(seqNr, done, nodes);
     }
 
-    public NodeElement parseNode(XmlPullParser parser) throws XmlPullParserException, IOException, SmackTextParseException {
+    public NodeElement parseNode(XmlPullParser parser) throws XmlPullParserException, IOException, ParseException {
         final int initialDepth = parser.getDepth();
         final NodeInfo nodeInfo = NodeInfoParser.parse(parser);
         List<TimestampElement> timestampElements = new ArrayList<>();
@@ -103,15 +102,11 @@ public class IoTFieldsExtensionProvider extends ExtensionElementProvider<IoTFiel
         return new NodeElement(nodeInfo, timestampElements);
     }
 
-    public TimestampElement parseTimestampElement(XmlPullParser parser) throws XmlPullParserException, IOException, SmackTextParseException {
+    public TimestampElement parseTimestampElement(XmlPullParser parser)
+                    throws XmlPullParserException, IOException, ParseException {
         final int initialDepth = parser.getDepth();
         final String dateString = parser.getAttributeValue(null, "value");
-        Date date;
-        try {
-            date = XmppDateTime.parseDate(dateString);
-        } catch (ParseException e) {
-            throw new SmackParsingException.SmackTextParseException(e);
-        }
+        Date date = XmppDateTime.parseDate(dateString);
         List<IoTDataField> fields = new ArrayList<>();
         outerloop: while (true) {
             final XmlPullParser.Event eventType = parser.next();

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/IoTProvisioningManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/IoTProvisioningManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2016-2019 Florian Schmaus
+ * Copyright 2016-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ import org.jivesoftware.smack.filter.StanzaTypeFilter;
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler.Mode;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smack.packet.Stanza;
@@ -201,7 +200,7 @@ public final class IoTProvisioningManager extends Manager {
         }, FRIEND_MESSAGE);
 
         connection.registerIQRequestHandler(
-                        new AbstractIqRequestHandler(ClearCache.ELEMENT, ClearCache.NAMESPACE, Type.set, Mode.async) {
+                        new AbstractIqRequestHandler(ClearCache.ELEMENT, ClearCache.NAMESPACE, IQ.Type.set, Mode.async) {
                             @Override
                             public IQ handleIQRequest(IQ iqRequest) {
                                 if (!isFromProvisioningService(iqRequest, true)) {

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/jingle_filetransfer/provider/JingleFileTransferProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/jingle_filetransfer/provider/JingleFileTransferProvider.java
@@ -44,7 +44,7 @@ public class JingleFileTransferProvider
         extends JingleContentDescriptionProvider<JingleFileTransfer> {
 
     @Override
-    public JingleFileTransfer parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public JingleFileTransfer parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         ArrayList<JingleContentDescriptionChildElement> payloads = new ArrayList<>();
         JingleFileTransferChild.Builder builder = JingleFileTransferChild.getBuilder();
 
@@ -59,11 +59,7 @@ public class JingleFileTransferProvider
                 elementName = parser.getName();
                 switch (elementName) {
                     case JingleFileTransferChild.ELEM_DATE:
-                    try {
                         builder.setDate(XmppDateTime.parseXEP0082Date(parser.nextText()));
-                    } catch (ParseException e) {
-                        throw new SmackParsingException.SmackTextParseException(e);
-                    }
                         break;
 
                     case JingleFileTransferChild.ELEM_DESC:

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamResultProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamResultProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2016 Fernando Ramirez, 2020 Florian Schmaus
+ * Copyright 2016 Fernando Ramirez, 2020-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.mam.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.XmlEnvironment;
@@ -40,7 +41,8 @@ import org.jivesoftware.smackx.mam.element.MamElements.MamResultExtension;
 public class MamResultProvider extends ExtensionElementProvider<MamResultExtension> {
 
     @Override
-    public MamResultExtension parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public MamResultExtension parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         Forwarded<Message> forwarded = null;
         String queryId = parser.getAttributeValue("", "queryid");
         String id = parser.getAttributeValue("", "id");

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/message_retraction/provider/RetractedElementProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/message_retraction/provider/RetractedElementProvider.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.message_retraction.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Date;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
@@ -34,7 +35,7 @@ public class RetractedElementProvider extends ExtensionElementProvider<Retracted
 
     @Override
     public RetractedElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
-            throws XmlPullParserException, IOException, SmackParsingException {
+            throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         Date date = ParserUtils.getDateFromXep82String(parser.getAttributeValue("", RetractedElement.ATTR_STAMP));
 
         OriginIdElement originIdElement = null;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/MultiUserChatLightManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/MultiUserChatLightManager.java
@@ -31,7 +31,6 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.filter.IQReplyFilter;
 import org.jivesoftware.smack.filter.StanzaFilter;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 import org.jivesoftware.smackx.disco.packet.DiscoverItems;
@@ -228,7 +227,7 @@ public final class MultiUserChatLightManager extends Manager {
     private MUCLightBlockingIQ getBlockingList(DomainBareJid mucLightService)
             throws NoResponseException, XMPPErrorException, InterruptedException, NotConnectedException {
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(null, null);
-        mucLightBlockingIQ.setType(Type.get);
+        mucLightBlockingIQ.setType(IQ.Type.get);
         mucLightBlockingIQ.setTo(mucLightService);
 
         StanzaFilter responseFilter = new IQReplyFilter(mucLightBlockingIQ, connection());
@@ -278,7 +277,7 @@ public final class MultiUserChatLightManager extends Manager {
     private void sendBlockRooms(DomainBareJid mucLightService, HashMap<Jid, Boolean> rooms)
             throws NoResponseException, XMPPErrorException, InterruptedException, NotConnectedException {
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(rooms, null);
-        mucLightBlockingIQ.setType(Type.set);
+        mucLightBlockingIQ.setType(IQ.Type.set);
         mucLightBlockingIQ.setTo(mucLightService);
         connection().createStanzaCollectorAndSend(mucLightBlockingIQ).nextResultOrThrow();
     }
@@ -322,7 +321,7 @@ public final class MultiUserChatLightManager extends Manager {
     private void sendBlockUsers(DomainBareJid mucLightService, HashMap<Jid, Boolean> users)
             throws NoResponseException, XMPPErrorException, InterruptedException, NotConnectedException {
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(null, users);
-        mucLightBlockingIQ.setType(Type.set);
+        mucLightBlockingIQ.setType(IQ.Type.set);
         mucLightBlockingIQ.setTo(mucLightService);
         connection().createStanzaCollectorAndSend(mucLightBlockingIQ).nextResultOrThrow();
     }
@@ -366,7 +365,7 @@ public final class MultiUserChatLightManager extends Manager {
     private void sendUnblockRooms(DomainBareJid mucLightService, HashMap<Jid, Boolean> rooms)
             throws NoResponseException, XMPPErrorException, InterruptedException, NotConnectedException {
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(rooms, null);
-        mucLightBlockingIQ.setType(Type.set);
+        mucLightBlockingIQ.setType(IQ.Type.set);
         mucLightBlockingIQ.setTo(mucLightService);
         connection().createStanzaCollectorAndSend(mucLightBlockingIQ).nextResultOrThrow();
     }
@@ -410,7 +409,7 @@ public final class MultiUserChatLightManager extends Manager {
     private void sendUnblockUsers(DomainBareJid mucLightService, HashMap<Jid, Boolean> users)
             throws NoResponseException, XMPPErrorException, InterruptedException, NotConnectedException {
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(null, users);
-        mucLightBlockingIQ.setType(Type.set);
+        mucLightBlockingIQ.setType(IQ.Type.set);
         mucLightBlockingIQ.setTo(mucLightService);
         connection().createStanzaCollectorAndSend(mucLightBlockingIQ).nextResultOrThrow();
     }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightBlockingIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightBlockingIQProvider.java
@@ -19,7 +19,7 @@ package org.jivesoftware.smackx.muclight.provider;
 import java.io.IOException;
 import java.util.HashMap;
 
-import org.jivesoftware.smack.packet.IQ.Type;
+import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.provider.IQProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -65,7 +65,7 @@ public class MUCLightBlockingIQProvider extends IQProvider<MUCLightBlockingIQ> {
         }
 
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(rooms, users);
-        mucLightBlockingIQ.setType(Type.result);
+        mucLightBlockingIQ.setType(IQ.Type.result);
         return mucLightBlockingIQ;
     }
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/push_notifications/PushNotificationsManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/push_notifications/PushNotificationsManager.java
@@ -28,7 +28,6 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPConnectionRegistry;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 import org.jivesoftware.smackx.push_notifications.element.DisablePushNotificationsIQ;
@@ -166,7 +165,7 @@ public final class PushNotificationsManager extends Manager {
             throws NotConnectedException, InterruptedException, NoResponseException, XMPPErrorException {
         final XMPPConnection connection = connection();
         IQ responseIQ = connection.createStanzaCollectorAndSend(iq).nextResultOrThrow();
-        return responseIQ.getType() != Type.error;
+        return responseIQ.getType() != IQ.Type.error;
     }
 
 }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/provider/ContentElementProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/stanza_content_encryption/provider/ContentElementProvider.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.stanza_content_encryption.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Date;
 
 import org.jivesoftware.smack.packet.ExtensionElement;
@@ -42,7 +43,7 @@ public class ContentElementProvider extends ExtensionElementProvider<ContentElem
 
     @Override
     public ContentElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
-            throws XmlPullParserException, IOException, SmackParsingException {
+            throws XmlPullParserException, IOException, ParseException, SmackParsingException {
         ContentElement.Builder builder = ContentElement.builder();
 
         while (true) {
@@ -117,7 +118,7 @@ public class ContentElementProvider extends ExtensionElementProvider<ContentElem
     }
 
     private static void parseTimestampAffix(XmlPullParser parser, ContentElement.Builder builder)
-            throws SmackParsingException.SmackTextParseException {
+            throws ParseException {
         Date timestamp = ParserUtils.getDateFromXep82String(
                 parser.getAttributeValue("", TimestampAffixElement.ATTR_STAMP));
         builder.setTimestamp(timestamp);

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamFinProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamFinProviderTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
@@ -68,7 +67,7 @@ public class MamFinProviderTest extends MamTest {
         IQ iq = PacketParserUtils.parseStanza(IQ_LIMITED_RESULTS_EXAMPLE);
 
         MamFinIQ mamFinIQ = (MamFinIQ) iq;
-        assertEquals(mamFinIQ.getType(), Type.result);
+        assertEquals(mamFinIQ.getType(), IQ.Type.result);
 
         assertTrue(mamFinIQ.isComplete());
         assertEquals(mamFinIQ.getRSMSet().getCount(), 16);

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamQueryIQProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamQueryIQProviderTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.util.PacketParserUtils;
 
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
@@ -57,7 +56,7 @@ public class MamQueryIQProviderTest {
         IQ iq1 = PacketParserUtils.parseStanza(exampleMamQueryIQ1);
         MamQueryIQ mamQueryIQ1 = (MamQueryIQ) iq1;
 
-        assertEquals(mamQueryIQ1.getType(), Type.set);
+        assertEquals(mamQueryIQ1.getType(), IQ.Type.set);
         assertEquals(mamQueryIQ1.getQueryId(), "test");
 
         DataForm dataForm1 = (DataForm) mamQueryIQ1.getExtension(DataForm.NAMESPACE);
@@ -73,7 +72,7 @@ public class MamQueryIQProviderTest {
         IQ iq2 = PacketParserUtils.parseStanza(exampleMamQueryIQ2);
         MamQueryIQ mamQueryIQ2 = (MamQueryIQ) iq2;
 
-        assertEquals(mamQueryIQ2.getType(), Type.result);
+        assertEquals(mamQueryIQ2.getType(), IQ.Type.result);
         assertNull(mamQueryIQ2.getQueryId());
 
         DataForm dataForm2 = (DataForm) mamQueryIQ2.getExtension(DataForm.NAMESPACE);

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/QueryArchiveTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/QueryArchiveTest.java
@@ -24,7 +24,6 @@ import java.util.TimeZone;
 
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Message;
-import org.jivesoftware.smack.packet.Message.Type;
 import org.jivesoftware.smack.packet.StanzaBuilder;
 import org.jivesoftware.smack.packet.StreamOpen;
 
@@ -75,7 +74,7 @@ public class QueryArchiveTest extends MamTest {
         DelayInformation delay = new DelayInformation(date);
         Message forwardedMessage = StanzaBuilder.buildMessage("162BEBB1-F6DB-4D9A-9BD8-CFDCC801A0B2")
                         .from(JidCreate.from("coven@chat.shakespeare.lit/firstwitch"))
-                        .ofType(Type.chat)
+                        .ofType(Message.Type.chat)
                         .setBody("Thrice the brinded cat hath mew.")
                         .build();
 
@@ -93,7 +92,7 @@ public class QueryArchiveTest extends MamTest {
         Message resultMessage = mamResultExtension.getForwarded().getForwardedStanza();
         assertEquals(resultMessage.getFrom(), JidCreate.from("coven@chat.shakespeare.lit/firstwitch"));
         assertEquals(resultMessage.getStanzaId(), "162BEBB1-F6DB-4D9A-9BD8-CFDCC801A0B2");
-        assertEquals(resultMessage.getType(), Type.chat);
+        assertEquals(resultMessage.getType(), Message.Type.chat);
         assertEquals(resultMessage.getBody(), "Thrice the brinded cat hath mew.");
     }
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/muclight/MUCLightBlockingTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/muclight/MUCLightBlockingTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashMap;
 
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.StreamOpen;
 import org.jivesoftware.smack.util.PacketParserUtils;
 
@@ -59,7 +58,7 @@ public class MUCLightBlockingTest {
     @Test
     public void checkGetBlockingListIQ() throws Exception {
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(null, null);
-        mucLightBlockingIQ.setType(Type.get);
+        mucLightBlockingIQ.setType(IQ.Type.get);
         mucLightBlockingIQ.setStanzaId("getblock1");
         mucLightBlockingIQ.setTo(JidCreate.from("muclight.shakespeare.lit"));
 
@@ -86,7 +85,7 @@ public class MUCLightBlockingTest {
         rooms.put(JidCreate.from("chapel@shakespeare.lit"), false);
 
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(rooms, null);
-        mucLightBlockingIQ.setType(Type.set);
+        mucLightBlockingIQ.setType(IQ.Type.set);
         mucLightBlockingIQ.setTo(JidCreate.from("muclight.shakespeare.lit"));
         mucLightBlockingIQ.setStanzaId("block1");
 
@@ -100,7 +99,7 @@ public class MUCLightBlockingTest {
         users.put(JidCreate.from("hag66@shakespeare.lit"), false);
 
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(null, users);
-        mucLightBlockingIQ.setType(Type.set);
+        mucLightBlockingIQ.setType(IQ.Type.set);
         mucLightBlockingIQ.setTo(JidCreate.from("muclight.shakespeare.lit"));
         mucLightBlockingIQ.setStanzaId("block2");
 
@@ -116,7 +115,7 @@ public class MUCLightBlockingTest {
         rooms.put(JidCreate.from("coven@muclight.shakespeare.lit"), true);
 
         MUCLightBlockingIQ mucLightBlockingIQ = new MUCLightBlockingIQ(rooms, users);
-        mucLightBlockingIQ.setType(Type.set);
+        mucLightBlockingIQ.setType(IQ.Type.set);
         mucLightBlockingIQ.setTo(JidCreate.from("muclight.shakespeare.lit"));
         mucLightBlockingIQ.setStanzaId("unblock1");
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/stanza_content_encryption/provider/ContentElementProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/stanza_content_encryption/provider/ContentElementProviderTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.StandardExtensionElement;
@@ -40,7 +41,7 @@ import org.jxmpp.jid.impl.JidCreate;
 public class ContentElementProviderTest {
 
     @Test
-    public void testParsing() throws XmlPullParserException, IOException, SmackParsingException {
+    public void testParsing() throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         String xml = "" +
                 "<content xmlns='urn:xmpp:sce:0'>\n" +
                 "  <payload>\n" +

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/address/provider/MultipleAddressesProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/address/provider/MultipleAddressesProvider.java
@@ -26,7 +26,6 @@ import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
 import org.jivesoftware.smackx.address.packet.MultipleAddresses;
-import org.jivesoftware.smackx.address.packet.MultipleAddresses.Type;
 
 import org.jxmpp.jid.Jid;
 
@@ -50,7 +49,7 @@ public class MultipleAddressesProvider extends ExtensionElementProvider<Multiple
                 switch (name) {
                 case MultipleAddresses.Address.ELEMENT:
                     String typeString = parser.getAttributeValue("", "type");
-                    Type type = Type.valueOf(typeString);
+                    MultipleAddresses.Type type = MultipleAddresses.Type.valueOf(typeString);
                     Jid jid = ParserUtils.getJidAttribute(parser, "jid");
                     String node = parser.getAttributeValue("", "node");
                     String desc = parser.getAttributeValue("", "desc");

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/BlockingCommandManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/BlockingCommandManager.java
@@ -35,7 +35,6 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler.Mode;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 
 import org.jivesoftware.smackx.blocking.element.BlockContactsIQ;
 import org.jivesoftware.smackx.blocking.element.BlockListIQ;
@@ -97,7 +96,7 @@ public final class BlockingCommandManager extends Manager {
 
         // block IQ handler
         connection.registerIQRequestHandler(
-                new AbstractIqRequestHandler(BlockContactsIQ.ELEMENT, BlockContactsIQ.NAMESPACE, Type.set, Mode.sync) {
+                new AbstractIqRequestHandler(BlockContactsIQ.ELEMENT, BlockContactsIQ.NAMESPACE, IQ.Type.set, Mode.sync) {
                     @Override
                     public IQ handleIQRequest(IQ iqRequest) {
                         BlockContactsIQ blockContactIQ = (BlockContactsIQ) iqRequest;
@@ -119,7 +118,7 @@ public final class BlockingCommandManager extends Manager {
 
         // unblock IQ handler
         connection.registerIQRequestHandler(new AbstractIqRequestHandler(UnblockContactsIQ.ELEMENT,
-                UnblockContactsIQ.NAMESPACE, Type.set, Mode.sync) {
+                UnblockContactsIQ.NAMESPACE, IQ.Type.set, Mode.sync) {
             @Override
             public IQ handleIQRequest(IQ iqRequest) {
                 UnblockContactsIQ unblockContactIQ = (UnblockContactsIQ) iqRequest;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/provider/BlockListIQProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/provider/BlockListIQProvider.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jivesoftware.smack.packet.IQ.Type;
+import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.provider.IQProvider;
 import org.jivesoftware.smack.util.ParserUtils;
@@ -70,7 +70,7 @@ public class BlockListIQProvider extends IQProvider<BlockListIQ> {
         }
 
         BlockListIQ blockListIQ = new BlockListIQ(jids);
-        blockListIQ.setType(Type.result);
+        blockListIQ.setType(IQ.Type.result);
         return blockListIQ;
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bob/BoBManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bob/BoBManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2016-2020 Fernando Ramirez, Florian Schmaus
+ * Copyright 2016-2021 Fernando Ramirez, Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler.Mode;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.util.SHA1;
 
 import org.jivesoftware.smackx.bob.element.BoBIQ;
@@ -91,7 +90,7 @@ public final class BoBManager extends Manager {
         serviceDiscoveryManager.addFeature(NAMESPACE);
 
         connection.registerIQRequestHandler(
-                new AbstractIqRequestHandler(BoBIQ.ELEMENT, BoBIQ.NAMESPACE, Type.get, Mode.async) {
+                new AbstractIqRequestHandler(BoBIQ.ELEMENT, BoBIQ.NAMESPACE, IQ.Type.get, Mode.async) {
                     @Override
                     public IQ handleIQRequest(IQ iqRequest) {
                         BoBIQ bobIQRequest = (BoBIQ) iqRequest;
@@ -105,7 +104,7 @@ public final class BoBManager extends Manager {
 
                         BoBData bobData = bobInfo.getData();
                         BoBIQ responseBoBIQ = new BoBIQ(contentId, bobData);
-                        responseBoBIQ.setType(Type.result);
+                        responseBoBIQ.setType(IQ.Type.result);
                         responseBoBIQ.setTo(bobIQRequest.getFrom());
                         return responseBoBIQ;
                     }
@@ -146,7 +145,7 @@ public final class BoBManager extends Manager {
         }
 
         BoBIQ requestBoBIQ = new BoBIQ(bobHash);
-        requestBoBIQ.setType(Type.get);
+        requestBoBIQ.setType(IQ.Type.get);
         requestBoBIQ.setTo(to);
 
         XMPPConnection connection = getAuthenticatedConnectionOrThrow();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamManager.java
@@ -441,7 +441,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    protected void replyRejectPacket(IQ request) throws NotConnectedException, InterruptedException {
+    void replyRejectPacket(IQ request) throws NotConnectedException, InterruptedException {
         IQ error = IQ.createErrorResponse(request, StanzaError.Condition.not_acceptable);
         connection().sendStanza(error);
     }
@@ -454,7 +454,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    protected void replyItemNotFoundPacket(IQ request) throws NotConnectedException, InterruptedException {
+    void replyItemNotFoundPacket(IQ request) throws NotConnectedException, InterruptedException {
         IQ error = IQ.createErrorResponse(request, StanzaError.Condition.item_not_found);
         connection().sendStanza(error);
     }
@@ -476,7 +476,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      *
      * @return the XMPP connection
      */
-    protected XMPPConnection getConnection() {
+    XMPPConnection getConnection() {
         return connection();
     }
 
@@ -487,7 +487,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * @param initiator the initiator's JID
      * @return the listener
      */
-    protected BytestreamListener getUserListener(Jid initiator) {
+    BytestreamListener getUserListener(Jid initiator) {
         return this.userListeners.get(initiator);
     }
 
@@ -497,7 +497,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      *
      * @return list of listeners
      */
-    protected List<BytestreamListener> getAllRequestListeners() {
+    List<BytestreamListener> getAllRequestListeners() {
         return this.allRequestListeners;
     }
 
@@ -506,7 +506,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      *
      * @return the sessions map
      */
-    protected Map<String, InBandBytestreamSession> getSessions() {
+    Map<String, InBandBytestreamSession> getSessions() {
         return sessions;
     }
 
@@ -515,7 +515,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      *
      * @return list of session IDs
      */
-    protected List<String> getIgnoredBytestreamRequests() {
+    List<String> getIgnoredBytestreamRequests() {
         return ignoredBytestreamRequests;
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/InitiationListener.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/InitiationListener.java
@@ -52,7 +52,7 @@ final class InitiationListener extends AbstractIqRequestHandler {
      *
      * @param manager the SOCKS5 Bytestream manager
      */
-    protected InitiationListener(Socks5BytestreamManager manager) {
+    InitiationListener(Socks5BytestreamManager manager) {
         super(Bytestream.ELEMENT, Bytestream.NAMESPACE, IQ.Type.set, Mode.async);
         this.manager = manager;
         initiationListenerExecutor = Executors.newCachedThreadPool();
@@ -117,7 +117,7 @@ final class InitiationListener extends AbstractIqRequestHandler {
     /**
      * Shuts down the listeners executor service.
      */
-    protected void shutdown() {
+    void shutdown() {
         this.initiationListenerExecutor.shutdownNow();
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5BytestreamManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5BytestreamManager.java
@@ -717,7 +717,7 @@ public final class Socks5BytestreamManager extends Manager implements Bytestream
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    protected void replyRejectPacket(IQ packet) throws NotConnectedException, InterruptedException {
+    void replyRejectPacket(IQ packet) throws NotConnectedException, InterruptedException {
         StanzaError xmppError = StanzaError.getBuilder(StanzaError.Condition.not_acceptable).build();
         IQ errorIQ = IQ.createErrorResponse(packet, xmppError);
         connection().sendStanza(errorIQ);
@@ -760,7 +760,7 @@ public final class Socks5BytestreamManager extends Manager implements Bytestream
      *
      * @return the XMPP connection
      */
-    protected XMPPConnection getConnection() {
+    XMPPConnection getConnection() {
         return connection();
     }
 
@@ -771,7 +771,7 @@ public final class Socks5BytestreamManager extends Manager implements Bytestream
      * @param initiator the initiator's JID
      * @return the listener
      */
-    protected BytestreamListener getUserListener(Jid initiator) {
+    BytestreamListener getUserListener(Jid initiator) {
         return this.userListeners.get(initiator);
     }
 
@@ -781,7 +781,7 @@ public final class Socks5BytestreamManager extends Manager implements Bytestream
      *
      * @return list of listeners
      */
-    protected List<BytestreamListener> getAllRequestListeners() {
+    List<BytestreamListener> getAllRequestListeners() {
         return this.allRequestListeners;
     }
 
@@ -790,7 +790,7 @@ public final class Socks5BytestreamManager extends Manager implements Bytestream
      *
      * @return list of session IDs
      */
-    protected List<String> getIgnoredBytestreamRequests() {
+    List<String> getIgnoredBytestreamRequests() {
         return ignoredBytestreamRequests;
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5BytestreamRequest.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5BytestreamRequest.java
@@ -311,7 +311,7 @@ public class Socks5BytestreamRequest implements BytestreamRequest {
      * Cancels the SOCKS5 Bytestream request by sending an error to the initiator and building a
      * XMPP exception.
      *
-     * @param streamHosts the stream hosts.
+     * @param streamHostsExceptions the stream hosts and their exceptions.
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      * @throws CouldNotConnectToAnyProvidedSocks5Host as expected result.

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/caps/EntityCapsManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/caps/EntityCapsManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2009 Jonas Ådahl, 2011-2020 Florian Schmaus
+ * Copyright © 2009 Jonas Ådahl, 2011-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public final class EntityCapsManager extends Manager {
 
     private static String DEFAULT_ENTITY_NODE = SmackConfiguration.SMACK_URL_STRING;
 
-    protected static EntityCapsPersistentCache persistentCache;
+    static EntityCapsPersistentCache persistentCache;
 
     private static boolean autoEnableEntityCaps = true;
 
@@ -595,7 +595,7 @@ public final class EntityCapsManager extends Manager {
         return true;
     }
 
-    protected static CapsVersionAndHash generateVerificationString(DiscoverInfoView discoverInfo) {
+    static CapsVersionAndHash generateVerificationString(DiscoverInfoView discoverInfo) {
         return generateVerificationString(discoverInfo, null);
     }
 
@@ -611,7 +611,7 @@ public final class EntityCapsManager extends Manager {
      * @return The generated verification String or null if the hash is not
      *         supported
      */
-    protected static CapsVersionAndHash generateVerificationString(DiscoverInfoView discoverInfo, String hash) {
+    static CapsVersionAndHash generateVerificationString(DiscoverInfoView discoverInfo, String hash) {
         if (hash == null) {
             hash = DEFAULT_HASH;
         }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandManager.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -520,8 +519,8 @@ public final class AdHocCommandManager extends Manager {
     private void sessionSweeper() {
         final long currentTime = System.currentTimeMillis();
         synchronized (this) {
-            for (Iterator<Entry<String, LocalCommand>> it = executingCommands.entrySet().iterator(); it.hasNext();) {
-                Entry<String, LocalCommand> entry = it.next();
+            for (Iterator<Map.Entry<String, LocalCommand>> it = executingCommands.entrySet().iterator(); it.hasNext();) {
+                Map.Entry<String, LocalCommand> entry = it.next();
                 LocalCommand command = entry.getValue();
 
                 long creationStamp = command.getCreationDate();
@@ -561,7 +560,6 @@ public final class AdHocCommandManager extends Manager {
      *
      * @param response the response to send.
      * @param condition the condition of the error.
-     * @throws NotConnectedException if the XMPP connection is not connected.
      */
     private static IQ respondError(AdHocCommandData response,
             StanzaError.Condition condition) {
@@ -574,7 +572,6 @@ public final class AdHocCommandManager extends Manager {
      * @param response the response to send.
      * @param condition the condition of the error.
      * @param specificCondition the adhoc command error condition.
-     * @throws NotConnectedException if the XMPP connection is not connected.
      */
     private static IQ respondError(AdHocCommandData response, StanzaError.Condition condition,
             AdHocCommand.SpecificErrorCondition specificCondition) {
@@ -589,7 +586,6 @@ public final class AdHocCommandManager extends Manager {
      *
      * @param response the response to send.
      * @param error the error to send.
-     * @throws NotConnectedException if the XMPP connection is not connected.
      */
     private static IQ respondError(AdHocCommandData response, StanzaError error) {
         response.setType(IQ.Type.error);
@@ -608,8 +604,8 @@ public final class AdHocCommandManager extends Manager {
      * @throws NoSuchMethodException if no such method is declared
      * @throws InvocationTargetException if a reflection-based method or constructor invocation threw.
      * @throws IllegalArgumentException if an illegal argument was given.
-     * @throws IllegalAccessException
-     * @throws InstantiationException
+     * @throws IllegalAccessException in case of an illegal access.
+     * @throws InstantiationException in case of an instantiation error.
      */
     private LocalCommand newInstanceOfCmd(String commandNode, String sessionID)
                     throws XMPPErrorException, InstantiationException, IllegalAccessException, IllegalArgumentException,

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/delay/provider/AbstractDelayInformationProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/delay/provider/AbstractDelayInformationProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2014-2019 Florian Schmaus
+ * Copyright © 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 package org.jivesoftware.smackx.delay.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Date;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -32,7 +32,7 @@ public abstract class AbstractDelayInformationProvider extends ExtensionElementP
     @Override
     public final DelayInformation parse(XmlPullParser parser,
                     int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException,
-                    IOException, SmackTextParseException {
+                    IOException, ParseException {
         String stampString = parser.getAttributeValue("", "stamp");
         String from = parser.getAttributeValue("", "from");
         final String reason;
@@ -54,5 +54,5 @@ public abstract class AbstractDelayInformationProvider extends ExtensionElementP
         return new DelayInformation(stamp, from, reason);
     }
 
-    protected abstract Date parseDate(String string) throws SmackTextParseException;
+    protected abstract Date parseDate(String string) throws ParseException;
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/delay/provider/DelayInformationProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/delay/provider/DelayInformationProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2014-2019 Florian Schmaus
+ * Copyright © 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.delay.provider;
 
+import java.text.ParseException;
 import java.util.Date;
 
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.util.ParserUtils;
 
 /**
@@ -31,7 +31,7 @@ public class DelayInformationProvider extends AbstractDelayInformationProvider {
     public static final DelayInformationProvider INSTANCE = new DelayInformationProvider();
 
     @Override
-    protected Date parseDate(String string) throws SmackTextParseException {
+    protected Date parseDate(String string) throws ParseException {
         return ParserUtils.getDateFromXep82String(string);
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/delay/provider/LegacyDelayInformationProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/delay/provider/LegacyDelayInformationProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2014-2019 Florian Schmaus
+ * Copyright © 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
  */
 package org.jivesoftware.smackx.delay.provider;
 
+import java.text.ParseException;
 import java.util.Date;
 
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.util.ParserUtils;
 
 /**
@@ -29,7 +29,7 @@ import org.jivesoftware.smack.util.ParserUtils;
 public class LegacyDelayInformationProvider extends AbstractDelayInformationProvider {
 
     @Override
-    protected Date parseDate(String string) throws SmackTextParseException {
+    protected Date parseDate(String string) throws ParseException {
         return ParserUtils.getDateFromString(string);
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferManager.java
@@ -142,7 +142,7 @@ public final class FileTransferManager extends Manager {
      * @return The IncomingFileTransfer which manages the download of the file
      *         from the transfer initiator.
      */
-    protected IncomingFileTransfer createIncomingFileTransfer(
+    IncomingFileTransfer createIncomingFileTransfer(
             FileTransferRequest request) {
         if (request == null) {
             throw new NullPointerException("ReceiveRequest cannot be null");
@@ -164,7 +164,7 @@ public final class FileTransferManager extends Manager {
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    protected void rejectIncomingFileTransfer(FileTransferRequest request) throws NotConnectedException, InterruptedException {
+    void rejectIncomingFileTransfer(FileTransferRequest request) throws NotConnectedException, InterruptedException {
         StreamInitiation initiation = request.getStreamInitiation();
 
         // Reject as specified in XEP-95 4.2. Note that this is not to be confused with the Socks 5

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferNegotiator.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferNegotiator.java
@@ -65,7 +65,7 @@ public final class FileTransferNegotiator extends Manager {
 
     private static final String STREAM_INIT_PREFIX = "jsi_";
 
-    protected static final String STREAM_DATA_FIELD_NAME = "stream-method";
+    static final String STREAM_DATA_FIELD_NAME = "stream-method";
 
     private static final Random randomGenerator = new Random();
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/StreamNegotiator.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/filetransfer/StreamNegotiator.java
@@ -29,7 +29,6 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.util.EventManger;
-import org.jivesoftware.smack.util.EventManger.Callback;
 
 import org.jivesoftware.smackx.si.packet.StreamInitiation;
 import org.jivesoftware.smackx.xdata.FormField;
@@ -101,7 +100,7 @@ public abstract class StreamNegotiator extends Manager {
         final String eventKey = initiation.getFrom().toString() + '\t' + initiation.getSessionID();
         IQ streamMethodInitiation;
         try {
-            streamMethodInitiation = initationSetEvents.performActionAndWaitForEvent(eventKey, connection.getReplyTimeout(), new Callback<NotConnectedException>() {
+            streamMethodInitiation = initationSetEvents.performActionAndWaitForEvent(eventKey, connection.getReplyTimeout(), new EventManger.Callback<NotConnectedException>() {
                 @Override
                 public void action() throws NotConnectedException {
                     try {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/forward/provider/ForwardedProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/forward/provider/ForwardedProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2013-2014 Georg Lukas, 2020 Florian Schmaus
+ * Copyright 2013-2014 Georg Lukas, 2020-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.forward.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.logging.Logger;
 
 import org.jivesoftware.smack.packet.Message;
@@ -45,7 +46,8 @@ public class ForwardedProvider extends ExtensionElementProvider<Forwarded<?>> {
     private static final Logger LOGGER = Logger.getLogger(ForwardedProvider.class.getName());
 
     @Override
-    public Forwarded<?> parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public Forwarded<?> parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         DelayInformation di = null;
         Stanza packet = null;
 
@@ -90,13 +92,14 @@ public class ForwardedProvider extends ExtensionElementProvider<Forwarded<?>> {
     }
 
     public static Forwarded<Message> parseForwardedMessage(XmlPullParser parser, XmlEnvironment xmlEnvironment)
-                    throws XmlPullParserException, IOException, SmackParsingException {
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         return parseForwardedMessage(parser, parser.getDepth(), xmlEnvironment);
     }
 
     @SuppressWarnings("unchecked")
     public static Forwarded<Message> parseForwardedMessage(XmlPullParser parser, int initialDepth,
-                    XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+                    XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         Forwarded<?> forwarded = INSTANCE.parse(parser, initialDepth, xmlEnvironment);
         if (!forwarded.isForwarded(Message.class)) {
             throw new SmackParsingException("Expecting a forwarded message, but got " + forwarded);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/geoloc/provider/GeoLocationProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/geoloc/provider/GeoLocationProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2015-2017 Ishan Khanna, Fernando Ramirez, 2019-2020 Florian Schmaus
+ * Copyright 2015-2017 Ishan Khanna, Fernando Ramirez, 2019-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 package org.jivesoftware.smackx.geoloc.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import javax.xml.namespace.QName;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.parsing.SmackParsingException.SmackUriSyntaxParsingException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.util.ParserUtils;
@@ -38,7 +38,7 @@ public class GeoLocationProvider extends ExtensionElementProvider<GeoLocation> {
 
     @Override
     public GeoLocation parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException,
-                    SmackTextParseException, SmackUriSyntaxParsingException {
+                    SmackUriSyntaxParsingException, ParseException {
 
         GeoLocation.Builder builder = GeoLocation.builder();
 
@@ -153,7 +153,7 @@ public class GeoLocationProvider extends ExtensionElementProvider<GeoLocation> {
 
         @Override
         public GeoLocation parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
-                        throws XmlPullParserException, IOException, SmackParsingException {
+                        throws XmlPullParserException, IOException, SmackParsingException, ParseException {
             return GeoLocationProvider.INSTANCE.parse(parser, initialDepth, xmlEnvironment);
         }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqlast/LastActivityManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqlast/LastActivityManager.java
@@ -32,7 +32,6 @@ import org.jivesoftware.smack.filter.StanzaTypeFilter;
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler.Mode;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smack.packet.Stanza;
@@ -164,7 +163,7 @@ public final class LastActivityManager extends Manager {
 
         // Register a listener for a last activity query
         connection.registerIQRequestHandler(new AbstractIqRequestHandler(LastActivity.ELEMENT, LastActivity.NAMESPACE,
-                        Type.get, Mode.async) {
+                        IQ.Type.get, Mode.async) {
             @Override
             public IQ handleIQRequest(IQ iqRequest) {
                 if (!enabled)

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqregister/AccountManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqregister/AccountManager.java
@@ -24,12 +24,10 @@ import java.util.Set;
 import java.util.WeakHashMap;
 
 import org.jivesoftware.smack.Manager;
-import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.StanzaCollector;
 import org.jivesoftware.smack.XMPPConnection;
-import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.filter.StanzaIdFilter;
 import org.jivesoftware.smack.packet.ExtensionElement;
@@ -355,13 +353,11 @@ public final class AccountManager extends Manager {
 
     /**
      * Gets the account registration info from the server.
+     *
      * @throws XMPPErrorException if there was an XMPP error returned.
      * @throws NoResponseException if there was no response from the remote entity.
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
-     *
-     * @throws XMPPException if an error occurs.
-     * @throws SmackException if there was no response from the server.
      */
     private synchronized void getRegistrationInfo() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         Registration reg = new Registration();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/JingleManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/JingleManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2017 Florian Schmaus
+ * Copyright 2017-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler.Mode;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.util.StringUtils;
 
 import org.jivesoftware.smackx.jingle.element.Jingle;
@@ -74,7 +73,7 @@ public final class JingleManager extends Manager {
         jutil = new JingleUtil(connection);
 
         connection.registerIQRequestHandler(
-                new AbstractIqRequestHandler(Jingle.ELEMENT, Jingle.NAMESPACE, Type.set, Mode.async) {
+                new AbstractIqRequestHandler(Jingle.ELEMENT, Jingle.NAMESPACE, IQ.Type.set, Mode.async) {
                     @Override
                     public IQ handleIQRequest(IQ iqRequest) {
                         final Jingle jingle = (Jingle) iqRequest;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2017-2020 Florian Schmaus
+ * Copyright 2017-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class JingleReason implements FullyQualifiedElement {
         unsupported_transports,
         ;
 
-        protected static final Map<String, Reason> LUT = new HashMap<>(Reason.values().length);
+        static final Map<String, Reason> LUT = new HashMap<>(Reason.values().length);
 
         static {
             for (Reason reason : Reason.values()) {
@@ -84,7 +84,7 @@ public class JingleReason implements FullyQualifiedElement {
             }
         }
 
-        protected final String asString;
+        final String asString;
 
         Reason() {
             asString = name().replace('_', '-');

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/provider/JingleContentDescriptionProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/provider/JingleContentDescriptionProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2017-2019 Florian Schmaus
+ * Copyright 2017-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.jingle.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
@@ -30,6 +31,7 @@ public abstract class JingleContentDescriptionProvider<D extends JingleContentDe
                 extends ExtensionElementProvider<D> {
 
     @Override
-    public abstract D parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)  throws XmlPullParserException, IOException, SmackParsingException;
+    public abstract D parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException;
 
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jiveproperties/provider/JivePropertiesExtensionProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jiveproperties/provider/JivePropertiesExtensionProvider.java
@@ -51,6 +51,7 @@ public class JivePropertiesExtensionProvider extends ExtensionElementProvider<Ji
      * @throws IOException if an I/O error occurred.
      * @throws XmlPullParserException if an error in the XML parser occurred.
      */
+    @SuppressWarnings("BanSerializableRead")
     @Override
     public JivePropertiesExtension parse(XmlPullParser parser,
                     int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException,

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/last_interaction/provider/IdleProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/last_interaction/provider/IdleProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2018 Paul Schaub, 2019 Florian Schmaus
+ * Copyright © 2018 Paul Schaub, 2019-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import java.text.ParseException;
 import java.util.Date;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
@@ -34,14 +32,9 @@ public class IdleProvider extends ExtensionElementProvider<IdleElement> {
     public static final IdleProvider TEST_INSTANCE = new IdleProvider();
 
     @Override
-    public IdleElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws SmackTextParseException {
+    public IdleElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws ParseException {
         String dateString = parser.getAttributeValue(null, IdleElement.ATTR_SINCE);
-        Date since;
-        try {
-            since = XmppDateTime.parseXEP0082Date(dateString);
-        } catch (ParseException e) {
-            throw new SmackParsingException.SmackTextParseException(e);
-        }
+        Date since = XmppDateTime.parseXEP0082Date(dateString);
         return new IdleElement(since);
     }
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -1044,8 +1044,8 @@ public class MultiUserChat {
     /**
      * Fires invitation rejection listeners.
      *
-     * @param invitee the user being invited.
-     * @param reason the reason for the rejection
+     * @param message the message.
+     * @param rejection the information about the rejection.
      */
     private void fireInvitationRejectionListeners(Message message, MUCUser.Decline rejection) {
         EntityBareJid invitee = rejection.getFrom();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/ping/PingManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/ping/PingManager.java
@@ -37,7 +37,6 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler.Mode;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smack.util.ExceptionCallback;
@@ -120,7 +119,7 @@ public final class PingManager extends Manager {
         ServiceDiscoveryManager sdm = ServiceDiscoveryManager.getInstanceFor(connection);
         sdm.addFeature(Ping.NAMESPACE);
 
-        connection.registerIQRequestHandler(new AbstractIqRequestHandler(Ping.ELEMENT, Ping.NAMESPACE, Type.get, Mode.async) {
+        connection.registerIQRequestHandler(new AbstractIqRequestHandler(Ping.ELEMENT, Ping.NAMESPACE, IQ.Type.get, Mode.async) {
             @Override
             public IQ handleIQRequest(IQ iqRequest) {
                 Ping ping = (Ping) iqRequest;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/filter/SetActiveListFilter.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/filter/SetActiveListFilter.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2015 Florian Schmaus
+ * Copyright 2015-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.jivesoftware.smackx.privacy.filter;
 
 import org.jivesoftware.smack.filter.FlexibleStanzaTypeFilter;
-import org.jivesoftware.smack.packet.IQ.Type;
+import org.jivesoftware.smack.packet.IQ;
 
 import org.jivesoftware.smackx.privacy.packet.Privacy;
 
@@ -30,7 +30,7 @@ public final class SetActiveListFilter extends FlexibleStanzaTypeFilter<Privacy>
 
     @Override
     protected boolean acceptSpecific(Privacy privacy) {
-        if (privacy.getType() != Type.set) {
+        if (privacy.getType() != IQ.Type.set) {
             return false;
         }
         return privacy.getActiveName() != null || privacy.isDeclineActiveList();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/filter/SetDefaultListFilter.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/filter/SetDefaultListFilter.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2015 Florian Schmaus
+ * Copyright 2015-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.jivesoftware.smackx.privacy.filter;
 
 import org.jivesoftware.smack.filter.FlexibleStanzaTypeFilter;
-import org.jivesoftware.smack.packet.IQ.Type;
+import org.jivesoftware.smack.packet.IQ;
 
 import org.jivesoftware.smackx.privacy.packet.Privacy;
 
@@ -30,7 +30,7 @@ public final class SetDefaultListFilter extends FlexibleStanzaTypeFilter<Privacy
 
     @Override
     protected boolean acceptSpecific(Privacy privacy) {
-        if (privacy.getType() != Type.set) {
+        if (privacy.getType() != IQ.Type.set) {
             return false;
         }
         return privacy.getDefaultName() != null || privacy.isDeclineDefaultList();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/LeafNode.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/LeafNode.java
@@ -24,7 +24,7 @@ import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.ExtensionElement;
-import org.jivesoftware.smack.packet.IQ.Type;
+import org.jivesoftware.smack.packet.IQ;
 
 import org.jivesoftware.smackx.disco.packet.DiscoverItems;
 import org.jivesoftware.smackx.pubsub.form.ConfigureForm;
@@ -90,7 +90,7 @@ public class LeafNode extends Node {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public <T extends Item> List<T> getItems(String subscriptionId) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub request = createPubsubPacket(Type.get, new GetItemsRequest(getId(), subscriptionId));
+        PubSub request = createPubsubPacket(IQ.Type.get, new GetItemsRequest(getId(), subscriptionId));
         return getItems(request);
     }
 
@@ -116,7 +116,7 @@ public class LeafNode extends Node {
         for (String id : ids) {
             itemList.add(new Item(id));
         }
-        PubSub request = createPubsubPacket(Type.get, new ItemsExtension(ItemsExtension.ItemsElementType.items, getId(), itemList));
+        PubSub request = createPubsubPacket(IQ.Type.get, new ItemsExtension(ItemsExtension.ItemsElementType.items, getId(), itemList));
         return getItems(request);
     }
 
@@ -133,7 +133,7 @@ public class LeafNode extends Node {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public <T extends Item> List<T> getItems(int maxItems) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub request = createPubsubPacket(Type.get, new GetItemsRequest(getId(), maxItems));
+        PubSub request = createPubsubPacket(IQ.Type.get, new GetItemsRequest(getId(), maxItems));
         return getItems(request);
     }
 
@@ -154,7 +154,7 @@ public class LeafNode extends Node {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public <T extends Item> List<T> getItems(int maxItems, String subscriptionId) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub request = createPubsubPacket(Type.get, new GetItemsRequest(getId(), subscriptionId, maxItems));
+        PubSub request = createPubsubPacket(IQ.Type.get, new GetItemsRequest(getId(), subscriptionId, maxItems));
         return getItems(request);
     }
 
@@ -180,7 +180,7 @@ public class LeafNode extends Node {
     public <T extends Item> List<T> getItems(List<ExtensionElement> additionalExtensions,
                     List<ExtensionElement> returnedExtensions) throws NoResponseException,
                     XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub request = createPubsubPacket(Type.get, new GetItemsRequest(getId()));
+        PubSub request = createPubsubPacket(IQ.Type.get, new GetItemsRequest(getId()));
         request.addExtensions(additionalExtensions);
         return getItems(request, returnedExtensions);
     }
@@ -276,7 +276,7 @@ public class LeafNode extends Node {
      *
      */
     public void publish() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub packet = createPubsubPacket(Type.set, new NodeExtension(PubSubElementType.PUBLISH, getId()));
+        PubSub packet = createPubsubPacket(IQ.Type.set, new NodeExtension(PubSubElementType.PUBLISH, getId()));
 
         pubSubManager.getConnection().createStanzaCollectorAndSend(packet).nextResultOrThrow();
     }
@@ -325,7 +325,7 @@ public class LeafNode extends Node {
      *
      */
     public <T extends Item> void publish(Collection<T> items) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub packet = createPubsubPacket(Type.set, new PublishItem<>(getId(), items));
+        PubSub packet = createPubsubPacket(IQ.Type.set, new PublishItem<>(getId(), items));
 
         pubSubManager.getConnection().createStanzaCollectorAndSend(packet).nextResultOrThrow();
     }
@@ -341,7 +341,7 @@ public class LeafNode extends Node {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public void deleteAllItems() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub request = createPubsubPacket(Type.set, new NodeExtension(PubSubElementType.PURGE_OWNER, getId()));
+        PubSub request = createPubsubPacket(IQ.Type.set, new NodeExtension(PubSubElementType.PURGE_OWNER, getId()));
 
         pubSubManager.getConnection().createStanzaCollectorAndSend(request).nextResultOrThrow();
     }
@@ -376,7 +376,7 @@ public class LeafNode extends Node {
         for (String id : itemIds) {
              items.add(new Item(id));
         }
-        PubSub request = createPubsubPacket(Type.set, new ItemsExtension(ItemsExtension.ItemsElementType.retract, getId(), items));
+        PubSub request = createPubsubPacket(IQ.Type.set, new ItemsExtension(ItemsExtension.ItemsElementType.retract, getId(), items));
         pubSubManager.getConnection().createStanzaCollectorAndSend(request).nextResultOrThrow();
     }
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/Node.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/Node.java
@@ -29,7 +29,7 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.filter.FlexibleStanzaTypeFilter;
 import org.jivesoftware.smack.filter.OrFilter;
 import org.jivesoftware.smack.packet.ExtensionElement;
-import org.jivesoftware.smack.packet.IQ.Type;
+import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Stanza;
 
@@ -94,7 +94,7 @@ public abstract class Node {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public ConfigureForm getNodeConfiguration() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub pubSub = createPubsubPacket(Type.get, new NodeExtension(
+        PubSub pubSub = createPubsubPacket(IQ.Type.get, new NodeExtension(
                         PubSubElementType.CONFIGURE_OWNER, getId()));
         Stanza reply = sendPubsubPacket(pubSub);
         return NodeUtils.getFormFromPacket(reply, PubSubElementType.CONFIGURE_OWNER);
@@ -110,7 +110,7 @@ public abstract class Node {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public void sendConfigurationForm(FillableConfigureForm configureForm) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub packet = createPubsubPacket(Type.set, new FormNode(FormNodeType.CONFIGURE_OWNER,
+        PubSub packet = createPubsubPacket(IQ.Type.set, new FormNode(FormNodeType.CONFIGURE_OWNER,
                         getId(), configureForm.getDataFormToSubmit()));
         pubSubManager.getConnection().createStanzaCollectorAndSend(packet).nextResultOrThrow();
     }
@@ -218,7 +218,7 @@ public abstract class Node {
                     throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         PubSubElementType pubSubElementType = subscriptionsNamespace.type;
 
-        PubSub pubSub = createPubsubPacket(Type.get, new NodeExtension(pubSubElementType, getId()));
+        PubSub pubSub = createPubsubPacket(IQ.Type.get, new NodeExtension(pubSubElementType, getId()));
         if (additionalExtensions != null) {
             for (ExtensionElement pe : additionalExtensions) {
                 pubSub.addExtension(pe);
@@ -251,7 +251,7 @@ public abstract class Node {
     public PubSub modifySubscriptionsAsOwner(List<Subscription> changedSubs)
         throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
 
-        PubSub pubSub = createPubsubPacket(Type.set,
+        PubSub pubSub = createPubsubPacket(IQ.Type.set,
             new SubscriptionsExtension(SubscriptionsNamespace.owner, getId(), changedSubs));
         return sendPubsubPacket(pubSub);
     }
@@ -337,7 +337,7 @@ public abstract class Node {
                     NotConnectedException, InterruptedException {
         PubSubElementType pubSubElementType = affiliationsNamespace.type;
 
-        PubSub pubSub = createPubsubPacket(Type.get, new NodeExtension(pubSubElementType, getId()));
+        PubSub pubSub = createPubsubPacket(IQ.Type.get, new NodeExtension(pubSubElementType, getId()));
         if (additionalExtensions != null) {
             for (ExtensionElement pe : additionalExtensions) {
                 pubSub.addExtension(pe);
@@ -375,7 +375,7 @@ public abstract class Node {
             }
         }
 
-        PubSub pubSub = createPubsubPacket(Type.set, new AffiliationsExtension(AffiliationNamespace.owner, affiliations, getId()));
+        PubSub pubSub = createPubsubPacket(IQ.Type.set, new AffiliationsExtension(AffiliationNamespace.owner, affiliations, getId()));
         return sendPubsubPacket(pubSub);
     }
 
@@ -398,7 +398,7 @@ public abstract class Node {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public Subscription subscribe(Jid jid) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub pubSub = createPubsubPacket(Type.set, new SubscribeExtension(jid, getId()));
+        PubSub pubSub = createPubsubPacket(IQ.Type.set, new SubscribeExtension(jid, getId()));
         PubSub reply = sendPubsubPacket(pubSub);
         return reply.getExtension(PubSubElementType.SUBSCRIPTION);
     }
@@ -460,7 +460,7 @@ public abstract class Node {
      */
     public Subscription subscribe(Jid jid, FillableSubscribeForm subForm) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         DataForm submitForm = subForm.getDataFormToSubmit();
-        PubSub request = createPubsubPacket(Type.set, new SubscribeExtension(jid, getId()));
+        PubSub request = createPubsubPacket(IQ.Type.set, new SubscribeExtension(jid, getId()));
         request.addExtension(new FormNode(FormNodeType.OPTIONS, submitForm));
         PubSub reply = sendPubsubPacket(request);
         return reply.getExtension(PubSubElementType.SUBSCRIPTION);
@@ -529,7 +529,7 @@ public abstract class Node {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public void unsubscribe(String jid, String subscriptionId) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        sendPubsubPacket(createPubsubPacket(Type.set, new UnsubscribeExtension(jid, getId(), subscriptionId)));
+        sendPubsubPacket(createPubsubPacket(IQ.Type.set, new UnsubscribeExtension(jid, getId(), subscriptionId)));
     }
 
     /**
@@ -563,7 +563,7 @@ public abstract class Node {
      *
      */
     public SubscribeForm getSubscriptionOptions(String jid, String subscriptionId) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub packet = sendPubsubPacket(createPubsubPacket(Type.get, new OptionsExtension(jid, getId(), subscriptionId)));
+        PubSub packet = sendPubsubPacket(createPubsubPacket(IQ.Type.get, new OptionsExtension(jid, getId(), subscriptionId)));
         FormNode ext = packet.getExtension(PubSubElementType.OPTIONS);
         return new SubscribeForm(ext.getForm());
     }
@@ -651,7 +651,7 @@ public abstract class Node {
         return super.toString() + " " + getClass().getName() + " id: " + id;
     }
 
-    protected PubSub createPubsubPacket(Type type, NodeExtension ext) {
+    protected PubSub createPubsubPacket(IQ.Type type, NodeExtension ext) {
         return PubSub.createPubsubPacket(pubSubManager.getServiceJid(), type, ext);
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/PubSubManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/PubSubManager.java
@@ -35,7 +35,6 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.EmptyResultIQ;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smack.packet.StanzaError.Condition;
@@ -217,7 +216,7 @@ public final class PubSubManager extends Manager {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public LeafNode createNode() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub reply = sendPubsubPacket(Type.set, new NodeExtension(PubSubElementType.CREATE), null);
+        PubSub reply = sendPubsubPacket(IQ.Type.set, new NodeExtension(PubSubElementType.CREATE), null);
         QName qname = new QName(PubSubNamespace.basic.getXmlns(), "create");
         NodeExtension elem = (NodeExtension) reply.getExtension(qname);
 
@@ -257,7 +256,7 @@ public final class PubSubManager extends Manager {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public Node createNode(String nodeId, FillableConfigureForm config) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub request = PubSub.createPubsubPacket(pubSubService, Type.set, new NodeExtension(PubSubElementType.CREATE, nodeId));
+        PubSub request = PubSub.createPubsubPacket(pubSubService, IQ.Type.set, new NodeExtension(PubSubElementType.CREATE, nodeId));
         boolean isLeafNode = true;
 
         if (config != null) {
@@ -507,7 +506,7 @@ public final class PubSubManager extends Manager {
      * @throws InterruptedException if the calling thread was interrupted.
      */
     public List<Subscription> getSubscriptions() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        Stanza reply = sendPubsubPacket(Type.get, new NodeExtension(PubSubElementType.SUBSCRIPTIONS), null);
+        Stanza reply = sendPubsubPacket(IQ.Type.get, new NodeExtension(PubSubElementType.SUBSCRIPTIONS), null);
         SubscriptionsExtension subElem = (SubscriptionsExtension) reply.getExtensionElement(PubSubElementType.SUBSCRIPTIONS.getElementName(), PubSubElementType.SUBSCRIPTIONS.getNamespace().getXmlns());
         return subElem.getSubscriptions();
     }
@@ -523,7 +522,7 @@ public final class PubSubManager extends Manager {
      *
      */
     public List<Affiliation> getAffiliations() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
-        PubSub reply = sendPubsubPacket(Type.get, new NodeExtension(PubSubElementType.AFFILIATIONS), null);
+        PubSub reply = sendPubsubPacket(IQ.Type.get, new NodeExtension(PubSubElementType.AFFILIATIONS), null);
         AffiliationsExtension listElem = reply.getExtension(PubSubElementType.AFFILIATIONS);
         return listElem.getAffiliations();
     }
@@ -541,7 +540,7 @@ public final class PubSubManager extends Manager {
     public boolean deleteNode(String nodeId) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         boolean res = true;
         try {
-            sendPubsubPacket(Type.set, new NodeExtension(PubSubElementType.DELETE, nodeId), PubSubElementType.DELETE.getNamespace());
+            sendPubsubPacket(IQ.Type.set, new NodeExtension(PubSubElementType.DELETE, nodeId), PubSubElementType.DELETE.getNamespace());
         } catch (XMPPErrorException e) {
             if (e.getStanzaError().getCondition() == StanzaError.Condition.item_not_found) {
                 res = false;
@@ -565,7 +564,7 @@ public final class PubSubManager extends Manager {
     public ConfigureForm getDefaultConfiguration() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         // Errors will cause exceptions in getReply, so it only returns
         // on success.
-        PubSub reply = sendPubsubPacket(Type.get, new NodeExtension(PubSubElementType.DEFAULT), PubSubElementType.DEFAULT.getNamespace());
+        PubSub reply = sendPubsubPacket(IQ.Type.get, new NodeExtension(PubSubElementType.DEFAULT), PubSubElementType.DEFAULT.getNamespace());
         return NodeUtils.getFormFromPacket(reply, PubSubElementType.DEFAULT);
     }
 
@@ -644,7 +643,7 @@ public final class PubSubManager extends Manager {
         return true;
     }
 
-    private PubSub sendPubsubPacket(Type type, ExtensionElement ext, PubSubNamespace ns)
+    private PubSub sendPubsubPacket(IQ.Type type, ExtensionElement ext, PubSubNamespace ns)
                     throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         return sendPubsubPacket(pubSubService, type, Collections.singletonList(ext), ns);
     }
@@ -653,7 +652,7 @@ public final class PubSubManager extends Manager {
         return connection();
     }
 
-    PubSub sendPubsubPacket(Jid to, Type type, List<ExtensionElement> extList, PubSubNamespace ns)
+    PubSub sendPubsubPacket(Jid to, IQ.Type type, List<ExtensionElement> extList, PubSubNamespace ns)
                     throws NoResponseException, XMPPErrorException, NotConnectedException,
                     InterruptedException {
 // CHECKSTYLE:OFF

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/softwareinfo/form/SoftwareInfoForm.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/softwareinfo/form/SoftwareInfoForm.java
@@ -27,7 +27,6 @@ import org.jivesoftware.smackx.xdata.TextSingleFormField;
 import org.jivesoftware.smackx.xdata.form.FilledForm;
 import org.jivesoftware.smackx.xdata.form.Form;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.jivesoftware.smackx.xdata.packet.DataForm.Type;
 
 /**
  * {@link Form} that contains the software information.
@@ -145,7 +144,7 @@ public final class SoftwareInfoForm extends FilledForm {
         DataForm.Builder dataFormBuilder;
 
         private Builder() {
-            dataFormBuilder = DataForm.builder(Type.result);
+            dataFormBuilder = DataForm.builder(DataForm.Type.result);
             TextSingleFormField formField = FormField.buildHiddenFormType(FORM_TYPE);
             dataFormBuilder.addField(formField);
         }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/time/EntityTimeManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/time/EntityTimeManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2014 Florian Schmaus
+ * Copyright 2014-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.iqrequest.AbstractIqRequestHandler;
 import org.jivesoftware.smack.iqrequest.IQRequestHandler.Mode;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.StanzaError.Condition;
 
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
@@ -72,7 +71,7 @@ public final class EntityTimeManager extends Manager {
         if (autoEnable)
             enable();
 
-        connection.registerIQRequestHandler(new AbstractIqRequestHandler(Time.ELEMENT, Time.NAMESPACE, Type.get,
+        connection.registerIQRequestHandler(new AbstractIqRequestHandler(Time.ELEMENT, Time.NAMESPACE, IQ.Type.get,
                         Mode.async) {
             @Override
             public IQ handleIQRequest(IQ iqRequest) {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -28,7 +28,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -612,10 +611,10 @@ public final class VCard extends IQ {
             xml.optElement("ORGUNIT", organizationUnit);
             xml.closeElement("ORG");
         }
-        for (Entry<String, String> entry : otherSimpleFields.entrySet()) {
+        for (Map.Entry<String, String> entry : otherSimpleFields.entrySet()) {
             xml.optElement(entry.getKey(), entry.getValue());
         }
-        for (Entry<String, String> entry : otherUnescapableFields.entrySet()) {
+        for (Map.Entry<String, String> entry : otherUnescapableFields.entrySet()) {
             final String value = entry.getValue();
             if (value == null) {
                 continue;
@@ -646,7 +645,7 @@ public final class VCard extends IQ {
             xml.element("USERID", emailHome);
             xml.closeElement("EMAIL");
         }
-        for (Entry<String, String> phone : workPhones.entrySet()) {
+        for (Map.Entry<String, String> phone : workPhones.entrySet()) {
             final String number = phone.getValue();
             if (number == null) {
                 continue;
@@ -657,7 +656,7 @@ public final class VCard extends IQ {
             xml.element("NUMBER", number);
             xml.closeElement("TEL");
         }
-        for (Entry<String, String> phone : homePhones.entrySet()) {
+        for (Map.Entry<String, String> phone : homePhones.entrySet()) {
             final String number = phone.getValue();
             if (number == null) {
                 continue;
@@ -671,7 +670,7 @@ public final class VCard extends IQ {
         if (!workAddr.isEmpty()) {
             xml.openElement("ADR");
             xml.emptyElement("WORK");
-            for (Entry<String, String> entry : workAddr.entrySet()) {
+            for (Map.Entry<String, String> entry : workAddr.entrySet()) {
                 final String value = entry.getValue();
                 if (value == null) {
                     continue;
@@ -683,7 +682,7 @@ public final class VCard extends IQ {
         if (!homeAddr.isEmpty()) {
             xml.openElement("ADR");
             xml.emptyElement("HOME");
-            for (Entry<String, String> entry : homeAddr.entrySet()) {
+            for (Map.Entry<String, String> entry : homeAddr.entrySet()) {
                 final String value = entry.getValue();
                 if (value == null) {
                     continue;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/FillableForm.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/FillableForm.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import org.jivesoftware.smackx.xdata.AbstractMultiFormField;
 import org.jivesoftware.smackx.xdata.AbstractSingleStringValueFormField;
 import org.jivesoftware.smackx.xdata.FormField;
-import org.jivesoftware.smackx.xdata.FormField.Type;
 import org.jivesoftware.smackx.xdata.FormFieldChildElement;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 
@@ -202,7 +201,7 @@ public class FillableForm extends FilledForm {
 
     public void setAnswer(String fieldName, boolean answer) {
         FormField blankField = getFieldOrThrow(fieldName);
-        if (blankField.getType() != Type.bool) {
+        if (blankField.getType() != FormField.Type.bool) {
             throw new IllegalArgumentException();
         }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/FilledForm.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/FilledForm.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2020 Florian Schmaus
+ * Copyright 2020-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.TextSingleFormField;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.jivesoftware.smackx.xdata.packet.DataForm.Type;
 
 public abstract class FilledForm implements FormReader {
 
@@ -36,7 +35,7 @@ public abstract class FilledForm implements FormReader {
         if (StringUtils.isNullOrEmpty(formType)) {
             throw new IllegalArgumentException("The provided data form has no hidden FROM_TYPE field.");
         }
-        if (dataForm.getType() == Type.cancel) {
+        if (dataForm.getType() == DataForm.Type.cancel) {
             throw new IllegalArgumentException("Forms of type 'cancel' are not filled nor fillable");
         }
         formTypeFormField = dataForm.getHiddenFormTypeField();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/Form.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/Form.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2020 Florian Schmaus
+ * Copyright 2020-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,12 @@ package org.jivesoftware.smackx.xdata.form;
 import org.jivesoftware.smack.packet.StanzaView;
 
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.jivesoftware.smackx.xdata.packet.DataForm.Type;
 
 public class Form extends FilledForm {
 
     public Form(DataForm dataForm) {
         super(dataForm);
-        if (dataForm.getType() != Type.form) {
+        if (dataForm.getType() != DataForm.Type.form) {
             throw new IllegalArgumentException();
         }
     }
@@ -36,7 +35,7 @@ public class Form extends FilledForm {
 
     public static Form from(StanzaView stanzaView) {
         DataForm dataForm = DataForm.from(stanzaView);
-        if (dataForm == null || dataForm.getType() != Type.form) {
+        if (dataForm == null || dataForm.getType() != DataForm.Type.form) {
             return null;
         }
         return new Form(dataForm);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdatavalidation/packet/ValidateElement.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdatavalidation/packet/ValidateElement.java
@@ -112,6 +112,8 @@ public abstract class ValidateElement implements FormFieldChildElement {
     }
 
     /**
+     * Append XML.
+     *
      * @param buf TODO javadoc me please
      */
     protected abstract void appendXML(XmlStringBuilder buf);
@@ -458,6 +460,8 @@ public abstract class ValidateElement implements FormFieldChildElement {
     }
 
     /**
+     * Check that the field being build is not of type multi (or hidden).
+     *
      * @param formField TODO javadoc me please
      * @param method TODO javadoc me please
      */

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/GetBlockingListTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/blocking/GetBlockingListTest.java
@@ -19,7 +19,6 @@ package org.jivesoftware.smackx.blocking;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.StreamOpen;
 import org.jivesoftware.smack.util.PacketParserUtils;
 
@@ -42,7 +41,7 @@ public class GetBlockingListTest {
     @Test
     public void checkGetBlockingListIQStanza() throws Exception {
         BlockListIQ getBlockListIQ = new BlockListIQ(null);
-        getBlockListIQ.setType(Type.get);
+        getBlockListIQ.setType(IQ.Type.get);
         getBlockListIQ.setStanzaId("blocklist1");
         assertEquals(getBlockingListIQExample, getBlockListIQ.toXML(StreamOpen.CLIENT_NAMESPACE).toString());
     }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bob/BoBIQTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bob/BoBIQTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 
-import org.jivesoftware.smack.packet.IQ.Type;
+import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.StreamOpen;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smack.util.PacketParserUtils;
@@ -46,7 +46,7 @@ public class BoBIQTest extends SmackTestSuite {
         BoBIQ createdBoBIQ = new BoBIQ(bobHash);
         createdBoBIQ.setStanzaId("sarasa");
         createdBoBIQ.setTo(JidCreate.from("ladymacbeth@shakespeare.lit/castle"));
-        createdBoBIQ.setType(Type.get);
+        createdBoBIQ.setType(IQ.Type.get);
 
         assertEquals(sampleBoBIQRequest, createdBoBIQ.toXML(StreamOpen.CLIENT_NAMESPACE).toString());
     }
@@ -61,7 +61,7 @@ public class BoBIQTest extends SmackTestSuite {
         BoBIQ createdBoBIQ = new BoBIQ(bobHash, bobData);
         createdBoBIQ.setStanzaId("sarasa");
         createdBoBIQ.setTo(JidCreate.from("doctor@shakespeare.lit/pda"));
-        createdBoBIQ.setType(Type.result);
+        createdBoBIQ.setType(IQ.Type.result);
 
         assertEquals(bobIQ.getContentId().getHash(), createdBoBIQ.getContentId().getHash());
         assertEquals(bobIQ.getContentId().getHashType(), createdBoBIQ.getContentId().getHashType());

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/ping/PingTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/ping/PingTest.java
@@ -237,7 +237,7 @@ public class PingTest extends SmackTestSuite {
     /**
      * The returned connection won't send replies to IQs
      *
-     * @return
+     * @return a dummy connection.
      * @throws XMPPException if an XMPP protocol error was received.
      * @throws IOException if an I/O error occurred.
      * @throws SmackException if Smack detected an exceptional situation.

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/AffiliationsExtensionTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/AffiliationsExtensionTest.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2017-2020 Florian Schmaus
+ * Copyright 2017-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jivesoftware.smackx.pubsub.Affiliation.Type;
 import org.jivesoftware.smackx.pubsub.packet.PubSub;
 
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,7 @@ public class AffiliationsExtensionTest {
     @Test
     public void testAffiliationsExtensionToXml() throws SAXException, IOException {
         BareJid affiliatedJid = JidTestUtil.BARE_JID_1;
-        Affiliation affiliation = new Affiliation(affiliatedJid, Type.member);
+        Affiliation affiliation = new Affiliation(affiliatedJid, Affiliation.Type.member);
         List<Affiliation> affiliationsList = new ArrayList<>();
         affiliationsList.add(affiliation);
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/ConfigureFormTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/ConfigureFormTest.java
@@ -28,7 +28,6 @@ import org.jivesoftware.smack.ThreadedDummyConnection;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smack.packet.StanzaError.Condition;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
@@ -63,7 +62,7 @@ public class ConfigureFormTest extends SmackTestSuite {
         Node node = mgr.getNode("princely_musings");
 
         PubSub errorIq = new PubSub();
-        errorIq.setType(Type.error);
+        errorIq.setType(IQ.Type.error);
         errorIq.setFrom(PubSubManagerTest.DUMMY_PUBSUB_SERVICE);
         StanzaError error = StanzaError.getBuilder(Condition.forbidden).build();
         errorIq.setError(error);

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/PubSubNodeTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/pubsub/PubSubNodeTest.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2018 Timothy Pitt, Florian Schmaus
+ * Copyright 2018 Timothy Pitt, 2018-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.ThreadedDummyConnection;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException;
-import org.jivesoftware.smack.packet.IQ.Type;
+import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smack.test.util.TestUtils;
 import org.jivesoftware.smack.util.PacketParserUtils;
@@ -89,7 +89,7 @@ public class PubSubNodeTest extends SmackTestSuite {
             new Affiliation(JidTestUtil.BARE_JID_2, Affiliation.Type.publisher)
         );
         AffiliationsExtension affiliationsExtension = new AffiliationsExtension(AffiliationNamespace.owner, affiliations);
-        PubSub response = new PubSub(JidTestUtil.PUBSUB_EXAMPLE_ORG, Type.result, PubSubNamespace.owner);
+        PubSub response = new PubSub(JidTestUtil.PUBSUB_EXAMPLE_ORG, IQ.Type.result, PubSubNamespace.owner);
         response.addExtension(affiliationsExtension);
         protocol.addResponse(response);
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/softwareinfo/SoftwareInfoFormTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/softwareinfo/SoftwareInfoFormTest.java
@@ -29,7 +29,6 @@ import org.jivesoftware.smackx.softwareinfo.form.SoftwareInfoForm;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.TextSingleFormField;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.jivesoftware.smackx.xdata.packet.DataForm.Type;
 
 import org.junit.jupiter.api.Test;
 
@@ -85,21 +84,21 @@ public class SoftwareInfoFormTest extends SmackTestSuite {
 
     @Test
     public void faultySoftwareInfoFormsTest() {
-        DataForm.Builder dataFormbuilder = DataForm.builder(Type.result);
+        DataForm.Builder dataFormbuilder = DataForm.builder(DataForm.Type.result);
         TextSingleFormField formField = FormField.buildHiddenFormType("faulty_formtype");
         dataFormbuilder.addField(formField);
         assertThrows(IllegalArgumentException.class, () -> {
             SoftwareInfoForm.getBuilder().setDataForm(dataFormbuilder.build()).build();
         });
 
-        DataForm.Builder builderWithoutFormType = DataForm.builder(Type.result);
+        DataForm.Builder builderWithoutFormType = DataForm.builder(DataForm.Type.result);
         assertThrows(IllegalArgumentException.class, () -> {
             SoftwareInfoForm.getBuilder().setDataForm(builderWithoutFormType.build()).build();
         });
     }
 
     public static SoftwareInfoForm createSoftwareInfoFormUsingDataForm() throws URISyntaxException {
-        DataForm.Builder dataFormBuilder = DataForm.builder(Type.result);
+        DataForm.Builder dataFormBuilder = DataForm.builder(DataForm.Type.result);
         TextSingleFormField formField = FormField.buildHiddenFormType(SoftwareInfoForm.FORM_TYPE);
         dataFormBuilder.addField(formField);
 

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/softwareinfo/SoftwareInfoManagerTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/softwareinfo/SoftwareInfoManagerTest.java
@@ -30,7 +30,6 @@ import org.jivesoftware.smackx.mediaelement.element.MediaElement;
 import org.jivesoftware.smackx.softwareinfo.form.SoftwareInfoForm;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.jivesoftware.smackx.xdata.packet.DataForm.Type;
 
 import org.jivesoftware.util.ConnectionUtils;
 import org.jivesoftware.util.Protocol;
@@ -70,7 +69,7 @@ public class SoftwareInfoManagerTest {
     }
 
     public static SoftwareInfoForm buildSoftwareInfoFromDataForm() throws URISyntaxException {
-        DataForm.Builder dataFormBuilder = DataForm.builder(Type.result);
+        DataForm.Builder dataFormBuilder = DataForm.builder(DataForm.Type.result);
         dataFormBuilder.addField(FormField.buildHiddenFormType(SoftwareInfoForm.FORM_TYPE));
         dataFormBuilder.addField(FormField.builder("icon")
                                    .addFormFieldChildElement(createMediaElement())

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/xdata/packet/DataFormTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/xdata/packet/DataFormTest.java
@@ -25,7 +25,6 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.xdata.FormField;
-import org.jivesoftware.smackx.xdata.FormField.Type;
 import org.jivesoftware.smackx.xdata.provider.DataFormProvider;
 import org.jivesoftware.smackx.xdatalayout.packet.DataLayout;
 import org.jivesoftware.smackx.xdatalayout.packet.DataLayout.Fieldref;
@@ -151,6 +150,6 @@ public class DataFormTest extends SmackTestSuite {
     public void testFixedField() throws Exception {
         final String formWithFixedField = "<x xmlns='jabber:x:data' type='form'><instructions>InstructionTest1</instructions><field type='fixed'><value>Fixed field value</value></field></x>";
         DataForm df = pr.parse(PacketParserUtils.getParserFor(formWithFixedField));
-        assertEquals(Type.fixed, df.getFields().get(0).getType());
+        assertEquals(FormField.Type.fixed, df.getFields().get(0).getType());
     }
 }

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/xdatavalidation/provider/DataValidationTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/xdatavalidation/provider/DataValidationTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 
 import org.jivesoftware.smack.parsing.SmackParsingException;
+import org.jivesoftware.smack.provider.AbstractProvider;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smack.test.util.SmackTestUtil;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -145,7 +146,7 @@ public class DataValidationTest extends SmackTestSuite {
     @ParameterizedTest
     @EnumSource(SmackTestUtil.XmlPullParserKind.class)
     public void testRangeFailure(SmackTestUtil.XmlPullParserKind parserKind) throws IOException, XmlPullParserException {
-        assertThrows(NumberFormatException.class,
+        assertThrows(AbstractProvider.NumberFormatParseException.class,
                         () -> SmackTestUtil.parse(TEST_OUTPUT_FAIL, DataValidationProvider.class, parserKind));
     }
 

--- a/smack-im/src/main/java/org/jivesoftware/smack/chat/ChatManager.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/chat/ChatManager.java
@@ -39,7 +39,6 @@ import org.jivesoftware.smack.filter.OrFilter;
 import org.jivesoftware.smack.filter.StanzaFilter;
 import org.jivesoftware.smack.filter.ThreadFilter;
 import org.jivesoftware.smack.packet.Message;
-import org.jivesoftware.smack.packet.Message.Type;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.util.StringUtils;
 
@@ -110,7 +109,7 @@ public final class ChatManager extends Manager{
 
         @Override
         protected boolean acceptSpecific(Message message) {
-            return normalIncluded ? message.getType() == Type.normal : false;
+            return normalIncluded ? message.getType() == Message.Type.normal : false;
         }
 
     });

--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/RosterEntry.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/RosterEntry.java
@@ -29,7 +29,6 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Presence;
-import org.jivesoftware.smack.packet.Presence.Type;
 import org.jivesoftware.smack.roster.packet.RosterPacket;
 import org.jivesoftware.smack.util.EqualsUtil;
 
@@ -221,7 +220,7 @@ public final class RosterEntry extends Manager {
         XMPPConnection connection = connection();
         Presence unsubscribed = connection.getStanzaFactory().buildPresenceStanza()
                 .to(item.getJid())
-                .ofType(Type.unsubscribed)
+                .ofType(Presence.Type.unsubscribed)
                 .build();
         connection.sendStanza(unsubscribed);
     }

--- a/smack-im/src/test/java/org/jivesoftware/smack/chat/ChatConnectionTest.java
+++ b/smack-im/src/test/java/org/jivesoftware/smack/chat/ChatConnectionTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.packet.Message;
-import org.jivesoftware.smack.packet.Message.Type;
 import org.jivesoftware.smack.packet.MessageBuilder;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.packet.StanzaBuilder;
@@ -92,7 +91,7 @@ public class ChatConnectionTest {
     @Test
     public void validateMessageTypeWithDefaults1() {
         MessageBuilder incomingChat = createChatPacket("134", true);
-        incomingChat.ofType(Type.chat);
+        incomingChat.ofType(Message.Type.chat);
         processServerMessage(incomingChat.build());
         assertNotNull(listener.getNewChat());
     }
@@ -100,14 +99,14 @@ public class ChatConnectionTest {
     @Test
     public void validateMessageTypeWithDefaults2() {
         MessageBuilder incomingChat = createChatPacket("134", true);
-        incomingChat.ofType(Type.normal);
+        incomingChat.ofType(Message.Type.normal);
         processServerMessage(incomingChat.build());
         assertNotNull(listener.getNewChat());
     }
     @Test
     public void validateMessageTypeWithDefaults3() {
         MessageBuilder incomingChat = createChatPacket("134", true);
-        incomingChat.ofType(Type.groupchat);
+        incomingChat.ofType(Message.Type.groupchat);
         processServerMessage(incomingChat.build());
         assertNull(listener.getNewChat());
     }
@@ -115,7 +114,7 @@ public class ChatConnectionTest {
     @Test
     public void validateMessageTypeWithDefaults4() {
         MessageBuilder incomingChat = createChatPacket("134", true);
-        incomingChat.ofType(Type.headline);
+        incomingChat.ofType(Message.Type.headline);
         assertNull(listener.getNewChat());
     }
 
@@ -123,7 +122,7 @@ public class ChatConnectionTest {
     public void validateMessageTypeWithNoNormal1() {
         cm.setNormalIncluded(false);
         MessageBuilder incomingChat = createChatPacket("134", true);
-        incomingChat.ofType(Type.chat);
+        incomingChat.ofType(Message.Type.chat);
         processServerMessage(incomingChat.build());
         assertNotNull(listener.getNewChat());
     }
@@ -132,7 +131,7 @@ public class ChatConnectionTest {
     public void validateMessageTypeWithNoNormal2() {
         cm.setNormalIncluded(false);
         MessageBuilder incomingChat = createChatPacket("134", true);
-        incomingChat.ofType(Type.normal);
+        incomingChat.ofType(Message.Type.normal);
         processServerMessage(incomingChat.build());
         assertNull(listener.getNewChat());
     }
@@ -318,7 +317,7 @@ public class ChatConnectionTest {
         cm.setNormalIncluded(false);
 
         MessageBuilder incomingChat = createChatPacket(null, false);
-        incomingChat.ofType(Type.normal);
+        incomingChat.ofType(Message.Type.normal);
         processServerMessage(incomingChat.build());
 
         assertNull(listener.getNewChat());

--- a/smack-im/src/test/java/org/jivesoftware/smack/roster/RosterTest.java
+++ b/smack-im/src/test/java/org/jivesoftware/smack/roster/RosterTest.java
@@ -35,7 +35,6 @@ import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.im.InitSmackIm;
 import org.jivesoftware.smack.packet.ErrorIQ;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.packet.StanzaError.Condition;
@@ -385,7 +384,7 @@ public class RosterTest extends InitSmackIm {
     public void testIgnoreInvalidFrom() throws XmppStringprepException {
         final BareJid spammerJid = JidCreate.entityBareFrom("spam@example.com");
         RosterPacket packet = new RosterPacket();
-        packet.setType(Type.set);
+        packet.setType(IQ.Type.set);
         packet.setTo(connection.getUser());
         packet.setFrom(JidCreate.entityBareFrom("mallory@example.com"));
         packet.addRosterItem(new Item(spammerJid, "Cool products!"));
@@ -530,7 +529,7 @@ public class RosterTest extends InitSmackIm {
         for (RosterEntry entry : roster.getEntries()) {
             // prepare the roster push packet
             final RosterPacket rosterPush = new RosterPacket();
-            rosterPush.setType(Type.set);
+            rosterPush.setType(IQ.Type.set);
             rosterPush.setTo(connection.getUser());
 
             // prepare the buddy's item entry which should be removed
@@ -555,7 +554,7 @@ public class RosterTest extends InitSmackIm {
         roster.reload();
         while (true) {
             final Stanza sentPacket = connection.getSentPacket();
-            if (sentPacket instanceof RosterPacket && ((IQ) sentPacket).getType() == Type.get) {
+            if (sentPacket instanceof RosterPacket && ((IQ) sentPacket).getType() == IQ.Type.get) {
                 // setup the roster get request
                 final RosterPacket rosterRequest = (RosterPacket) sentPacket;
                 assertSame("The <query/> element MUST NOT contain any <item/> child elements!",
@@ -565,7 +564,7 @@ public class RosterTest extends InitSmackIm {
                 // prepare the roster result
                 final RosterPacket rosterResult = new RosterPacket();
                 rosterResult.setTo(connection.getUser());
-                rosterResult.setType(Type.result);
+                rosterResult.setType(IQ.Type.result);
                 rosterResult.setStanzaId(rosterRequest.getStanzaId());
 
                 // prepare romeo's roster entry
@@ -674,7 +673,7 @@ public class RosterTest extends InitSmackIm {
             try {
                 while (true) {
                     final Stanza packet = connection.getSentPacket();
-                    if (packet instanceof RosterPacket && ((IQ) packet).getType() == Type.set) {
+                    if (packet instanceof RosterPacket && ((IQ) packet).getType() == IQ.Type.set) {
                         final RosterPacket rosterRequest = (RosterPacket) packet;
 
                         // Prepare and process the roster push
@@ -683,7 +682,7 @@ public class RosterTest extends InitSmackIm {
                         if (item.getItemType() != ItemType.remove) {
                             item.setItemType(ItemType.none);
                         }
-                        rosterPush.setType(Type.set);
+                        rosterPush.setType(IQ.Type.set);
                         rosterPush.setTo(connection.getUser());
                         rosterPush.addRosterItem(item);
                         connection.processStanza(rosterPush);

--- a/smack-im/src/test/java/org/jivesoftware/smack/roster/RosterVersioningTest.java
+++ b/smack-im/src/test/java/org/jivesoftware/smack/roster/RosterVersioningTest.java
@@ -30,7 +30,6 @@ import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.roster.RosterTest.TestRosterListener;
 import org.jivesoftware.smack.roster.packet.RosterPacket;
@@ -146,7 +145,7 @@ public class RosterVersioningTest {
             RosterPacket sentRP = (RosterPacket) sentPacket;
             RosterPacket answer = new RosterPacket();
             answer.setStanzaId(sentRP.getStanzaId());
-            answer.setType(Type.result);
+            answer.setType(IQ.Type.result);
             answer.setTo(sentRP.getFrom());
 
             answer.setVersion("newVersion");
@@ -188,7 +187,7 @@ public class RosterVersioningTest {
         {
             RosterPacket rosterPush = new RosterPacket();
             rosterPush.setTo(JidCreate.from("rostertest@example.com/home"));
-            rosterPush.setType(Type.set);
+            rosterPush.setType(IQ.Type.set);
             rosterPush.setVersion("v97");
 
             Item pushedItem = vaglafItem();
@@ -214,7 +213,7 @@ public class RosterVersioningTest {
         {
             RosterPacket rosterPush = new RosterPacket();
             rosterPush.setTo(JidCreate.from("rostertest@example.com/home"));
-            rosterPush.setType(Type.set);
+            rosterPush.setType(IQ.Type.set);
             rosterPush.setVersion("v98");
 
             Item item = new Item(JidCreate.entityBareFrom("vaglaf@example.com"), "vaglaf the only");

--- a/smack-im/src/test/java/org/jivesoftware/smack/roster/SubscriptionPreApprovalTest.java
+++ b/smack-im/src/test/java/org/jivesoftware/smack/roster/SubscriptionPreApprovalTest.java
@@ -26,7 +26,6 @@ import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.SmackException.FeatureNotSupportedException;
 import org.jivesoftware.smack.im.InitSmackIm;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IQ.Type;
 import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.roster.RosterTest.TestRosterListener;
@@ -161,7 +160,7 @@ public class SubscriptionPreApprovalTest extends InitSmackIm {
             try {
                 while (true) {
                     final Stanza packet = connection.getSentPacket();
-                    if (packet instanceof RosterPacket && ((IQ) packet).getType() == Type.set) {
+                    if (packet instanceof RosterPacket && ((IQ) packet).getType() == IQ.Type.set) {
                         final RosterPacket rosterRequest = (RosterPacket) packet;
 
                         // Prepare and process the roster push
@@ -170,7 +169,7 @@ public class SubscriptionPreApprovalTest extends InitSmackIm {
                         if (item.getItemType() != ItemType.remove) {
                             item.setItemType(ItemType.none);
                         }
-                        rosterPush.setType(Type.set);
+                        rosterPush.setType(IQ.Type.set);
                         rosterPush.setTo(connection.getUser());
                         rosterPush.addRosterItem(item);
                         connection.processStanza(rosterPush);

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -24,7 +24,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -447,7 +447,7 @@ public final class Configuration {
 
         // Properties set via the system override the file properties
         Properties systemProperties = System.getProperties();
-        for (Entry<Object, Object> entry : systemProperties.entrySet()) {
+        for (Map.Entry<Object, Object> entry : systemProperties.entrySet()) {
             String key = (String) entry.getKey();
             if (!key.startsWith(SINTTEST)) {
                 continue;

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2015-2020 Florian Schmaus
+ * Copyright 2015-2021 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -106,7 +105,7 @@ public class SmackIntegrationTestFramework {
         SmackIntegrationTestFramework sinttest = new SmackIntegrationTestFramework(config);
         TestRunResult testRunResult = sinttest.run();
 
-        for (Entry<Class<? extends AbstractSmackIntTest>, Throwable> entry : testRunResult.impossibleTestClasses.entrySet()) {
+        for (Map.Entry<Class<? extends AbstractSmackIntTest>, Throwable> entry : testRunResult.impossibleTestClasses.entrySet()) {
             LOGGER.info("Could not run " + entry.getKey().getName() + " because: "
                             + entry.getValue().getLocalizedMessage());
         }
@@ -769,7 +768,7 @@ public class SmackIntegrationTestFramework {
             /**
              * Execute the test.
              *
-             * @throws IllegalAccessException
+             * @throws IllegalAccessException if there was an illegal access.
              * @throws InterruptedException if the calling thread was interrupted.
              * @throws InvocationTargetException if the reflective invoked test throws an exception.
              * @throws XMPPException in case an XMPPException happens when <em>preparing</em> the test.

--- a/smack-java8/src/main/java/org/jivesoftware/smack/java7/XmppHostnameVerifier.java
+++ b/smack-java8/src/main/java/org/jivesoftware/smack/java7/XmppHostnameVerifier.java
@@ -245,7 +245,7 @@ public class XmppHostnameVerifier implements HostnameVerifier {
      *
      * @param expectedIP TODO javadoc me please
      * @param cert TODO javadoc me please
-     * @throws CertificateException
+     * @throws CertificateException in case of a certificate issue.
      */
     private static void matchIp(String expectedIP, X509Certificate cert)
                     throws CertificateException {

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/JingleSession.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/JingleSession.java
@@ -85,7 +85,7 @@ public final class JingleSession extends JingleNegotiator implements MediaReceiv
 
     private StanzaFilter packetFilter;
 
-    protected List<JingleMediaManager> jingleMediaManagers = null;
+    List<JingleMediaManager> jingleMediaManagers = null;
 
     private JingleSessionState sessionState;
 
@@ -228,7 +228,7 @@ public final class JingleSession extends JingleNegotiator implements MediaReceiv
      * @param sessionId TODO javadoc me please
      *            the sid to set
      */
-    protected void setSid(String sessionId) {
+    void setSid(String sessionId) {
         sid = sessionId;
     }
 
@@ -237,7 +237,7 @@ public final class JingleSession extends JingleNegotiator implements MediaReceiv
      *
      * @return the generated session ID.
      */
-    protected static String generateSessionId() {
+    static String generateSessionId() {
         return String.valueOf(randomGenerator.nextInt(Integer.MAX_VALUE) + randomGenerator.nextInt(Integer.MAX_VALUE));
     }
 
@@ -675,7 +675,7 @@ public final class JingleSession extends JingleNegotiator implements MediaReceiv
     /**
      * Remove the stanza listener used for processing packet.
      */
-    protected void removeAsyncPacketListener() {
+    void removeAsyncPacketListener() {
         if (packetListener != null) {
             getConnection().removeAsyncStanzaListener(packetListener);
 
@@ -687,7 +687,7 @@ public final class JingleSession extends JingleNegotiator implements MediaReceiv
      * Install the stanza listener. The listener is responsible for responding
      * to any stanza that we receive...
      */
-    protected void updatePacketListener() {
+    void updatePacketListener() {
         removeAsyncPacketListener();
 
         LOGGER.fine("UpdatePacketListener");
@@ -895,7 +895,7 @@ public final class JingleSession extends JingleNegotiator implements MediaReceiv
      *
      * @param reason the reason.
      */
-    protected void triggerSessionClosed(String reason) {
+    void triggerSessionClosed(String reason) {
         //        for (ContentNegotiator contentNegotiator : contentNegotiators) {
         //
         //            contentNegotiator.stopJingleMediaSession();
@@ -919,7 +919,7 @@ public final class JingleSession extends JingleNegotiator implements MediaReceiv
      *
      * @param exc the exception.
      */
-    protected void triggerSessionClosedOnError(XMPPException exc) {
+    void triggerSessionClosedOnError(XMPPException exc) {
         for (ContentNegotiator contentNegotiator : contentNegotiators) {
 
             contentNegotiator.stopJingleMediaSession();
@@ -954,7 +954,7 @@ public final class JingleSession extends JingleNegotiator implements MediaReceiv
      *
      * @param participant the participant.
      */
-    protected void triggerMediaReceived(String participant) {
+    void triggerMediaReceived(String participant) {
         List<JingleListener> listeners = getListenersList();
         for (JingleListener li : listeners) {
             if (li instanceof JingleSessionListener) {

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/media/MediaNegotiator.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/media/MediaNegotiator.java
@@ -271,7 +271,7 @@ public class MediaNegotiator extends JingleNegotiator {
      * @param jingle TODO javadoc me please
      *            The input packet
      * @return a Jingle packet
-     * @throws JingleException
+     * @throws JingleException in case of an jingle exception.
      */
     private IQ receiveSessionInfoAction(Jingle jingle, JingleDescription description) throws JingleException {
         IQ response = null;
@@ -308,10 +308,10 @@ public class MediaNegotiator extends JingleNegotiator {
      * A jmf description has been accepted. In this case, we must save the
      * accepted payload type and notify any listener...
      *
-     * @param jin TODO javadoc me please
-     *            The input packet
+     * @param jingle TODO javadoc me please
+     * @param description the description.
      * @return a Jingle packet
-     * @throws JingleException
+     * @throws JingleException in case of an jingle exception.
      */
     private IQ receiveSessionAcceptAction(Jingle jingle, JingleDescription description) throws JingleException {
         IQ response = null;

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/jmf/AudioChannel.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/jmf/AudioChannel.java
@@ -448,6 +448,7 @@ public class AudioChannel {
         failed = true;
     }
 
+    @SuppressWarnings("LockOnBoxedPrimitive")
     private synchronized boolean waitForState(Processor p, int state) {
         p.addControllerListener(new StateListener());
         failed = false;
@@ -485,6 +486,7 @@ public class AudioChannel {
 
     class StateListener implements ControllerListener {
 
+        @SuppressWarnings("LockOnBoxedPrimitive")
         @Override
         public void controllerUpdate(ControllerEvent ce) {
 

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/sshare/api/ImageTransmitter.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/mediaimpl/sshare/api/ImageTransmitter.java
@@ -150,6 +150,7 @@ public class ImageTransmitter implements Runnable {
 
                                         }
                                         catch (Exception e) {
+                                            LOGGER.log(Level.WARNING, "exception", e);
                                         }
 
                                     }

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/ICETransportManager.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/ICETransportManager.java
@@ -28,7 +28,6 @@ import org.jivesoftware.smackx.jingleold.JingleSession;
 import org.jivesoftware.smackx.jingleold.listeners.CreatedJingleSessionListener;
 import org.jivesoftware.smackx.jingleold.listeners.JingleSessionListener;
 import org.jivesoftware.smackx.jingleold.media.PayloadType;
-import org.jivesoftware.smackx.jingleold.nat.ICECandidate.Type;
 
 @SuppressWarnings("UnusedVariable")
 public class ICETransportManager extends JingleTransportManager implements JingleSessionListener, CreatedJingleSessionListener {
@@ -62,7 +61,7 @@ public class ICETransportManager extends JingleTransportManager implements Jingl
     @Override
     public void sessionEstablished(PayloadType pt, TransportCandidate rc, TransportCandidate lc, JingleSession jingleSession) throws NotConnectedException, InterruptedException {
         if (lc instanceof ICECandidate) {
-            if (((ICECandidate) lc).getType().equals(Type.relay)) {
+            if (((ICECandidate) lc).getType().equals(ICECandidate.Type.relay)) {
                 RTPBridge rtpBridge = RTPBridge.relaySession(lc.getConnection(), lc.getSessionId(), lc.getPassword(), rc, lc);
             }
         }

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/STUNResolver.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/STUNResolver.java
@@ -161,11 +161,7 @@ public class STUNResolver extends TransportResolver {
                         // Parse the port
                         parser.next();
                         parser.next();
-                        try {
-                            serverPort = Integer.parseInt(parser.nextText());
-                        }
-                        catch (Exception e) {
-                        }
+                        serverPort = Integer.parseInt(parser.nextText());
 
                         // If we have a valid hostname and port, add
                         // it to the list.

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/TransportNegotiator.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/TransportNegotiator.java
@@ -37,7 +37,6 @@ import org.jivesoftware.smackx.jingleold.JingleNegotiatorState;
 import org.jivesoftware.smackx.jingleold.JingleSession;
 import org.jivesoftware.smackx.jingleold.listeners.JingleListener;
 import org.jivesoftware.smackx.jingleold.listeners.JingleTransportListener;
-import org.jivesoftware.smackx.jingleold.nat.ICECandidate.Type;
 import org.jivesoftware.smackx.jingleold.packet.Jingle;
 import org.jivesoftware.smackx.jingleold.packet.JingleContent;
 import org.jivesoftware.smackx.jingleold.packet.JingleTransport;
@@ -364,7 +363,7 @@ public abstract class TransportNegotiator extends JingleNegotiator {
                         for (TransportCandidate candidate : remoteCandidates) {
                             if (candidate instanceof ICECandidate) {
                                 ICECandidate iceCandidate = (ICECandidate) candidate;
-                                if (iceCandidate.getType().equals(Type.relay)) {
+                                if (iceCandidate.getType().equals(ICECandidate.Type.relay)) {
                                     // TODO Check if the relay is reachable.
                                     addValidRemoteCandidate(iceCandidate);
                                     foundRemoteRelay = true;
@@ -379,7 +378,7 @@ public abstract class TransportNegotiator extends JingleNegotiator {
                             for (TransportCandidate candidate : offeredCandidates) {
                                 if (candidate instanceof ICECandidate) {
                                     ICECandidate iceCandidate = (ICECandidate) candidate;
-                                    if (iceCandidate.getType().equals(Type.relay)) {
+                                    if (iceCandidate.getType().equals(ICECandidate.Type.relay)) {
                                         foundLocalRelay = true;
                                     }
                                 }
@@ -512,7 +511,7 @@ public abstract class TransportNegotiator extends JingleNegotiator {
     /**
      * Parse the list of transport candidates from a Jingle packet.
      *
-     * @param jin The input jingle packet
+     * @param jingle The input jingle packet
      */
     private List<TransportCandidate> obtainCandidatesList(Jingle jingle) {
         List<TransportCandidate> result = new ArrayList<>();
@@ -943,7 +942,7 @@ public abstract class TransportNegotiator extends JingleNegotiator {
                 result = chose;
             }
 
-            if (result != null && result.getType().equals(Type.relay))
+            if (result != null && result.getType().equals(ICECandidate.Type.relay))
                 LOGGER.fine("Relay Type");
 
             return result;

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/provider/JingleContentDescriptionProvider.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/provider/JingleContentDescriptionProvider.java
@@ -41,21 +41,15 @@ public abstract class JingleContentDescriptionProvider extends ExtensionElementP
      * @return a payload type element
      */
     protected JinglePayloadType parsePayload(final XmlPullParser parser) {
-        int ptId = 0;
+        int ptId;
         String ptName;
-        int ptChannels = 0;
+        int ptChannels;
 
-        try {
-            ptId = Integer.parseInt(parser.getAttributeValue("", "id"));
-        } catch (Exception e) {
-        }
+        ptId = Integer.parseInt(parser.getAttributeValue("", "id"));
 
         ptName = parser.getAttributeValue("", "name");
 
-        try {
-            ptChannels = Integer.parseInt(parser.getAttributeValue("", "channels"));
-        } catch (Exception e) {
-        }
+        ptChannels = Integer.parseInt(parser.getAttributeValue("", "channels"));
 
         return new JinglePayloadType(new PayloadType(ptId, ptName, ptChannels));
     }
@@ -115,12 +109,7 @@ public abstract class JingleContentDescriptionProvider extends ExtensionElementP
         public JinglePayloadType parsePayload(final XmlPullParser parser) {
             JinglePayloadType pte = super.parsePayload(parser);
             PayloadType.Audio pt = new PayloadType.Audio(pte.getPayloadType());
-            int ptClockRate = 0;
-
-            try {
-                ptClockRate = Integer.parseInt(parser.getAttributeValue("", "clockrate"));
-            } catch (Exception e) {
-            }
+            int ptClockRate = Integer.parseInt(parser.getAttributeValue("", "clockrate"));
             pt.setClockRate(ptClockRate);
 
             return new JinglePayloadType.Audio(pt);

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/provider/JingleDescriptionProvider.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/provider/JingleDescriptionProvider.java
@@ -41,21 +41,15 @@ public abstract class JingleDescriptionProvider extends ExtensionElementProvider
      * @return a payload type element
      */
     protected PayloadType parsePayload(final XmlPullParser parser) {
-        int ptId = 0;
+        int ptId;
         String ptName;
-        int ptChannels = 0;
+        int ptChannels;
 
-        try {
-            ptId = Integer.parseInt(parser.getAttributeValue("", "id"));
-        } catch (Exception e) {
-        }
+        ptId = Integer.parseInt(parser.getAttributeValue("", "id"));
 
         ptName = parser.getAttributeValue("", "name");
 
-        try {
-            ptChannels = Integer.parseInt(parser.getAttributeValue("", "channels"));
-        } catch (Exception e) {
-        }
+        ptChannels = Integer.parseInt(parser.getAttributeValue("", "channels"));
 
         return new PayloadType(ptId, ptName, ptChannels);
     }
@@ -114,12 +108,7 @@ public abstract class JingleDescriptionProvider extends ExtensionElementProvider
         public PayloadType parsePayload(final XmlPullParser parser) {
             PayloadType pte = super.parsePayload(parser);
             PayloadType.Audio pt = new PayloadType.Audio(pte);
-            int ptClockRate = 0;
-
-            try {
-                ptClockRate = Integer.parseInt(parser.getAttributeValue("", "clockrate"));
-            } catch (Exception e) {
-            }
+            int ptClockRate = Integer.parseInt(parser.getAttributeValue("", "clockrate"));
             pt.setClockRate(ptClockRate);
 
             return pt;

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/provider/JingleTransportProvider.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/provider/JingleTransportProvider.java
@@ -132,11 +132,7 @@ public abstract class JingleTransportProvider extends ExtensionElementProvider<J
             }
 
             if (generation != null) {
-                try {
-                    mt.setGeneration(Integer.parseInt(generation));
-                }
-                catch (Exception e) {
-                }
+                mt.setGeneration(Integer.parseInt(generation));
             }
 
             if (ip != null) {
@@ -151,11 +147,7 @@ public abstract class JingleTransportProvider extends ExtensionElementProvider<J
             }
 
             if (network != null) {
-                try {
-                    mt.setNetwork(Integer.parseInt(network));
-                }
-                catch (Exception e) {
-                }
+                mt.setNetwork(Integer.parseInt(network));
             }
 
             if (username != null) {
@@ -167,19 +159,11 @@ public abstract class JingleTransportProvider extends ExtensionElementProvider<J
             }
 
             if (port != null) {
-                try {
-                    mt.setPort(Integer.parseInt(port));
-                }
-                catch (Exception e) {
-                }
+                mt.setPort(Integer.parseInt(port));
             }
 
             if (preference != null) {
-                try {
-                    mt.setPreference(Integer.parseInt(preference));
-                }
-                catch (Exception e) {
-                }
+                mt.setPreference(Integer.parseInt(preference));
             }
 
             if (proto != null) {
@@ -234,11 +218,7 @@ public abstract class JingleTransportProvider extends ExtensionElementProvider<J
             // LOGGER.debug();
 
             if (generation != null) {
-                try {
-                    mt.setGeneration(Integer.parseInt(generation));
-                }
-                catch (Exception e) {
-                }
+                mt.setGeneration(Integer.parseInt(generation));
             }
 
             if (ip != null) {
@@ -250,11 +230,7 @@ public abstract class JingleTransportProvider extends ExtensionElementProvider<J
             }
 
             if (port != null) {
-                try {
-                    mt.setPort(Integer.parseInt(port));
-                }
-                catch (Exception e) {
-                }
+                mt.setPort(Integer.parseInt(port));
             }
             return new JingleTransport.RawUdp.Candidate(mt);
         }

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/agent/OfferConfirmation.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/agent/OfferConfirmation.java
@@ -73,18 +73,10 @@ public class OfferConfirmation extends SimpleIQ {
                 parser.next();
                 String elementName = parser.getName();
                 if (parser.getEventType() == XmlPullParser.Event.START_ELEMENT && "user-jid".equals(elementName)) {
-                    try {
-                        confirmation.setUserJID(parser.nextText());
-                    }
-                    catch (NumberFormatException nfe) {
-                    }
+                    confirmation.setUserJID(parser.nextText());
                 }
                 else if (parser.getEventType() == XmlPullParser.Event.START_ELEMENT && "session-id".equals(elementName)) {
-                    try {
-                        confirmation.setSessionID(Long.valueOf(parser.nextText()));
-                    }
-                    catch (NumberFormatException nfe) {
-                    }
+                    confirmation.setSessionID(Long.valueOf(parser.nextText()));
                 }
                 else if (parser.getEventType() == XmlPullParser.Event.END_ELEMENT && "offer-confirmation".equals(elementName)) {
                     done = true;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/AgentStatus.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/AgentStatus.java
@@ -238,7 +238,8 @@ public class AgentStatus implements ExtensionElement {
     public static class Provider extends ExtensionElementProvider<AgentStatus> {
 
         @Override
-        public AgentStatus parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public AgentStatus parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                        throws XmlPullParserException, IOException, ParseException {
             AgentStatus agentStatus = new AgentStatus();
 
             agentStatus.workgroupJID = ParserUtils.getBareJidAttribute(parser);
@@ -249,7 +250,8 @@ public class AgentStatus implements ExtensionElement {
 
                 if (eventType == XmlPullParser.Event.START_ELEMENT) {
                     if ("chat".equals(parser.getName())) {
-                        agentStatus.currentChats.add(parseChatInfo(parser));
+                        ChatInfo chatInfo = parseChatInfo(parser);
+                        agentStatus.currentChats.add(chatInfo);
                     }
                     else if ("max-chats".equals(parser.getName())) {
                         agentStatus.maxChats = Integer.parseInt(parser.nextText());
@@ -263,17 +265,13 @@ public class AgentStatus implements ExtensionElement {
             return agentStatus;
         }
 
-        private static ChatInfo parseChatInfo(XmlPullParser parser) {
+        private static ChatInfo parseChatInfo(XmlPullParser parser) throws ParseException {
 
             String sessionID = parser.getAttributeValue("", "sessionID");
             String userID = parser.getAttributeValue("", "userID");
             Date date = null;
-            try {
-                synchronized (UTC_FORMAT) {
-                    date = UTC_FORMAT.parse(parser.getAttributeValue("", "startTime"));
-                }
-            }
-            catch (ParseException e) {
+            synchronized (UTC_FORMAT) {
+                date = UTC_FORMAT.parse(parser.getAttributeValue("", "startTime"));
             }
 
             String email = parser.getAttributeValue("", "email");

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OccupantsInfo.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OccupantsInfo.java
@@ -28,8 +28,6 @@ import java.util.TimeZone;
 
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.provider.IQProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -137,7 +135,8 @@ public class OccupantsInfo extends IQ {
     public static class Provider extends IQProvider<OccupantsInfo> {
 
         @Override
-        public OccupantsInfo parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackTextParseException {
+        public OccupantsInfo parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                        throws XmlPullParserException, IOException, ParseException {
             OccupantsInfo occupantsInfo = new OccupantsInfo(parser.getAttributeValue("", "roomID"));
 
             boolean done = false;
@@ -155,7 +154,7 @@ public class OccupantsInfo extends IQ {
         }
 
         private static OccupantInfo parseOccupantInfo(XmlPullParser parser)
-                        throws XmlPullParserException, IOException, SmackTextParseException {
+                        throws XmlPullParserException, IOException, ParseException {
             boolean done = false;
             String jid = null;
             String nickname = null;
@@ -170,11 +169,7 @@ public class OccupantsInfo extends IQ {
                 } else if (eventType == XmlPullParser.Event.START_ELEMENT &&
                         "joined".equals(parser.getName())) {
                         synchronized (UTC_FORMAT) {
-                        try {
                             joined = UTC_FORMAT.parse(parser.nextText());
-                        } catch (ParseException e) {
-                            throw new SmackParsingException.SmackTextParseException(e);
-                        }
                         }
                 } else if (eventType == XmlPullParser.Event.END_ELEMENT &&
                         "occupant".equals(parser.getName())) {

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/QueueDetails.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/QueueDetails.java
@@ -28,8 +28,6 @@ import java.util.logging.Logger;
 
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -147,7 +145,7 @@ public final class QueueDetails implements ExtensionElement {
         @Override
         public QueueDetails parse(XmlPullParser parser,
                         int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException,
-                        IOException, SmackTextParseException {
+                        IOException, TextParseException, ParseException {
 
             SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
             QueueDetails queueDetails = new QueueDetails();
@@ -178,19 +176,10 @@ public final class QueueDetails implements ExtensionElement {
                             time = Integer.parseInt(parser.nextText());
                         }
                         else if ("join-time".equals(parser.getName())) {
-                                try {
-                                    joinTime = dateFormat.parse(parser.nextText());
-                                } catch (ParseException e) {
-                                    throw new SmackParsingException.SmackTextParseException(e);
-                                }
+                                joinTime = dateFormat.parse(parser.nextText());
                         }
                         else if (parser.getName().equals("waitTime")) {
-                            Date wait;
-                            try {
-                                wait = dateFormat.parse(parser.nextText());
-                            } catch (ParseException e) {
-                                throw new SmackParsingException.SmackTextParseException(e);
-                            }
+                            Date wait = dateFormat.parse(parser.nextText());
                             LOGGER.fine(wait.toString());
                         }
 

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/QueueOverview.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/QueueOverview.java
@@ -24,8 +24,6 @@ import java.util.Date;
 
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -128,7 +126,7 @@ public class QueueOverview implements ExtensionElement {
         @Override
         public QueueOverview parse(XmlPullParser parser,
                         int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException,
-                        IOException, SmackTextParseException {
+                        IOException, TextParseException, ParseException {
             QueueOverview queueOverview = new QueueOverview();
             SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
 
@@ -142,11 +140,7 @@ public class QueueOverview implements ExtensionElement {
                     queueOverview.setAverageWaitTime(Integer.parseInt(parser.nextText()));
                 }
                 else if ("oldest".equals(parser.getName())) {
-                    try {
-                        queueOverview.setOldestEntry(dateFormat.parse(parser.nextText()));
-                    } catch (ParseException e) {
-                        throw new SmackParsingException.SmackTextParseException(e);
-                    }
+                    queueOverview.setOldestEntry(dateFormat.parse(parser.nextText()));
                 }
                 else if ("status".equals(parser.getName())) {
                     queueOverview.setStatus(WorkgroupQueue.Status.fromString(parser.nextText()));

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/QueueUpdate.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/QueueUpdate.java
@@ -106,18 +106,10 @@ public class QueueUpdate implements ExtensionElement {
                 parser.next();
                 String elementName = parser.getName();
                 if (parser.getEventType() == XmlPullParser.Event.START_ELEMENT && "position".equals(elementName)) {
-                    try {
-                        position = Integer.parseInt(parser.nextText());
-                    }
-                    catch (NumberFormatException nfe) {
-                    }
+                    position = Integer.parseInt(parser.nextText());
                 }
                 else if (parser.getEventType() == XmlPullParser.Event.START_ELEMENT && "time".equals(elementName)) {
-                    try {
-                        timeRemaining = Integer.parseInt(parser.nextText());
-                    }
-                    catch (NumberFormatException nfe) {
-                    }
+                    timeRemaining = Integer.parseInt(parser.nextText());
                 }
                 else if (parser.getEventType() == XmlPullParser.Event.END_ELEMENT && "queue-status".equals(elementName)) {
                     done = true;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/TranscriptsProvider.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/TranscriptsProvider.java
@@ -47,7 +47,8 @@ public class TranscriptsProvider extends IQProvider<Transcripts> {
     }
 
     @Override
-    public Transcripts parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public Transcripts parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, TextParseException, ParseException {
         Jid userID = ParserUtils.getJidAttribute(parser, "userID");
         List<Transcripts.TranscriptSummary> summaries = new ArrayList<>();
 
@@ -56,7 +57,8 @@ public class TranscriptsProvider extends IQProvider<Transcripts> {
             XmlPullParser.Event eventType = parser.next();
             if (eventType == XmlPullParser.Event.START_ELEMENT) {
                 if (parser.getName().equals("transcript")) {
-                    summaries.add(parseSummary(parser));
+                    Transcripts.TranscriptSummary summary = parseSummary(parser);
+                    summaries.add(summary);
                 }
             }
             else if (eventType == XmlPullParser.Event.END_ELEMENT) {
@@ -70,7 +72,7 @@ public class TranscriptsProvider extends IQProvider<Transcripts> {
     }
 
     private static Transcripts.TranscriptSummary parseSummary(XmlPullParser parser)
-                    throws IOException, XmlPullParserException {
+                    throws IOException, XmlPullParserException, ParseException {
         String sessionID =  parser.getAttributeValue("", "sessionID");
         Date joinTime = null;
         Date leftTime = null;
@@ -81,18 +83,14 @@ public class TranscriptsProvider extends IQProvider<Transcripts> {
             XmlPullParser.Event eventType = parser.next();
             if (eventType == XmlPullParser.Event.START_ELEMENT) {
                 if (parser.getName().equals("joinTime")) {
-                    try {
-                        synchronized (UTC_FORMAT) {
-                            joinTime = UTC_FORMAT.parse(parser.nextText());
-                        }
-                    } catch (ParseException e) { }
+                    synchronized (UTC_FORMAT) {
+                        joinTime = UTC_FORMAT.parse(parser.nextText());
+                     }
                 }
                 else if (parser.getName().equals("leftTime")) {
-                    try {
-                        synchronized (UTC_FORMAT) {
-                            leftTime = UTC_FORMAT.parse(parser.nextText());
-                        }
-                    } catch (ParseException e) { }
+                    synchronized (UTC_FORMAT) {
+                        leftTime = UTC_FORMAT.parse(parser.nextText());
+                    }
                 }
                 else if (parser.getName().equals("agents")) {
                     agents = parseAgents(parser);
@@ -109,7 +107,7 @@ public class TranscriptsProvider extends IQProvider<Transcripts> {
     }
 
     private static List<Transcripts.AgentDetail> parseAgents(XmlPullParser parser)
-                    throws IOException, XmlPullParserException {
+                    throws IOException, XmlPullParserException, ParseException {
         List<Transcripts.AgentDetail> agents = new ArrayList<>();
         String agentJID =  null;
         Date joinTime = null;
@@ -123,18 +121,14 @@ public class TranscriptsProvider extends IQProvider<Transcripts> {
                     agentJID = parser.nextText();
                 }
                 else if (parser.getName().equals("joinTime")) {
-                    try {
-                        synchronized (UTC_FORMAT) {
-                            joinTime = UTC_FORMAT.parse(parser.nextText());
-                        }
-                    } catch (ParseException e) { }
+                    synchronized (UTC_FORMAT) {
+                        joinTime = UTC_FORMAT.parse(parser.nextText());
+                    }
                 }
                 else if (parser.getName().equals("leftTime")) {
-                    try {
-                        synchronized (UTC_FORMAT) {
-                            leftTime = UTC_FORMAT.parse(parser.nextText());
-                        }
-                    } catch (ParseException e) { }
+                    synchronized (UTC_FORMAT) {
+                        leftTime = UTC_FORMAT.parse(parser.nextText());
+                    }
                 }
                 else if (parser.getName().equals("agent")) {
                     agentJID =  null;

--- a/smack-omemo/src/test/java/org/jivesoftware/smackx/omemo/OmemoStoreTest.java
+++ b/smack-omemo/src/test/java/org/jivesoftware/smackx/omemo/OmemoStoreTest.java
@@ -247,6 +247,7 @@ public abstract class OmemoStoreTest<T_IdKeyPair, T_IdKey, T_PreKey, T_SigPreKey
         assertEquals(0, store.loadOmemoSignedPreKeys(alice).size());
     }
 
+    @SuppressWarnings("UndefinedEquals")
     @Test
     public void loadStoreDateOfLastSignedPreKeyRenewal() throws IOException {
         assertNull("The date of last signed preKey renewal must be null at this stage.",
@@ -257,6 +258,7 @@ public abstract class OmemoStoreTest<T_IdKeyPair, T_IdKey, T_PreKey, T_SigPreKey
         assertEquals("Dates must equal.", after, before);
     }
 
+    @SuppressWarnings("UndefinedEquals")
     @Test
     public void loadStoreDateOfLastMessageReceived() throws IOException {
         assertNull("The date of last message received must be null at this stage.",

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/OpenPgpManager.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/OpenPgpManager.java
@@ -425,7 +425,7 @@ public final class OpenPgpManager extends Manager {
      *
      * @see <a href="https://xmpp.org/extensions/xep-0373.html#synchro-pep">XEP-0373 §5</a>
      *
-     * @param selectKeyCallback callback, which will receive the users choice of which keys will be backed up. @param selectKeyCallback
+     * @param selectKeyCallback callback, which will receive the users choice of which keys will be backed up.
      * @param passphrase secret key passphrase
      *
      * @throws InterruptedException if the thread is interrupted.
@@ -631,7 +631,7 @@ public final class OpenPgpManager extends Manager {
     }
 
     /**
-     * Create a {@link PubkeyElement} which contains the given {@code data} base64 encoded.
+     * Create a {@link PubkeyElement} which contains the given {@code date} base64 encoded.
      *
      * @param bytes byte representation of an OpenPGP public key
      * @param date date of creation of the element

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/element/PublicKeysListElement.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/element/PublicKeysListElement.java
@@ -138,6 +138,8 @@ public final class PublicKeysListElement implements ExtensionElement {
             return getV4Fingerprint().hashCode() + 3 * getDate().hashCode();
         }
 
+        @SuppressWarnings("UndefinedEquals")
+        // TODO: Fix the UndefinedEquals due using Date.equals(Date)
         @Override
         public boolean equals(Object o) {
             if (o == null) {

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/CryptElementProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/CryptElementProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2017-2019 Florian Schmaus.
+ * Copyright 2017-2021 Florian Schmaus.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.ox.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
@@ -33,7 +34,8 @@ public class CryptElementProvider extends OpenPgpContentElementProvider<CryptEle
     public static final CryptElementProvider INSTANCE = new CryptElementProvider();
 
     @Override
-    public CryptElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public CryptElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         OpenPgpContentElementData data = parseOpenPgpContentElementData(parser, initialDepth);
 
         return new CryptElement(data.to, data.rpad, data.timestamp, data.payload);

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/OpenPgpContentElementProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/OpenPgpContentElementProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2017-2019 Florian Schmaus, 2018 Paul Schaub.
+ * Copyright 2017-2021 Florian Schmaus, 2018 Paul Schaub.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.ox.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -78,10 +79,11 @@ public abstract class OpenPgpContentElementProvider<O extends OpenPgpContentElem
     }
 
     @Override
-    public abstract O parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException;
+    public abstract O parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException;
 
     protected static OpenPgpContentElementData parseOpenPgpContentElementData(XmlPullParser parser, int initialDepth)
-            throws XmlPullParserException, IOException, SmackParsingException {
+            throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         Set<Jid> to = new HashSet<>();
         Date timestamp = null;
         String rpad = null;
@@ -155,10 +157,10 @@ public abstract class OpenPgpContentElementProvider<O extends OpenPgpContentElem
     }
 
     protected static final class OpenPgpContentElementData {
-        protected final Set<Jid> to;
-        protected final Date timestamp;
-        protected final String rpad;
-        protected final List<ExtensionElement> payload;
+        final Set<Jid> to;
+        final Date timestamp;
+        final String rpad;
+        final List<ExtensionElement> payload;
 
         private OpenPgpContentElementData(Set<Jid> to, Date timestamp, String rpad, List<ExtensionElement> payload) {
             this.to = to;

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/PubkeyElementProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/PubkeyElementProvider.java
@@ -17,10 +17,10 @@
 package org.jivesoftware.smackx.ox.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Date;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -36,7 +36,8 @@ public class PubkeyElementProvider extends ExtensionElementProvider<PubkeyElemen
     public static final PubkeyElementProvider INSTANCE = new PubkeyElementProvider();
 
     @Override
-    public PubkeyElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackTextParseException {
+    public PubkeyElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, ParseException {
         String dateString = parser.getAttributeValue(null, PubkeyElement.ATTR_DATE);
         Date date = ParserUtils.getDateFromOptionalXep82String(dateString);
         while (true) {

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/PublicKeysListElementProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/PublicKeysListElementProvider.java
@@ -17,10 +17,10 @@
 package org.jivesoftware.smackx.ox.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Date;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.parsing.SmackParsingException.SmackTextParseException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -35,7 +35,8 @@ public final class PublicKeysListElementProvider extends ExtensionElementProvide
     public static final PublicKeysListElementProvider TEST_INSTANCE = new PublicKeysListElementProvider();
 
     @Override
-    public PublicKeysListElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackTextParseException {
+    public PublicKeysListElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, ParseException {
 
         PublicKeysListElement.Builder builder = PublicKeysListElement.builder();
 

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/SignElementProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/SignElementProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2017-2019 Florian Schmaus.
+ * Copyright 2017-2021 Florian Schmaus.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.ox.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.logging.Logger;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
@@ -36,7 +37,8 @@ public class SignElementProvider extends OpenPgpContentElementProvider<SignEleme
     public static final SignElementProvider INSTANCE = new SignElementProvider();
 
     @Override
-    public SignElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public SignElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         OpenPgpContentElementData data = parseOpenPgpContentElementData(parser, initialDepth);
 
         if (StringUtils.isNotEmpty(data.rpad)) {

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/SigncryptElementProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/provider/SigncryptElementProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2017-2019 Florian Schmaus, 2018 Paul Schaub.
+ * Copyright 2017-2021 Florian Schmaus, 2018 Paul Schaub.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.smackx.ox.provider;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
@@ -33,7 +34,8 @@ public class SigncryptElementProvider extends OpenPgpContentElementProvider<Sign
     public static final SigncryptElementProvider INSTANCE = new SigncryptElementProvider();
 
     @Override
-    public SigncryptElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public SigncryptElement parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
         OpenPgpContentElementData data = parseOpenPgpContentElementData(parser, initialDepth);
         return new SigncryptElement(data.to, data.rpad, data.timestamp, data.payload);
     }

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/OpenPgpElementTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/OpenPgpElementTest.java
@@ -88,6 +88,7 @@ public class OpenPgpElementTest extends SmackTestSuite {
         assertNotNull(element.getTimestamp());
     }
 
+    @SuppressWarnings("UndefinedEquals")
     @Test
     public void signElementProviderTest() throws Exception {
         String expected =
@@ -114,6 +115,7 @@ public class OpenPgpElementTest extends SmackTestSuite {
         assertEquals(element.getExtensions(), parsed.getExtensions());
     }
 
+    @SuppressWarnings("UndefinedEquals")
     @Test
     public void cryptElementProviderTest() throws Exception {
         String expected =
@@ -144,6 +146,7 @@ public class OpenPgpElementTest extends SmackTestSuite {
         assertEquals(element.getExtensions(), parsed.getExtensions());
     }
 
+    @SuppressWarnings("UndefinedEquals")
     @Test
     public void signcryptElementProviderTest() throws Exception {
         String expected =

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PubkeyElementTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PubkeyElementTest.java
@@ -38,6 +38,7 @@ import org.jxmpp.util.XmppDateTime;
 
 public class PubkeyElementTest extends SmackTestSuite {
 
+    @SuppressWarnings("UndefinedEquals")
     @ParameterizedTest
     @EnumSource(SmackTestUtil.XmlPullParserKind.class)
     public void providerTest(SmackTestUtil.XmlPullParserKind parserKind)

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -187,7 +187,7 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
     /**
      * The stream ID of the stream that is currently resumable, ie. the stream we hold the state
      * for in {@link #clientHandledStanzasCount}, {@link #serverHandledStanzasCount} and
-     * {@link #unFailedNonzaExceptionacknowledgedStanzas}.
+     * {@link #unacknowledgedStanzas}.
      */
     private String smSessionId;
 
@@ -668,8 +668,6 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
      * Initializes the connection by creating a stanza reader and writer and opening a
      * XMPP stream to the server.
      *
-     * @throws XMPPException if establishing a connection to the server fails.
-     * @throws SmackException if the server fails to respond back or if there is anther error.
      * @throws IOException if an I/O error occurred.
      * @throws InterruptedException if the calling thread was interrupted.
      */

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XmppTcpTransportModule.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XmppTcpTransportModule.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
@@ -115,7 +114,7 @@ public class XmppTcpTransportModule extends ModularXmppClientToServerConnectionM
     private Iterator<CharSequence> outgoingCharSequenceIterator;
 
     private final List<TopLevelStreamElement> currentlyOutgoingElements = new ArrayList<>();
-    private final Map<ByteBuffer, List<TopLevelStreamElement>> bufferToElementMap = new IdentityHashMap<>();
+    private final IdentityHashMap<ByteBuffer, List<TopLevelStreamElement>> bufferToElementMap = new IdentityHashMap<>();
 
     private ByteBuffer outgoingBuffer;
     private ByteBuffer filteredOutgoingBuffer;
@@ -224,7 +223,7 @@ public class XmppTcpTransportModule extends ModularXmppClientToServerConnectionM
             }
             streamOpen.append("stream");
             streamClose.append("stream>");
-            for (Entry<String, String> entry : attributes.entrySet()) {
+            for (Map.Entry<String, String> entry : attributes.entrySet()) {
                 String attributeName = entry.getKey();
                 String attributeValue = entry.getValue();
                 switch (attributeName) {
@@ -571,7 +570,7 @@ public class XmppTcpTransportModule extends ModularXmppClientToServerConnectionM
 
     final class XmppTcpNioTransport extends XmppClientToServerTransport {
 
-        protected XmppTcpNioTransport(ModularXmppClientToServerConnectionInternal connectionInternal) {
+        XmppTcpNioTransport(ModularXmppClientToServerConnectionInternal connectionInternal) {
             super(connectionInternal);
         }
 
@@ -1319,7 +1318,7 @@ public class XmppTcpTransportModule extends ModularXmppClientToServerConnectionM
             try {
                 socketChannel.close();
             } catch (IOException e) {
-
+                LOGGER.log(Level.FINE, "Closing the socket channel failed", e);
             }
         }
 

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/rce/RemoteXmppTcpConnectionEndpoints.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/rce/RemoteXmppTcpConnectionEndpoints.java
@@ -169,8 +169,10 @@ public class RemoteXmppTcpConnectionEndpoints {
      *
      * @param domain the domain.
      * @param domainType the XMPP domain type, server or client.
-     * @param failedAddresses a list that will be populated with host addresses that failed to resolve.
-     * @return a list of resolver host addresses for this domain.
+     * @param lookupFailures a list that will be populated with all failures that oocured during lookup.
+     * @param dnssecMode the DNSSEC mode.
+     * @param dnsResolver the DNS resolver to use.
+     * @return a list of resolved host addresses for this domain.
      */
     private static List<Rfc6120TcpRemoteConnectionEndpoint> resolveDomain(DnsName domain, DomainType domainType,
                     List<RemoteConnectionEndpointLookupFailure> lookupFailures, DnssecMode dnssecMode, DNSResolver dnsResolver) {

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/rce/SrvXmppRemoteConnectionEndpoint.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/rce/SrvXmppRemoteConnectionEndpoint.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2020 Florian Schmaus.
+ * Copyright 2020-2021 Florian Schmaus.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.minidns.record.SRV;
 public final class SrvXmppRemoteConnectionEndpoint extends SrvRemoteConnectionEndpoint
                 implements Rfc6120TcpRemoteConnectionEndpoint {
 
-    protected SrvXmppRemoteConnectionEndpoint(SRV srv, List<? extends InetAddress> inetAddresses) {
+    SrvXmppRemoteConnectionEndpoint(SRV srv, List<? extends InetAddress> inetAddresses) {
         super(srv, inetAddresses);
     }
 

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/rce/SrvXmppsRemoteConnectionEndpoint.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/rce/SrvXmppsRemoteConnectionEndpoint.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2020 Florian Schmaus.
+ * Copyright 2020-2021 Florian Schmaus.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import java.util.List;
 
 import org.minidns.record.SRV;
 
-public class SrvXmppsRemoteConnectionEndpoint extends SrvRemoteConnectionEndpoint {
+public final class SrvXmppsRemoteConnectionEndpoint extends SrvRemoteConnectionEndpoint {
 
-    protected SrvXmppsRemoteConnectionEndpoint(SRV srv, List<? extends InetAddress> inetAddresses) {
+    SrvXmppsRemoteConnectionEndpoint(SRV srv, List<? extends InetAddress> inetAddresses) {
         super(srv, inetAddresses);
     }
 

--- a/smack-websocket/src/main/java/org/jivesoftware/smack/websocket/XmppWebSocketTransportModule.java
+++ b/smack-websocket/src/main/java/org/jivesoftware/smack/websocket/XmppWebSocketTransportModule.java
@@ -67,7 +67,7 @@ public final class XmppWebSocketTransportModule
 
     private AbstractWebSocket websocket;
 
-    protected XmppWebSocketTransportModule(XmppWebSocketTransportModuleDescriptor moduleDescriptor,
+    XmppWebSocketTransportModule(XmppWebSocketTransportModuleDescriptor moduleDescriptor,
                     ModularXmppClientToServerConnectionInternal connectionInternal) {
         super(moduleDescriptor, connectionInternal);
 
@@ -98,7 +98,7 @@ public final class XmppWebSocketTransportModule
     }
 
     final class EstablishingWebSocketConnectionState extends State.AbstractTransport {
-        protected EstablishingWebSocketConnectionState(StateDescriptor stateDescriptor,
+        EstablishingWebSocketConnectionState(StateDescriptor stateDescriptor,
                         ModularXmppClientToServerConnectionInternal connectionInternal) {
             super(websocketTransport, stateDescriptor, connectionInternal);
         }
@@ -156,7 +156,7 @@ public final class XmppWebSocketTransportModule
 
         AsyncButOrdered<Queue<TopLevelStreamElement>> asyncButOrderedOutgoingElementsQueue;
 
-        protected XmppWebSocketTransport(ModularXmppClientToServerConnectionInternal connectionInternal) {
+        XmppWebSocketTransport(ModularXmppClientToServerConnectionInternal connectionInternal) {
             super(connectionInternal);
             asyncButOrderedOutgoingElementsQueue = new AsyncButOrdered<Queue<TopLevelStreamElement>>();
         }


### PR DESCRIPTION
This also resulted in a refactoring of the Providers and parsing
Exceptions. NumberFormatException and ParseException can now be thrown
directly, the wrapping in a SmackParsingException is down at a higher
layer, i.e. in AbstractProvider.