### PR TITLE
OpenPGP: Bump PGPainless to 0.2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ allprojects {
 		smackMinAndroidSdk = 19
 		junitVersion = '5.7.1'
 		commonsIoVersion = '2.6'
-		bouncyCastleVersion = '1.68'
+		bouncyCastleVersion = '1.69'
 		guavaVersion = '30.1-jre'
 		mockitoVersion = '3.7.7'
 		orgReflectionsVersion = '0.9.11'

--- a/smack-openpgp/build.gradle
+++ b/smack-openpgp/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	api project(':smack-extensions')
 	api project(':smack-experimental')
 
-	api 'org.pgpainless:pgpainless-core:0.2.0'
+	api 'org.pgpainless:pgpainless-core:0.2.8'
 
 	testImplementation "org.bouncycastle:bcprov-jdk15on:${bouncyCastleVersion}"
 

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/PainlessOpenPgpProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/PainlessOpenPgpProvider.java
@@ -47,6 +47,7 @@ import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
 import org.bouncycastle.util.io.Streams;
 import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.DocumentSignatureType;
+import org.pgpainless.decryption_verification.ConsumerOptions;
 import org.pgpainless.decryption_verification.DecryptionStream;
 import org.pgpainless.decryption_verification.MissingPublicKeyCallback;
 import org.pgpainless.decryption_verification.OpenPgpMetadata;
@@ -209,10 +210,10 @@ public class PainlessOpenPgpProvider implements OpenPgpProvider {
 
         DecryptionStream cipherStream = PGPainless.decryptAndOrVerify()
                 .onInputStream(cipherText)
-                .decryptWith(getStore().getKeyRingProtector(), self.getSecretKeys())
-                .verifyWith(announcedPublicKeys)
-                .handleMissingPublicKeysWith(missingPublicKeyCallback)
-                .build();
+                .withOptions(new ConsumerOptions()
+                        .addDecryptionKeys(self.getSecretKeys(), getStore().getKeyRingProtector())
+                        .addVerificationCerts(announcedPublicKeys)
+                        .setMissingCertificateCallback(missingPublicKeyCallback));
 
         Streams.pipeAll(cipherStream, plainText);
 

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/util/SecretKeyBackupHelper.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/util/SecretKeyBackupHelper.java
@@ -37,6 +37,7 @@ import org.bouncycastle.util.io.Streams;
 import org.jxmpp.jid.BareJid;
 import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
+import org.pgpainless.decryption_verification.ConsumerOptions;
 import org.pgpainless.decryption_verification.DecryptionStream;
 import org.pgpainless.encryption_signing.EncryptionOptions;
 import org.pgpainless.encryption_signing.EncryptionStream;
@@ -153,9 +154,8 @@ public class SecretKeyBackupHelper {
         try {
             DecryptionStream decryptionStream = PGPainless.decryptAndOrVerify()
                     .onInputStream(encryptedIn)
-                    .decryptWith(Passphrase.fromPassword(backupCode.toString()))
-                    .doNotVerify()
-                    .build();
+                    .withOptions(new ConsumerOptions()
+                            .addDecryptionPassphrase(Passphrase.fromPassword(backupCode.toString())));
 
             Streams.pipeAll(decryptionStream, plaintextOut);
             decryptionStream.close();

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
@@ -142,7 +142,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
         // Decrypt and Verify
         decrypted = bobProvider.decryptAndOrVerify(bobConnection, encrypted.getElement(), bobSelf, aliceForBob);
 
-        OpenPgpV4Fingerprint decryptionFingerprint = decrypted.getMetadata().getDecryptionFingerprint();
+        OpenPgpV4Fingerprint decryptionFingerprint = decrypted.getMetadata().getDecryptionKey().getFingerprint();
         assertTrue(bobSelf.getSecretKeys().contains(decryptionFingerprint.getKeyId()));
         assertTrue(decrypted.getMetadata().containsVerifiedSignatureFrom(alicePubKeys));
 
@@ -162,9 +162,9 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
 
         decrypted = bobProvider.decryptAndOrVerify(bobConnection, encrypted.getElement(), bobSelf, aliceForBob);
 
-        decryptionFingerprint = decrypted.getMetadata().getDecryptionFingerprint();
+        decryptionFingerprint = decrypted.getMetadata().getDecryptionKey().getFingerprint();
         assertTrue(bobSelf.getSecretKeys().contains(decryptionFingerprint.getKeyId()));
-        assertTrue(decrypted.getMetadata().getVerifiedSignatureKeyFingerprints().isEmpty());
+        assertTrue(decrypted.getMetadata().getVerifiedSignatures().isEmpty());
 
         assertEquals(OpenPgpMessage.State.crypt, decrypted.getState());
         CryptElement decryptedCrypt = (CryptElement) decrypted.getOpenPgpContentElement();
@@ -182,7 +182,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
 
         decrypted = bobProvider.decryptAndOrVerify(bobConnection, encrypted.getElement(), bobSelf, aliceForBob);
 
-        assertNull(decrypted.getMetadata().getDecryptionFingerprint());
+        assertNull(decrypted.getMetadata().getDecryptionKey());
         assertTrue(decrypted.getMetadata().containsVerifiedSignatureFrom(alicePubKeys));
 
         assertEquals(OpenPgpMessage.State.sign, decrypted.getState());

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingManagerTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingManagerTest.java
@@ -155,7 +155,7 @@ public class OXInstantMessagingManagerTest extends SmackTestSuite {
         assertTrue(metadata.isSigned() && metadata.isEncrypted());
 
         // Check, if one of Bobs keys was used for decryption
-        assertNotNull(bobSelf.getSigningKeyRing().getPublicKey(metadata.getDecryptionFingerprint().getKeyId()));
+        assertNotNull(bobSelf.getSigningKeyRing().getPublicKey(metadata.getDecryptionKey().getKeyId()));
 
         // TODO: I observed this assertTrue() to fail sporadically. As a first attempt to diagnose this, a message was
         // added to the assertion. However since most (all?) objects used in the message do not implement a proper


### PR DESCRIPTION
This PR both bumps bouncycastle to 1.69 (no breaking changes expected, yet some very useful bug fixes), as well as PGPainless to 0.2.8.

Since PGPainless-0.2.0, a lot of changes were made to the code base, including some security related fixes (checksum verifications, expiration date validation, ...).

For a list of improvements that went into PGPainless since the 0.2.0 release, see the [changelog](https://github.com/pgpainless/pgpainless/blob/master/CHANGELOG.md).