### PR TITLE
MAM - added support for multiple versions of MAM

### DIFF
--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/MamManager.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/MamManager.java
@@ -16,10 +16,26 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import org.jivesoftware.smack.*;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.jivesoftware.smack.ConnectionCreationListener;
+import org.jivesoftware.smack.Manager;
+import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.SmackException.NotLoggedInException;
+import org.jivesoftware.smack.StanzaCollector;
+import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.XMPPConnectionRegistry;
+import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.filter.IQReplyFilter;
 import org.jivesoftware.smack.packet.IQ;
@@ -33,19 +49,23 @@ import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 import org.jivesoftware.smackx.disco.packet.DiscoverInfo;
 import org.jivesoftware.smackx.disco.packet.DiscoverItems;
 import org.jivesoftware.smackx.forward.packet.Forwarded;
-import org.jivesoftware.smackx.mam.element.*;
+import org.jivesoftware.smackx.mam.element.Mam1ElementFactory;
+import org.jivesoftware.smackx.mam.element.Mam2ElementFactory;
+import org.jivesoftware.smackx.mam.element.MamElementFactory;
+import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamElements.MamResultExtension;
+import org.jivesoftware.smackx.mam.element.MamFinIQ;
+import org.jivesoftware.smackx.mam.element.MamPrefsIQ;
 import org.jivesoftware.smackx.mam.element.MamPrefsIQ.DefaultBehavior;
+import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.mam.filter.MamResultFilter;
 import org.jivesoftware.smackx.muc.MultiUserChat;
 import org.jivesoftware.smackx.rsm.packet.RSMSet;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
+
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.Jid;
-
-import java.text.ParseException;
-import java.util.*;
 
 /**
  * A Manager for Message Archive Management (MAM, <a href="http://xmpp.org/extensions/xep-0313.html">XEP-0313</a>).
@@ -172,7 +192,7 @@ public final class MamManager extends Manager {
     }
 
     /**
-     * Add a {@link MamElementFactory} used to create IQ's and extensions for a specific MAM namespace
+     * Add a {@link MamElementFactory} used to create IQ's and extensions for a specific MAM namespace.
      * @param mamNamespace the namespace of the MAM version that this factory creates elements for
      * @param factory the factory that creates elements for the specified namespace
      * @since 4.5.0

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/Mam1ElementFactory.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/Mam1ElementFactory.java
@@ -1,0 +1,37 @@
+package org.jivesoftware.smackx.mam.element;
+
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smackx.forward.packet.Forwarded;
+
+import javax.xml.namespace.QName;
+
+public class Mam1ElementFactory implements MamElementFactory {
+
+    public static final String MAM1_NAMESPACE = MamElements.MAM1_NAMESPACE;
+
+    @Override
+    public String getSupportedMamNamespace() {
+        return MAM1_NAMESPACE;
+    }
+
+    @Override
+    public MamElements.MamResultExtension newResultExtension(String queryId, String id, Forwarded<Message> forwarded) {
+        return new Mam1ResultExtension(queryId, id, forwarded);
+    }
+
+    public static class Mam1ResultExtension extends MamElements.MamResultExtension {
+
+        public static final QName QNAME = new QName(MAM1_NAMESPACE, ELEMENT);
+
+        /**
+         * MAM result extension constructor.
+         *
+         * @param queryId    TODO javadoc me please
+         * @param id         TODO javadoc me please
+         * @param forwarded  TODO javadoc me please
+         */
+        public Mam1ResultExtension(String queryId, String id, Forwarded<Message> forwarded) {
+            super(MAM1_NAMESPACE, queryId, id, forwarded);
+        }
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/Mam1ElementFactory.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/Mam1ElementFactory.java
@@ -1,10 +1,29 @@
+/**
+ *
+ * Copyright © 2016-2020 Florian Schmaus and Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.smackx.mam.element;
+
+import javax.xml.namespace.QName;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smackx.forward.packet.Forwarded;
 
-import javax.xml.namespace.QName;
-
+/**
+ * Factory that creates MAM elements for MAM version 1.
+ */
 public class Mam1ElementFactory implements MamElementFactory {
 
     public static final String MAM1_NAMESPACE = MamElements.MAM1_NAMESPACE;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/Mam2ElementFactory.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/Mam2ElementFactory.java
@@ -1,10 +1,29 @@
+/**
+ *
+ * Copyright © 2016-2020 Florian Schmaus and Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.smackx.mam.element;
+
+import javax.xml.namespace.QName;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smackx.forward.packet.Forwarded;
 
-import javax.xml.namespace.QName;
-
+/**
+ * Factory that creates MAM elements for MAM version 2.
+ */
 public class Mam2ElementFactory implements MamElementFactory {
 
     public static final String MAM2_NAMESPACE = MamElements.MAM2_NAMESPACE;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/Mam2ElementFactory.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/Mam2ElementFactory.java
@@ -1,0 +1,37 @@
+package org.jivesoftware.smackx.mam.element;
+
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smackx.forward.packet.Forwarded;
+
+import javax.xml.namespace.QName;
+
+public class Mam2ElementFactory implements MamElementFactory {
+
+    public static final String MAM2_NAMESPACE = MamElements.MAM2_NAMESPACE;
+
+    @Override
+    public String getSupportedMamNamespace() {
+        return MAM2_NAMESPACE;
+    }
+
+    @Override
+    public MamElements.MamResultExtension newResultExtension(String queryId, String id, Forwarded<Message> forwarded) {
+        return new Mam2ResultExtension(queryId, id, forwarded);
+    }
+
+    public static class Mam2ResultExtension extends MamElements.MamResultExtension {
+
+        public static final QName QNAME = new QName(MAM2_NAMESPACE, ELEMENT);
+
+        /**
+         * MAM result extension constructor.
+         *
+         * @param queryId    TODO javadoc me please
+         * @param id         TODO javadoc me please
+         * @param forwarded  TODO javadoc me please
+         */
+        public Mam2ResultExtension(String queryId, String id, Forwarded<Message> forwarded) {
+            super(MAM2_NAMESPACE, queryId, id, forwarded);
+        }
+    }
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamElementFactory.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamElementFactory.java
@@ -1,13 +1,31 @@
+/**
+ *
+ * Copyright © 2016-2020 Florian Schmaus and Fernando Ramirez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.smackx.mam.element;
+
+import java.util.List;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smackx.forward.packet.Forwarded;
 import org.jivesoftware.smackx.mam.MamManager;
 import org.jivesoftware.smackx.rsm.packet.RSMSet;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
+
 import org.jxmpp.jid.Jid;
 
-import java.util.List;
 
 /**
  * A factory that creates extension elements and IQs for a specific MAM version. {@link #getSupportedMamNamespace()}
@@ -15,8 +33,22 @@ import java.util.List;
  */
 public interface MamElementFactory {
 
+    /**
+     * Returns the MAM namespace for which this factory creates elements.
+     *
+     * @return the mam namespace
+     */
     String getSupportedMamNamespace();
 
+    /**
+     * Returns a new {@link org.jivesoftware.smackx.mam.element.MamElements.MamResultExtension} instance suitable for
+     * the MAM namespace of this factory.
+     *
+     * @param queryId TODO javadoc me please
+     * @param id TODO javadoc me please
+     * @param forwarded TODO javadoc me please
+     * @return MAM result extension
+     */
     MamElements.MamResultExtension newResultExtension(String queryId, String id, Forwarded<Message> forwarded);
 
     default MamFinIQ newFinIQ(String queryId, RSMSet rsmSet, boolean complete, boolean stable) {

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamElementFactory.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamElementFactory.java
@@ -1,0 +1,38 @@
+package org.jivesoftware.smackx.mam.element;
+
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smackx.forward.packet.Forwarded;
+import org.jivesoftware.smackx.mam.MamManager;
+import org.jivesoftware.smackx.rsm.packet.RSMSet;
+import org.jivesoftware.smackx.xdata.packet.DataForm;
+import org.jxmpp.jid.Jid;
+
+import java.util.List;
+
+/**
+ * A factory that creates extension elements and IQs for a specific MAM version. {@link #getSupportedMamNamespace()}
+ * returns the namespace of the MAM version the elements are created for. Used by {@link MamManager}.
+ */
+public interface MamElementFactory {
+
+    String getSupportedMamNamespace();
+
+    MamElements.MamResultExtension newResultExtension(String queryId, String id, Forwarded<Message> forwarded);
+
+    default MamFinIQ newFinIQ(String queryId, RSMSet rsmSet, boolean complete, boolean stable) {
+        return new MamFinIQ(getSupportedMamNamespace(), queryId, rsmSet, complete, stable);
+    }
+
+    default MamPrefsIQ newPrefsIQ() {
+        return new MamPrefsIQ(getSupportedMamNamespace());
+    }
+
+    default MamPrefsIQ newPrefsIQ(List<Jid> alwaysJids, List<Jid> neverJids, MamPrefsIQ.DefaultBehavior defaultBehavior) {
+        return new MamPrefsIQ(getSupportedMamNamespace(), alwaysJids, neverJids, defaultBehavior);
+    }
+
+    default MamQueryIQ newQueryIQ(String queryId, String node, DataForm dataForm) {
+        return new MamQueryIQ(getSupportedMamNamespace(), queryId, node, dataForm);
+    }
+
+}

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamElements.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamElements.java
@@ -16,20 +16,14 @@
  */
 package org.jivesoftware.smackx.mam.element;
 
-import java.util.List;
-
-import javax.xml.namespace.QName;
-
-import org.jivesoftware.smack.packet.Element;
-import org.jivesoftware.smack.packet.ExtensionElement;
-import org.jivesoftware.smack.packet.Message;
-import org.jivesoftware.smack.packet.MessageView;
+import org.jivesoftware.smack.packet.*;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.util.XmlStringBuilder;
-
 import org.jivesoftware.smackx.forward.packet.Forwarded;
-
 import org.jxmpp.jid.Jid;
+
+import javax.xml.namespace.QName;
+import java.util.List;
 
 /**
  * MAM elements.
@@ -41,7 +35,8 @@ import org.jxmpp.jid.Jid;
  */
 public class MamElements {
 
-    public static final String NAMESPACE = "urn:xmpp:mam:2";
+    public static final String MAM1_NAMESPACE = "urn:xmpp:mam:1";
+    public static final String MAM2_NAMESPACE = "urn:xmpp:mam:2";
 
     /**
      * MAM result extension class.
@@ -50,7 +45,7 @@ public class MamElements {
      *      Archive Management</a>
      *
      */
-    public static class MamResultExtension implements ExtensionElement {
+    public abstract static class MamResultExtension implements ExtensionElement {
 
         /**
          * result element.
@@ -60,7 +55,7 @@ public class MamElements {
         /**
          * The qualified name of the MAM result extension element.
          */
-        public static final QName QNAME = new QName(NAMESPACE, ELEMENT);
+        public final QName qname;
 
         /**
          * id of the result.
@@ -80,17 +75,19 @@ public class MamElements {
         /**
          * MAM result extension constructor.
          *
+         * @param mamNamespace TODO javadoc me please
          * @param queryId TODO javadoc me please
          * @param id TODO javadoc me please
          * @param forwarded TODO javadoc me please
          */
-        public MamResultExtension(String queryId, String id, Forwarded<Message> forwarded) {
+        MamResultExtension(String mamNamespace, String queryId, String id, Forwarded<Message> forwarded) {
             if (StringUtils.isEmpty(id)) {
                 throw new IllegalArgumentException("id must not be null or empty");
             }
             if (forwarded == null) {
                 throw new IllegalArgumentException("forwarded must no be null");
             }
+            this.qname = new QName(mamNamespace, ELEMENT);
             this.id = id;
             this.forwarded = forwarded;
             this.queryId = queryId;
@@ -130,7 +127,7 @@ public class MamElements {
 
         @Override
         public final String getNamespace() {
-            return NAMESPACE;
+            return qname.getNamespaceURI();
         }
 
         @Override
@@ -148,9 +145,14 @@ public class MamElements {
         }
 
         public static MamResultExtension from(MessageView message) {
-            return message.getExtension(MamResultExtension.class);
-        }
+            for (XmlElement extension : message.getExtensions()) {
+                if (extension instanceof MamResultExtension) {
+                    return (MamResultExtension) extension;
+                }
+            }
 
+            return null;
+        }
     }
 
     /**

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamElements.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamElements.java
@@ -16,14 +16,20 @@
  */
 package org.jivesoftware.smackx.mam.element;
 
-import org.jivesoftware.smack.packet.*;
+import java.util.List;
+import javax.xml.namespace.QName;
+
+import org.jivesoftware.smack.packet.Element;
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.MessageView;
+import org.jivesoftware.smack.packet.XmlElement;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.util.XmlStringBuilder;
 import org.jivesoftware.smackx.forward.packet.Forwarded;
+
 import org.jxmpp.jid.Jid;
 
-import javax.xml.namespace.QName;
-import java.util.List;
 
 /**
  * MAM elements.

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamFinIQ.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamFinIQ.java
@@ -17,7 +17,6 @@
 package org.jivesoftware.smackx.mam.element;
 
 import org.jivesoftware.smack.packet.IQ;
-
 import org.jivesoftware.smackx.rsm.packet.RSMSet;
 
 /**
@@ -34,11 +33,6 @@ public class MamFinIQ extends IQ {
      * fin element.
      */
     public static final String ELEMENT = "fin";
-
-    /**
-     * the IQ NAMESPACE.
-     */
-    public static final String NAMESPACE = MamElements.NAMESPACE;
 
     /**
      * RSM set.
@@ -63,13 +57,14 @@ public class MamFinIQ extends IQ {
     /**
      * MamFinIQ constructor.
      *
+     * @param mamNamespace TODO javadoc me please
      * @param queryId TODO javadoc me please
      * @param rsmSet TODO javadoc me please
      * @param complete TODO javadoc me please
      * @param stable TODO javadoc me please
      */
-    public MamFinIQ(String queryId, RSMSet rsmSet, boolean complete, boolean stable) {
-        super(ELEMENT, NAMESPACE);
+    public MamFinIQ(String mamNamespace, String queryId, RSMSet rsmSet, boolean complete, boolean stable) {
+        super(ELEMENT, mamNamespace);
         if (rsmSet == null) {
             throw new IllegalArgumentException("rsmSet must not be null");
         }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamPrefsIQ.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamPrefsIQ.java
@@ -16,12 +16,13 @@
  */
 package org.jivesoftware.smackx.mam.element;
 
+import java.util.List;
+
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smackx.mam.element.MamElements.AlwaysJidListElement;
 import org.jivesoftware.smackx.mam.element.MamElements.NeverJidListElement;
-import org.jxmpp.jid.Jid;
 
-import java.util.List;
+import org.jxmpp.jid.Jid;
 
 /**
  * MAM Preferences IQ class.

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamPrefsIQ.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamPrefsIQ.java
@@ -16,14 +16,12 @@
  */
 package org.jivesoftware.smackx.mam.element;
 
-import java.util.List;
-
 import org.jivesoftware.smack.packet.IQ;
-
 import org.jivesoftware.smackx.mam.element.MamElements.AlwaysJidListElement;
 import org.jivesoftware.smackx.mam.element.MamElements.NeverJidListElement;
-
 import org.jxmpp.jid.Jid;
+
+import java.util.List;
 
 /**
  * MAM Preferences IQ class.
@@ -47,11 +45,6 @@ public class MamPrefsIQ extends IQ {
     public static final String ELEMENT = "prefs";
 
     /**
-     * the IQ NAMESPACE.
-     */
-    public static final String NAMESPACE = MamElements.NAMESPACE;
-
-    /**
      * list of always.
      */
     private final List<Jid> alwaysJids;
@@ -68,9 +61,11 @@ public class MamPrefsIQ extends IQ {
 
     /**
      * Construct a new MAM {@code <prefs/>} IQ retrieval request (IQ type 'get').
+     *
+     * @param mamNamespace TODO javadoc me please
      */
-    public MamPrefsIQ() {
-        super(ELEMENT, NAMESPACE);
+    public MamPrefsIQ(String mamNamespace) {
+        super(ELEMENT, mamNamespace);
         alwaysJids = null;
         neverJids = null;
         defaultBehavior = null;
@@ -79,12 +74,13 @@ public class MamPrefsIQ extends IQ {
     /**
      * MAM preferences IQ constructor.
      *
+     * @param mamNamespace TODO javadoc me please
      * @param alwaysJids TODO javadoc me please
      * @param neverJids TODO javadoc me please
      * @param defaultBehavior TODO javadoc me please
      */
-    public MamPrefsIQ(List<Jid> alwaysJids, List<Jid> neverJids, DefaultBehavior defaultBehavior) {
-        super(ELEMENT, NAMESPACE);
+    public MamPrefsIQ(String mamNamespace, List<Jid> alwaysJids, List<Jid> neverJids, DefaultBehavior defaultBehavior) {
+        super(ELEMENT, mamNamespace);
         setType(Type.set);
         this.alwaysJids = alwaysJids;
         this.neverJids = neverJids;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamQueryIQ.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamQueryIQ.java
@@ -56,7 +56,7 @@ public class MamQueryIQ extends IQ {
      * @param form TODO javadoc me please
      */
     public MamQueryIQ(String mamNamespace, DataForm form) {
-        this(mamNamespace,null, null, form);
+        this(mamNamespace, null, null, form);
     }
 
     /**

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamQueryIQ.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/element/MamQueryIQ.java
@@ -17,7 +17,6 @@
 package org.jivesoftware.smackx.mam.element;
 
 import org.jivesoftware.smack.packet.IQ;
-
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 
 /**
@@ -35,11 +34,6 @@ public class MamQueryIQ extends IQ {
      */
     public static final String ELEMENT = QUERY_ELEMENT;
 
-    /**
-     * the MAM query IQ NAMESPACE.
-     */
-    public static final String NAMESPACE = MamElements.NAMESPACE;
-
     private final String queryId;
     private final String node;
     private final DataForm dataForm;
@@ -47,41 +41,45 @@ public class MamQueryIQ extends IQ {
     /**
      * MAM query IQ constructor.
      *
+     * @param mamNamespace TODO javadoc me please
      * @param queryId TODO javadoc me please
      */
-    public MamQueryIQ(String queryId) {
-        this(queryId, null, null);
+    public MamQueryIQ(String mamNamespace, String queryId) {
+        this(mamNamespace, queryId, null, null);
         setType(IQ.Type.get);
     }
 
     /**
      * MAM query IQ constructor.
      *
+     * @param mamNamespace TODO javadoc me please
      * @param form TODO javadoc me please
      */
-    public MamQueryIQ(DataForm form) {
-        this(null, null, form);
+    public MamQueryIQ(String mamNamespace, DataForm form) {
+        this(mamNamespace,null, null, form);
     }
 
     /**
      * MAM query IQ constructor.
      *
+     * @param mamNamespace TODO javadoc me please
      * @param queryId TODO javadoc me please
      * @param form TODO javadoc me please
      */
-    public MamQueryIQ(String queryId, DataForm form) {
-        this(queryId, null, form);
+    public MamQueryIQ(String mamNamespace, String queryId, DataForm form) {
+        this(mamNamespace, queryId, null, form);
     }
 
     /**
      * MAM query IQ constructor.
      *
+     * @param mamNamespace TODO javadoc me please
      * @param queryId TODO javadoc me please
      * @param node TODO javadoc me please
      * @param dataForm TODO javadoc me please
      */
-    public MamQueryIQ(String queryId, String node, DataForm dataForm) {
-        super(ELEMENT, NAMESPACE);
+    public MamQueryIQ(String mamNamespace, String queryId, String node, DataForm dataForm) {
+        super(ELEMENT, mamNamespace);
         this.queryId = queryId;
         this.node = node;
         this.dataForm = dataForm;
@@ -91,9 +89,9 @@ public class MamQueryIQ extends IQ {
             if (formType == null) {
                 throw new IllegalArgumentException("If a data form is given it must posses a hidden form type field");
             }
-            if (!formType.equals(MamElements.NAMESPACE)) {
+            if (!formType.equals(mamNamespace)) {
                 throw new IllegalArgumentException(
-                        "Value of the hidden form type field must be '" + MamElements.NAMESPACE + "'");
+                        "Value of the hidden form type field must be '" + mamNamespace + "'");
             }
             addExtension(dataForm);
         }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamFinIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamFinIQProvider.java
@@ -16,18 +16,19 @@
  */
 package org.jivesoftware.smackx.mam.provider;
 
-import java.io.IOException;
-
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.provider.IQProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
-
+import org.jivesoftware.smackx.mam.MamManager;
+import org.jivesoftware.smackx.mam.element.MamElementFactory;
 import org.jivesoftware.smackx.mam.element.MamFinIQ;
 import org.jivesoftware.smackx.rsm.packet.RSMSet;
 import org.jivesoftware.smackx.rsm.provider.RSMSetProvider;
+
+import java.io.IOException;
 
 /**
  * MAM Fin IQ Provider class.
@@ -41,6 +42,7 @@ public class MamFinIQProvider extends IQProvider<MamFinIQ> {
 
     @Override
     public MamFinIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+        MamElementFactory mamElementFactory = MamManager.getMamElementFactory(xmlEnvironment.getEffectiveNamespace());
         String queryId = parser.getAttributeValue("", "queryid");
         boolean complete = ParserUtils.getBooleanAttribute(parser, "complete", false);
         boolean stable = ParserUtils.getBooleanAttribute(parser, "stable", true);
@@ -65,7 +67,7 @@ public class MamFinIQProvider extends IQProvider<MamFinIQ> {
             }
         }
 
-        return new MamFinIQ(queryId, rsmSet, complete, stable);
+        return mamElementFactory.newFinIQ(queryId, rsmSet, complete, stable);
     }
 
 }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamFinIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamFinIQProvider.java
@@ -16,6 +16,8 @@
  */
 package org.jivesoftware.smackx.mam.provider;
 
+import java.io.IOException;
+
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.provider.IQProvider;
@@ -28,7 +30,6 @@ import org.jivesoftware.smackx.mam.element.MamFinIQ;
 import org.jivesoftware.smackx.rsm.packet.RSMSet;
 import org.jivesoftware.smackx.rsm.provider.RSMSetProvider;
 
-import java.io.IOException;
 
 /**
  * MAM Fin IQ Provider class.

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamPrefsIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamPrefsIQProvider.java
@@ -16,6 +16,10 @@
  */
 package org.jivesoftware.smackx.mam.provider;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.provider.IQProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -24,12 +28,11 @@ import org.jivesoftware.smackx.mam.MamManager;
 import org.jivesoftware.smackx.mam.element.MamElementFactory;
 import org.jivesoftware.smackx.mam.element.MamPrefsIQ;
 import org.jivesoftware.smackx.mam.element.MamPrefsIQ.DefaultBehavior;
+
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+
 
 /**
  * MAM Preferences IQ Provider class.

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamQueryIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamQueryIQProvider.java
@@ -16,17 +16,18 @@
  */
 package org.jivesoftware.smackx.mam.provider;
 
-import java.io.IOException;
-
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.provider.IQProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
-
+import org.jivesoftware.smackx.mam.MamManager;
+import org.jivesoftware.smackx.mam.element.MamElementFactory;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 import org.jivesoftware.smackx.xdata.provider.DataFormProvider;
+
+import java.io.IOException;
 
 /**
  * MAM Query IQ Provider class.
@@ -41,6 +42,7 @@ public class MamQueryIQProvider extends IQProvider<MamQueryIQ> {
     @Override
     public MamQueryIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
                     throws XmlPullParserException, IOException, SmackParsingException {
+        MamElementFactory mamElementFactory = MamManager.getMamElementFactory(xmlEnvironment.getEffectiveNamespace());
         DataForm dataForm = null;
         String queryId = parser.getAttributeValue("", "queryid");
         String node = parser.getAttributeValue("", "node");
@@ -68,7 +70,7 @@ public class MamQueryIQProvider extends IQProvider<MamQueryIQ> {
             }
         }
 
-        return new MamQueryIQ(queryId, node, dataForm);
+        return mamElementFactory.newQueryIQ(queryId, node, dataForm);
     }
 
 }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamQueryIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamQueryIQProvider.java
@@ -16,6 +16,8 @@
  */
 package org.jivesoftware.smackx.mam.provider;
 
+import java.io.IOException;
+
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.provider.IQProvider;
@@ -26,8 +28,6 @@ import org.jivesoftware.smackx.mam.element.MamElementFactory;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 import org.jivesoftware.smackx.xdata.provider.DataFormProvider;
-
-import java.io.IOException;
 
 /**
  * MAM Query IQ Provider class.

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamResultProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamResultProvider.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2016 Fernando Ramirez, 2020-2021 Florian Schmaus
+ * Copyright 2016 Fernando Ramirez, 2020 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,20 @@
  */
 package org.jivesoftware.smackx.mam.provider;
 
-import java.io.IOException;
-import java.text.ParseException;
-
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
-
 import org.jivesoftware.smackx.forward.packet.Forwarded;
 import org.jivesoftware.smackx.forward.provider.ForwardedProvider;
+import org.jivesoftware.smackx.mam.MamManager;
+import org.jivesoftware.smackx.mam.element.MamElementFactory;
 import org.jivesoftware.smackx.mam.element.MamElements.MamResultExtension;
+
+import java.io.IOException;
+import java.text.ParseException;
 
 /**
  * MAM Result Provider class.
@@ -42,7 +43,8 @@ public class MamResultProvider extends ExtensionElementProvider<MamResultExtensi
 
     @Override
     public MamResultExtension parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
-                    throws XmlPullParserException, IOException, SmackParsingException, ParseException {
+            throws XmlPullParserException, IOException, SmackParsingException, ParseException {
+        MamElementFactory mamElementFactory = MamManager.getMamElementFactory(xmlEnvironment.getEffectiveNamespace());
         Forwarded<Message> forwarded = null;
         String queryId = parser.getAttributeValue("", "queryid");
         String id = parser.getAttributeValue("", "id");
@@ -69,7 +71,7 @@ public class MamResultProvider extends ExtensionElementProvider<MamResultExtensi
             }
         }
 
-        return new MamResultExtension(queryId, id, forwarded);
+        return mamElementFactory.newResultExtension(queryId, id, forwarded);
     }
 
 }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamResultProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamResultProvider.java
@@ -16,6 +16,9 @@
  */
 package org.jivesoftware.smackx.mam.provider;
 
+import java.io.IOException;
+import java.text.ParseException;
+
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
@@ -27,9 +30,6 @@ import org.jivesoftware.smackx.forward.provider.ForwardedProvider;
 import org.jivesoftware.smackx.mam.MamManager;
 import org.jivesoftware.smackx.mam.element.MamElementFactory;
 import org.jivesoftware.smackx.mam.element.MamElements.MamResultExtension;
-
-import java.io.IOException;
-import java.text.ParseException;
 
 /**
  * MAM Result Provider class.

--- a/smack-experimental/src/main/resources/org.jivesoftware.smack.experimental/experimental.providers
+++ b/smack-experimental/src/main/resources/org.jivesoftware.smack.experimental/experimental.providers
@@ -35,6 +35,26 @@
         <namespace>urn:xmpp:mam:2</namespace>
         <className>org.jivesoftware.smackx.mam.provider.MamResultProvider</className>
     </extensionProvider>
+    <iqProvider>
+        <elementName>prefs</elementName>
+        <namespace>urn:xmpp:mam:1</namespace>
+        <className>org.jivesoftware.smackx.mam.provider.MamPrefsIQProvider</className>
+    </iqProvider>
+    <iqProvider>
+        <elementName>query</elementName>
+        <namespace>urn:xmpp:mam:1</namespace>
+        <className>org.jivesoftware.smackx.mam.provider.MamQueryIQProvider</className>
+    </iqProvider>
+    <iqProvider>
+        <elementName>fin</elementName>
+        <namespace>urn:xmpp:mam:1</namespace>
+        <className>org.jivesoftware.smackx.mam.provider.MamFinIQProvider</className>
+    </iqProvider>
+    <extensionProvider>
+        <elementName>result</elementName>
+        <namespace>urn:xmpp:mam:1</namespace>
+        <className>org.jivesoftware.smackx.mam.provider.MamResultProvider</className>
+    </extensionProvider>
 
     <!-- XEP-0323: Internet of Things - Data -->
     <iqProvider>

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/FiltersTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/FiltersTest.java
@@ -16,19 +16,20 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import org.jivesoftware.smackx.mam.MamManager.MamQueryArgs;
-import org.jivesoftware.smackx.mam.element.MamElements;
-import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.junit.jupiter.api.Test;
-import org.jxmpp.jid.Jid;
-import org.jxmpp.jid.JidTestUtil;
-import org.jxmpp.util.XmppDateTime;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.jivesoftware.smackx.mam.MamManager.MamQueryArgs;
+import org.jivesoftware.smackx.mam.element.MamElements;
+import org.jivesoftware.smackx.xdata.packet.DataForm;
+
+import org.junit.jupiter.api.Test;
+import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.JidTestUtil;
+import org.jxmpp.util.XmppDateTime;
 
 public class FiltersTest extends MamTest {
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/FiltersTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/FiltersTest.java
@@ -16,26 +16,25 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import org.jivesoftware.smackx.mam.MamManager.MamQueryArgs;
 import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-
 import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.JidTestUtil;
 import org.jxmpp.util.XmppDateTime;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class FiltersTest extends MamTest {
 
     private static String getMamXMemberWith(List<String> fieldsNames, List<? extends CharSequence> fieldsValues) {
         String xml = "<x xmlns='jabber:x:data' type='submit'>" + "<field var='FORM_TYPE'>" + "<value>"
-                + MamElements.NAMESPACE + "</value>" + "</field>";
+                + MamElements.MAM2_NAMESPACE + "</value>" + "</field>";
 
         for (int i = 0; i < fieldsNames.size() && i < fieldsValues.size(); i++) {
             xml += "<field var='" + fieldsNames.get(i) + "'>" + "<value>" + fieldsValues.get(i) + "</value>"
@@ -51,7 +50,7 @@ public class FiltersTest extends MamTest {
         Date date = new Date();
 
         MamQueryArgs mamQueryArgs = MamQueryArgs.builder().limitResultsSince(date).build();
-        DataForm dataForm = mamQueryArgs.getDataForm();
+        DataForm dataForm = mamQueryArgs.getDataForm(MamElements.MAM2_NAMESPACE);
 
         List<String> fields = new ArrayList<>();
         fields.add("start");
@@ -66,7 +65,7 @@ public class FiltersTest extends MamTest {
         Date date = new Date();
 
         MamQueryArgs mamQueryArgs = MamQueryArgs.builder().limitResultsBefore(date).build();
-        DataForm dataForm = mamQueryArgs.getDataForm();
+        DataForm dataForm = mamQueryArgs.getDataForm(MamElements.MAM2_NAMESPACE);
 
         List<String> fields = new ArrayList<>();
         fields.add("end");
@@ -81,7 +80,7 @@ public class FiltersTest extends MamTest {
         Jid jid = JidTestUtil.BARE_JID_1;
 
         MamQueryArgs mamQueryArgs = MamQueryArgs.builder().limitResultsToJid(jid).build();
-        DataForm dataForm = mamQueryArgs.getDataForm();
+        DataForm dataForm = mamQueryArgs.getDataForm(MamElements.MAM2_NAMESPACE);
 
         List<String> fields = new ArrayList<>();
         fields.add("with");

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamTest.java
@@ -16,16 +16,15 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
-
+import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-
 import org.junit.jupiter.api.BeforeAll;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class MamTest extends SmackTestSuite {
 
@@ -47,9 +46,9 @@ public class MamTest extends SmackTestSuite {
 
     protected DataForm getNewMamForm() throws NoSuchMethodException, SecurityException, IllegalAccessException,
             IllegalArgumentException, InvocationTargetException {
-        Method methodGetNewMamForm = MamManager.class.getDeclaredMethod("getNewMamForm");
+        Method methodGetNewMamForm = MamManager.class.getDeclaredMethod("getNewMamForm", String.class);
         methodGetNewMamForm.setAccessible(true);
-        DataForm.Builder dataFormBuilder = (DataForm.Builder) methodGetNewMamForm.invoke(mamManager);
+        DataForm.Builder dataFormBuilder = (DataForm.Builder) methodGetNewMamForm.invoke(mamManager, MamElements.MAM2_NAMESPACE);
         return dataFormBuilder.build();
     }
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamTest.java
@@ -16,15 +16,16 @@
  */
 package org.jivesoftware.smackx.mam;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.jivesoftware.smack.DummyConnection;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
 import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.junit.jupiter.api.BeforeAll;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import org.junit.jupiter.api.BeforeAll;
 
 public class MamTest extends SmackTestSuite {
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/PagingTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/PagingTest.java
@@ -16,15 +16,16 @@
  */
 package org.jivesoftware.smackx.mam;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.StreamOpen;
 import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.rsm.packet.RSMSet;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class PagingTest extends MamTest {
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/PagingTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/PagingTest.java
@@ -16,16 +16,15 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.StreamOpen;
-
+import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.rsm.packet.RSMSet;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PagingTest extends MamTest {
 
@@ -40,7 +39,7 @@ public class PagingTest extends MamTest {
         int max = 10;
         RSMSet rsmSet = new RSMSet(max);
 
-        MamQueryIQ mamQueryIQ = new MamQueryIQ(queryId, dataForm);
+        MamQueryIQ mamQueryIQ = new MamQueryIQ(MamElements.MAM2_NAMESPACE, queryId, dataForm);
         mamQueryIQ.setStanzaId("sarasa");
         mamQueryIQ.setType(IQ.Type.set);
         mamQueryIQ.addExtension(rsmSet);

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/PreferencesTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/PreferencesTest.java
@@ -16,18 +16,19 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import org.jivesoftware.smack.packet.StreamOpen;
-import org.jivesoftware.smackx.mam.element.MamElements;
-import org.jivesoftware.smackx.mam.element.MamPrefsIQ;
-import org.jivesoftware.smackx.mam.element.MamPrefsIQ.DefaultBehavior;
-import org.junit.jupiter.api.Test;
-import org.jxmpp.jid.Jid;
-import org.jxmpp.jid.impl.JidCreate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.jivesoftware.smack.packet.StreamOpen;
+import org.jivesoftware.smackx.mam.element.MamElements;
+import org.jivesoftware.smackx.mam.element.MamPrefsIQ;
+import org.jivesoftware.smackx.mam.element.MamPrefsIQ.DefaultBehavior;
+
+import org.junit.jupiter.api.Test;
+import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.impl.JidCreate;
 
 public class PreferencesTest {
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/PreferencesTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/PreferencesTest.java
@@ -16,33 +16,31 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.jivesoftware.smack.packet.StreamOpen;
-
 import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamPrefsIQ;
 import org.jivesoftware.smackx.mam.element.MamPrefsIQ.DefaultBehavior;
-
 import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class PreferencesTest {
 
-    private static final String retrievePrefsStanzaExample = "<iq id='sarasa' type='get'>" + "<prefs xmlns='" + MamElements.NAMESPACE
+    private static final String retrievePrefsStanzaExample = "<iq id='sarasa' type='get'>" + "<prefs xmlns='" + MamElements.MAM2_NAMESPACE
             + "'/>" + "</iq>";
 
-    private static final String updatePrefsStanzaExample = "<iq id='sarasa' type='set'>" + "<prefs xmlns='" + MamElements.NAMESPACE
+    private static final String updatePrefsStanzaExample = "<iq id='sarasa' type='set'>" + "<prefs xmlns='" + MamElements.MAM2_NAMESPACE
             + "' default='roster'>" + "<always>" + "<jid>romeo@montague.lit</jid>" + "<jid>other@montague.lit</jid>"
             + "</always>" + "<never>" + "<jid>montague@montague.lit</jid>" + "</never>" + "</prefs>" + "</iq>";
 
     @Test
     public void checkRetrievePrefsStanza() throws Exception {
-        MamPrefsIQ mamPrefIQ = new MamPrefsIQ();
+        MamPrefsIQ mamPrefIQ = new MamPrefsIQ(MamElements.MAM2_NAMESPACE);
         mamPrefIQ.setStanzaId("sarasa");
         assertEquals(mamPrefIQ.toXML(StreamOpen.CLIENT_NAMESPACE).toString(), retrievePrefsStanzaExample);
     }
@@ -56,7 +54,7 @@ public class PreferencesTest {
         List<Jid> neverJids = new ArrayList<>();
         neverJids.add(JidCreate.from("montague@montague.lit"));
 
-        MamPrefsIQ mamPrefIQ =  new MamPrefsIQ(alwaysJids, neverJids, DefaultBehavior.roster);
+        MamPrefsIQ mamPrefIQ =  new MamPrefsIQ(MamElements.MAM2_NAMESPACE, alwaysJids, neverJids, DefaultBehavior.roster);
         mamPrefIQ.setStanzaId("sarasa");
         assertEquals(mamPrefIQ.toXML(StreamOpen.CLIENT_NAMESPACE).toString(), updatePrefsStanzaExample);
     }

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/QueryArchiveTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/QueryArchiveTest.java
@@ -16,6 +16,12 @@
  */
 package org.jivesoftware.smackx.mam;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.StanzaBuilder;
@@ -27,14 +33,9 @@ import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamElements.MamResultExtension;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
+
 import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.impl.JidCreate;
-
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QueryArchiveTest extends MamTest {
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/QueryArchiveTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/QueryArchiveTest.java
@@ -16,32 +16,31 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.StanzaBuilder;
+import org.jivesoftware.smack.packet.StreamOpen;
+import org.jivesoftware.smackx.delay.packet.DelayInformation;
+import org.jivesoftware.smackx.forward.packet.Forwarded;
+import org.jivesoftware.smackx.mam.element.Mam2ElementFactory;
+import org.jivesoftware.smackx.mam.element.MamElements;
+import org.jivesoftware.smackx.mam.element.MamElements.MamResultExtension;
+import org.jivesoftware.smackx.mam.element.MamQueryIQ;
+import org.jivesoftware.smackx.xdata.packet.DataForm;
+import org.junit.jupiter.api.Test;
+import org.jxmpp.jid.impl.JidCreate;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.Message;
-import org.jivesoftware.smack.packet.StanzaBuilder;
-import org.jivesoftware.smack.packet.StreamOpen;
-
-import org.jivesoftware.smackx.delay.packet.DelayInformation;
-import org.jivesoftware.smackx.forward.packet.Forwarded;
-import org.jivesoftware.smackx.mam.element.MamElements;
-import org.jivesoftware.smackx.mam.element.MamElements.MamResultExtension;
-import org.jivesoftware.smackx.mam.element.MamQueryIQ;
-import org.jivesoftware.smackx.xdata.packet.DataForm;
-
-import org.junit.jupiter.api.Test;
-import org.jxmpp.jid.impl.JidCreate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QueryArchiveTest extends MamTest {
 
     private static final String mamSimpleQueryIQ = "<iq id='sarasa' type='set'>" + "<query xmlns='urn:xmpp:mam:2' queryid='testid'>"
             + "<x xmlns='jabber:x:data' type='submit'>" + "<field var='FORM_TYPE'>" + "<value>"
-            + MamElements.NAMESPACE + "</value>" + "</field>" + "</x>" + "</query>" + "</iq>";
+            + MamElements.MAM2_NAMESPACE + "</value>" + "</field>" + "</x>" + "</query>" + "</iq>";
 
     private static final String mamQueryResultExample = "<message to='hag66@shakespeare.lit/pda' from='coven@chat.shakespeare.lit' id='iasd207'>"
             + "<result xmlns='urn:xmpp:mam:2' queryid='g27' id='34482-21985-73620'>"
@@ -54,7 +53,7 @@ public class QueryArchiveTest extends MamTest {
     @Test
     public void checkMamQueryIQ() throws Exception {
         DataForm dataForm = getNewMamForm();
-        MamQueryIQ mamQueryIQ = new MamQueryIQ(queryId, dataForm);
+        MamQueryIQ mamQueryIQ = new MamQueryIQ(MamElements.MAM2_NAMESPACE, queryId, dataForm);
         mamQueryIQ.setType(IQ.Type.set);
         mamQueryIQ.setStanzaId("sarasa");
         assertEquals(mamQueryIQ.toXML(StreamOpen.CLIENT_NAMESPACE).toString(), mamSimpleQueryIQ);
@@ -80,7 +79,7 @@ public class QueryArchiveTest extends MamTest {
 
         Forwarded<Message> forwarded = new Forwarded<>(forwardedMessage, delay);
 
-        message.addExtension(new MamResultExtension("g27", "34482-21985-73620", forwarded));
+        message.addExtension(new Mam2ElementFactory().newResultExtension("g27", "34482-21985-73620", forwarded));
 
         assertEquals(mamQueryResultExample, message.toXML(StreamOpen.CLIENT_NAMESPACE).toString());
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/ResultsLimitTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/ResultsLimitTest.java
@@ -16,15 +16,16 @@
  */
 package org.jivesoftware.smackx.mam;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.StreamOpen;
 import org.jivesoftware.smackx.mam.MamManager.MamQueryArgs;
 import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class ResultsLimitTest extends MamTest {
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/ResultsLimitTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/ResultsLimitTest.java
@@ -16,29 +16,27 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.StreamOpen;
-
 import org.jivesoftware.smackx.mam.MamManager.MamQueryArgs;
 import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResultsLimitTest extends MamTest {
 
     private static final String resultsLimitStanza = "<iq id='sarasa' type='set'>" + "<query xmlns='urn:xmpp:mam:2' queryid='testid'>"
             + "<x xmlns='jabber:x:data' type='submit'>" + "<field var='FORM_TYPE'>" + "<value>"
-            + MamElements.NAMESPACE + "</value>" + "</field>" + "</x>" + "<set xmlns='http://jabber.org/protocol/rsm'>"
+            + MamElements.MAM2_NAMESPACE + "</value>" + "</field>" + "</x>" + "<set xmlns='http://jabber.org/protocol/rsm'>"
             + "<max>10</max>" + "</set>" + "</query>" + "</iq>";
 
     @Test
     public void checkResultsLimit() throws Exception {
         DataForm dataForm = getNewMamForm();
-        MamQueryIQ mamQueryIQ = new MamQueryIQ(queryId, dataForm);
+        MamQueryIQ mamQueryIQ = new MamQueryIQ(MamElements.MAM2_NAMESPACE, queryId, dataForm);
         mamQueryIQ.setType(IQ.Type.set);
         mamQueryIQ.setStanzaId("sarasa");
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/RetrieveFormFieldsTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/RetrieveFormFieldsTest.java
@@ -16,17 +16,18 @@
  */
 package org.jivesoftware.smackx.mam;
 
+import static org.jivesoftware.smack.test.util.XmlAssertUtil.assertXmlSimilar;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jivesoftware.smack.packet.StreamOpen;
 import org.jivesoftware.smackx.mam.MamManager.MamQueryArgs;
 import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
+
 import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.JidTestUtil;
-
-import static org.jivesoftware.smack.test.util.XmlAssertUtil.assertXmlSimilar;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RetrieveFormFieldsTest extends MamTest {
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/RetrieveFormFieldsTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/RetrieveFormFieldsTest.java
@@ -16,34 +16,32 @@
  */
 package org.jivesoftware.smackx.mam;
 
-import static org.jivesoftware.smack.test.util.XmlAssertUtil.assertXmlSimilar;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.jivesoftware.smack.packet.StreamOpen;
-
 import org.jivesoftware.smackx.mam.MamManager.MamQueryArgs;
 import org.jivesoftware.smackx.mam.element.MamElements;
 import org.jivesoftware.smackx.mam.element.MamQueryIQ;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
-
 import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.JidTestUtil;
 
+import static org.jivesoftware.smack.test.util.XmlAssertUtil.assertXmlSimilar;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class RetrieveFormFieldsTest extends MamTest {
 
-    private static final String retrieveFormFieldStanza = "<iq id='sarasa' type='get'>" + "<query xmlns='" + MamElements.NAMESPACE
+    private static final String retrieveFormFieldStanza = "<iq id='sarasa' type='get'>" + "<query xmlns='" + MamElements.MAM2_NAMESPACE
             + "' queryid='testid'></query>" + "</iq>";
 
     private static final String additionalFieldsStanza = "<x xmlns='jabber:x:data' type='submit'>" + "<field var='FORM_TYPE'>"
-            + "<value>" + MamElements.NAMESPACE + "</value>" + "</field>"
+            + "<value>" + MamElements.MAM2_NAMESPACE + "</value>" + "</field>"
             + "<field var='urn:example:xmpp:free-text-search'>" + "<value>Hi</value>" + "</field>"
             + "<field var='urn:example:xmpp:stanza-content'>" + "<value>one@exampleone.org</value>" + "</field>"
             + "</x>";
 
     @Test
     public void checkRetrieveFormFieldsStanza() throws Exception {
-        MamQueryIQ mamQueryIQ = new MamQueryIQ(queryId);
+        MamQueryIQ mamQueryIQ = new MamQueryIQ(MamElements.MAM2_NAMESPACE, queryId);
         mamQueryIQ.setStanzaId("sarasa");
 
         assertEquals(retrieveFormFieldStanza, mamQueryIQ.toXML(StreamOpen.CLIENT_NAMESPACE).toString());
@@ -63,7 +61,7 @@ public class RetrieveFormFieldsTest extends MamTest {
                         .withAdditionalFormField(field1)
                         .withAdditionalFormField(field2)
                         .build();
-        DataForm dataForm = mamQueryArgs.getDataForm();
+        DataForm dataForm = mamQueryArgs.getDataForm(MamElements.MAM2_NAMESPACE);
 
         String dataFormResult = dataForm.toXML().toString();
 


### PR DESCRIPTION
The versions of the MAM extension that a chat server supports are exposed as features.
Version 1 of the MAM is exposed as feature 'urn:xmpp:mam:1', and version 2 as feature 'urn:xmpp:mam:2'.

The v2 of the extension is largely identical to v1, except for a number of additional filtering options.
These filtering options are optional for clients, and are not implemented in the Smack implementation of MAM.

When we ignore the optional fields, the only difference between MAMv1 and MAMv2 is the use of a different
extension namespace (urn:xmpp:mam:2 instead of urn:xmpp:mam:1) and a different FORM_TYPE (again urn:xmpp:mam:2 instead of
urn:xmpp:mam:1).

Smack currently only supports MAMv2 with namespace urn:xmpp:mam:2.

This commit changes Smack to support multiple versions of MAM, and to do discovery of the version of MAM supported by
the archive.
The default behavior is to do no discovery, and to use MAMv2. The behavior and API is unchanged.
When MamManager.enableMamVersionDiscovery() is called, newly created MamManager instances will
discover which version of MAM is supported by the archive, and use the highest version supported.
