### PR TITLE
Add missing stream namespace to xml declaration

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -203,7 +203,8 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
         }
 
         try {
-            XmlPullParser parser = PacketParserUtils.getParserFor("<stream:stream xmlns='jabber:client'/>");
+            XmlPullParser parser = PacketParserUtils.getParserFor(
+                            "<stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'/>");
             onStreamOpen(parser);
         } catch (XmlPullParserException | IOException e) {
             throw new AssertionError("Failed to setup stream environment", e);


### PR DESCRIPTION
Follow-up to PR #498

Sorry @Flowdalic that I didn't catch this in the first PR, I must have messed up the imported versions. Anyway, without this the parser instantiation fails with an unbounded prefix error message.