### PR TITLE
[sinttest] Fix ordering of parameters in muc assertEquals checks

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatIntegrationTest.java
@@ -100,7 +100,7 @@ public class MultiUserChatIntegrationTest extends AbstractSmackIntegrationTest {
             assertNotNull(mucUser);
             assertTrue(mucUser.getStatus().contains(MUCUser.Status.PRESENCE_TO_SELF_110));
             assertEquals(mucAddress + "/nick-one", reflectedJoinPresence.getFrom().toString());
-            assertEquals(reflectedJoinPresence.getTo().toString(), conOne.getUser().asEntityFullJidIfPossible().toString());
+            assertEquals(conOne.getUser().asEntityFullJidIfPossible().toString(), reflectedJoinPresence.getTo().toString());
         } finally {
             tryDestroy(muc);
         }
@@ -133,7 +133,7 @@ public class MultiUserChatIntegrationTest extends AbstractSmackIntegrationTest {
 
             assertTrue(mucUser.getStatus().contains(MUCUser.Status.PRESENCE_TO_SELF_110));
             assertEquals(mucAddress + "/nick-one", reflectedLeavePresence.getFrom().toString());
-            assertEquals(reflectedLeavePresence.getTo().toString(), conOne.getUser().asEntityFullJidIfPossible().toString());
+            assertEquals(conOne.getUser().asEntityFullJidIfPossible().toString(), reflectedLeavePresence.getTo().toString());
         } finally {
             tryDestroy(muc);
         }


### PR DESCRIPTION
Spotted by @Flowdalic when reviewing #468
Tested working against Openfire master