### PR TITLE
SMACK-908: Don't use components to count tabs in Debugger

### DIFF
--- a/smack-debug/src/main/java/org/jivesoftware/smackx/debugger/EnhancedDebuggerWindow.java
+++ b/smack-debug/src/main/java/org/jivesoftware/smackx/debugger/EnhancedDebuggerWindow.java
@@ -140,12 +140,12 @@ public final class EnhancedDebuggerWindow {
         if (frame == null) {
             createDebug();
         }
-        debugger.tabbedPane.setName("XMPPConnection_" + tabbedPane.getComponentCount());
-        tabbedPane.add(debugger.tabbedPane, tabbedPane.getComponentCount() - 1);
+        debugger.tabbedPane.setName("XMPPConnection_" + tabbedPane.getTabCount());
+        tabbedPane.add(debugger.tabbedPane, -1);
         tabbedPane.setIconAt(tabbedPane.indexOfComponent(debugger.tabbedPane), connectionCreatedIcon);
         tabbedPane.setSelectedIndex(tabbedPane.indexOfComponent(debugger.tabbedPane));
         frame.setTitle(
-                "Smack Debug Window -- Total connections: " + (tabbedPane.getComponentCount() - 1));
+                "Smack Debug Window -- Total connections: " + (tabbedPane.getTabCount() - 1));
         // Keep the added debugger for later access
         debuggers.add(debugger);
     }
@@ -286,7 +286,7 @@ public final class EnhancedDebuggerWindow {
             @Override
             public void actionPerformed(ActionEvent e) {
                 // Remove the selected tab pane if it's not the Smack info pane
-                if (tabbedPane.getSelectedIndex() < tabbedPane.getComponentCount() - 1) {
+                if (tabbedPane.getSelectedIndex() < tabbedPane.getTabCount() - 1) {
                     int index = tabbedPane.getSelectedIndex();
                     // Notify to the debugger to stop debugging
                     EnhancedDebugger debugger = debuggers.get(index);
@@ -297,7 +297,7 @@ public final class EnhancedDebuggerWindow {
                     // Update the root window title
                     frame.setTitle(
                             "Smack Debug Window -- Total connections: "
-                                    + (tabbedPane.getComponentCount() - 1));
+                                    + (tabbedPane.getTabCount() - 1));
                 }
             }
         });
@@ -309,7 +309,7 @@ public final class EnhancedDebuggerWindow {
             public void actionPerformed(ActionEvent e) {
                 ArrayList<EnhancedDebugger> debuggersToRemove = new ArrayList<>();
                 // Remove all the debuggers of which their connections are no longer valid
-                for (int index = 0; index < tabbedPane.getComponentCount() - 1; index++) {
+                for (int index = 0; index < tabbedPane.getTabCount() - 1; index++) {
                     EnhancedDebugger debugger = debuggers.get(index);
                     if (!debugger.isConnectionActive()) {
                         // Notify to the debugger to stop debugging
@@ -325,7 +325,7 @@ public final class EnhancedDebuggerWindow {
                 // Update the root window title
                 frame.setTitle(
                         "Smack Debug Window -- Total connections: "
-                                + (tabbedPane.getComponentCount() - 1));
+                                + (tabbedPane.getTabCount() - 1));
             }
         });
         menu.add(menuItem);


### PR DESCRIPTION
This PR holds the same commit as the one in https://github.com/igniterealtime/Smack/pull/483, but cherry-picked against the 4.4 branch.