### PR TITLE
Prevent password enforcement for SASL anonymous

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/SASLAnonymous.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/sasl/core/SASLAnonymous.java
@@ -60,4 +60,8 @@ public class SASLAnonymous extends SASLMechanism {
         // SASL Anonymous is always successful :)
     }
 
+    @Override
+    public boolean requiresPassword() {
+        return false;
+    }
 }


### PR DESCRIPTION
requirePassword from 92f4aadfdc45c144763c2e2a1921c2fa9a6db90b already excludes SASL external, but missed SASL anonymous.