### PR TITLE
Fix BOSH connection establishment

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -43,6 +43,7 @@ import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smack.util.CloseableUtil;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
+import org.jivesoftware.smack.xml.XmlPullParserException;
 
 import org.igniterealtime.jbosh.AbstractBody;
 import org.igniterealtime.jbosh.BOSHClient;
@@ -199,6 +200,13 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
             String errorMessage = "Timeout reached for the connection to "
                     + getHost() + ":" + getPort() + ".";
             throw new SmackException.SmackMessageException(errorMessage);
+        }
+
+        try {
+            XmlPullParser parser = PacketParserUtils.getParserFor("<stream:stream xmlns='jabber:client'/>");
+            onStreamOpen(parser);
+        } catch (XmlPullParserException | IOException e) {
+            throw new AssertionError("Failed to setup stream environment", e);
         }
     }
 
@@ -511,7 +519,7 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
                                 parseAndProcessStanza(parser);
                                 break;
                             case "features":
-                                parseFeatures(parser);
+                                parseFeaturesAndNotify(parser);
                                 break;
                             case "error":
                                 // Some BOSH error isn't stream error.


### PR DESCRIPTION
AbstractXMPPConnection waits for the flag lastFeaturesReceived since 57961a8cc1f2df6ecc1afa8c4f8460794d8d2dce, but it is never set from BOSH connections. Use `parseFeaturesAndNotify` instead of `parseFeaturesto` set the signal. Alternatively, instead of using `parseFeaturesAndNotify` the `lastFeaturesReceived` flag could be directly set after calling `parseFeatures` combined with `notifyWaitingThreads()`. I'm not sure which one is better.

The `incomingStreamXmlEnvironment` is not set in a BOSH connection, but required/assumed to be not null in `ParserUtils.getXmlLang`. Since there's no stream announcement as in TCP connections, using `onStreamOpen` does not seem to be an option. Adding a null-check in getXmlLang would probably just lead to the next failure.
