### PR TITLE
Bookmark parsing should not require non-empty nick

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bookmarks/Bookmarks.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bookmarks/Bookmarks.java
@@ -282,7 +282,9 @@ public class Bookmarks implements PrivateData {
             XmlPullParser.Event eventType = parser.next();
             if (eventType == XmlPullParser.Event.START_ELEMENT && "nick".equals(parser.getName())) {
                 String nickString = parser.nextText();
-                conf.setNickname(Resourcepart.from(nickString));
+                if (nickString != null && !nickString.isEmpty()) {
+                    conf.setNickname(Resourcepart.from(nickString));
+                }
             }
             else if (eventType == XmlPullParser.Event.START_ELEMENT && "password".equals(parser.getName())) {
                 conf.setPassword(parser.nextText());


### PR DESCRIPTION
XEP-0048 defines an optional nickname for a bookmarked conference room, using an element named 'nick'.

Some clients have been observed to include an empty 'nick' element (instead of no such element) when a nickname is not stored as part of the bookmark.

Smack should not fail to parse these elements. Without the change in this commit, it fails with the following exception:

```
org.jxmpp.stringprep.XmppStringprepException: Argument can't be the empty string
    at org.jxmpp.stringprep.XmppStringPrepUtil.throwIfEmptyString(XmppStringPrepUtil.java:131)
    at org.jxmpp.stringprep.XmppStringPrepUtil.resourceprep(XmppStringPrepUtil.java:101)
    at org.jxmpp.jid.parts.Resourcepart.from(Resourcepart.java:91)
    at org.jivesoftware.smackx.bookmarks.Bookmarks.getConferenceStorage(Bookmarks.java:285)
    ...
```