### PR TITLE
Add removeExtension methods to StanzaBuilder.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/StanzaBuilder.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/StanzaBuilder.java
@@ -184,6 +184,19 @@ public abstract class StanzaBuilder<B extends StanzaBuilder<B>> implements Stanz
         return getThis();
     }
 
+    public final B removeExtension(String elementName, String namespace) {
+        QName key = new QName(namespace, elementName);
+        extensionElements.remove(key);
+        return getThis();
+    }
+
+    public final B removeExtension(ExtensionElement extension) {
+        QName key = extension.getQName();
+        List<ExtensionElement> list = extensionElements.getAll(key);
+        list.remove(extension);
+        return getThis();
+    }
+
     public abstract Stanza build();
 
     public abstract B getThis();


### PR DESCRIPTION
This adds removeExtension methods to StanzaBuilder, to make it a full replacement for the deprecated methods on Stanza.