### PR TITLE
Make Smack jars OSGi bundles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
 		classpath 'org.kordamp.gradle:clirr-gradle-plugin:0.2.2'
 		classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.3.1"
+		classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:6.0.0"
     }
 }
 
@@ -413,6 +414,7 @@ subprojects {
 	apply plugin: 'signing'
 	apply plugin: 'checkstyle'
 	apply plugin: 'org.kordamp.gradle.clirr'
+	apply plugin: 'biz.aQute.bnd.builder'
 
 	checkstyle {
 		toolVersion = '8.27'
@@ -575,9 +577,15 @@ project(':smack-omemo').clirr.enabled = false
 project(':smack-omemo-signal').clirr.enabled = false
 
 subprojects*.jar {
-   manifest {
-       from sharedManifest
-   }
+	manifest {
+		from sharedManifest
+	}
+	bundle {
+		bnd(
+				'-removeheaders': 'Tool, Bnd-*',
+				'-exportcontents': '*',
+		)
+	}
 }
 
 configure(subprojects - gplLicensedProjects) {

--- a/smack-core/build.gradle
+++ b/smack-core/build.gradle
@@ -1,3 +1,8 @@
+// Note that this is also declared in the main build.gradle for
+// subprojects, but since evaluationDependsOnChildren is enabled we
+// need to declare it here too to have bundle{bnd{...}} available
+apply plugin: 'biz.aQute.bnd.builder'
+
 description = """\
 Smack core components."""
 
@@ -55,3 +60,11 @@ task createVersionResource(type: CreateFileTask) {
 }
 
 compileJava.dependsOn(createVersionResource)
+
+jar {
+	bundle {
+		bnd(
+				'DynamicImport-Package': '*',
+		)
+	}
+}

--- a/smack-xmlparser-stax/build.gradle
+++ b/smack-xmlparser-stax/build.gradle
@@ -1,7 +1,22 @@
+// Note that this is also declared in the main build.gradle for
+// subprojects, but since evaluationDependsOnChildren is enabled we
+// need to declare it here too to have bundle{bnd{...}} available
+apply plugin: 'biz.aQute.bnd.builder'
+
 description = """\
 Smack XML parser using Stax."""
 
 dependencies {
 	compile project(':smack-xmlparser')
 	//testCompile project(path: ":smack-xmlparser", configuration: "testRuntime")
+}
+
+jar {
+	bundle {
+		bnd(
+				// see http://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.loader.html
+				'Require-Capability': 'osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"',
+				'Provide-Capability': "osgi.serviceloader;osgi.serviceloader=org.jivesoftware.smack.xml.XmlPullParserFactory;register:=org.jivesoftware.smack.xml.stax.StaxXmlPullParserFactory",
+		)
+	}
 }

--- a/smack-xmlparser-xpp3/build.gradle
+++ b/smack-xmlparser-xpp3/build.gradle
@@ -1,3 +1,8 @@
+// Note that this is also declared in the main build.gradle for
+// subprojects, but since evaluationDependsOnChildren is enabled we
+// need to declare it here too to have bundle{bnd{...}} available
+apply plugin: 'biz.aQute.bnd.builder'
+
 description = """\
 Smack XML parser using XPP3."""
 
@@ -10,4 +15,14 @@ dependencies {
 	implementation "xpp3:xpp3:$xpp3Version"
 	api project(':smack-xmlparser')
 	//testCompile project(path: ":smack-xmlparser", configuration: "testRuntime")
+}
+
+jar {
+	bundle {
+		bnd(
+				// see http://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.loader.html
+				'Require-Capability': 'osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"',
+				'Provide-Capability': "osgi.serviceloader;osgi.serviceloader=org.jivesoftware.smack.xml.XmlPullParserFactory;register:=org.jivesoftware.smack.xml.xpp3.Xpp3XmlPullParserFactory",
+		)
+	}
 }

--- a/smack-xmlparser/build.gradle
+++ b/smack-xmlparser/build.gradle
@@ -1,2 +1,16 @@
+// Note that this is also declared in the main build.gradle for
+// subprojects, but since evaluationDependsOnChildren is enabled we
+// need to declare it here too to have bundle{bnd{...}} available
+apply plugin: 'biz.aQute.bnd.builder'
+
 description = """\
 Smack XML parser fundamentals"""
+
+jar {
+    bundle {
+        bnd(
+                // see http://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.loader.html
+                'Require-Capability': 'osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)"',
+        )
+    }
+}


### PR DESCRIPTION
Fixes SMACK-343 by using bnd instead of the deprecated Gradle plugin that was previously used and removed in commit d06f533bb975f41a5e86c990e1bb830b7e7dc923.