### PR TITLE
Add Smack import schema file for Intellij

### DIFF
--- a/resources/intellij/Smack Import Order.xml
+++ b/resources/intellij/Smack Import Order.xml
@@ -1,0 +1,18 @@
+<code_scheme name="Smack" version="173">
+  <JavaCodeStyleSettings>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10000" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="java" withSubpackages="true" static="false" />
+        <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="org.jivesoftware" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+      </value>
+    </option>
+  </JavaCodeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
This PR adds an Intellij IDEA Code Style XML file with Smacks custom import order.
The file can be imported in Intellij IDEA in Settings -> Editor -> Code Style -> Java -> Scheme: Import Scheme.