### PR TITLE
Bump PGPainless to 0.2.19

### DIFF
--- a/smack-openpgp/build.gradle
+++ b/smack-openpgp/build.gradle
@@ -8,9 +8,10 @@ dependencies {
 	api project(':smack-extensions')
 	api project(':smack-experimental')
 
-	api 'org.pgpainless:pgpainless-core:0.2.8'
+	api 'org.pgpainless:pgpainless-core:0.2.19'
 
 	testImplementation "org.bouncycastle:bcprov-jdk15on:${bouncyCastleVersion}"
+	testImplementation 'ch.qos.logback:logback-classic:1.2.6'
 
 	testFixturesApi(testFixtures(project(":smack-core")))
 	testImplementation group: 'commons-io', name: 'commons-io', version: "$commonsIoVersion"

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/PainlessOpenPgpProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/PainlessOpenPgpProvider.java
@@ -29,7 +29,6 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.util.Objects;
 import org.jivesoftware.smack.util.stringencoder.Base64;
-
 import org.jivesoftware.smackx.ox.OpenPgpContact;
 import org.jivesoftware.smackx.ox.OpenPgpMessage;
 import org.jivesoftware.smackx.ox.OpenPgpSelf;
@@ -90,7 +89,7 @@ public class PainlessOpenPgpProvider implements OpenPgpProvider {
 
         SigningOptions signOpts = new SigningOptions();
         signOpts.addInlineSignature(getStore().getKeyRingProtector(), self.getSigningKeyRing(),
-                "xmpp:" + self.getJid().toString(), DocumentSignatureType.BINARY_DOCUMENT);
+                DocumentSignatureType.BINARY_DOCUMENT);
 
         EncryptionStream cipherStream = PGPainless.encryptAndOrSign()
                 .onOutputStream(cipherText)

--- a/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
+++ b/smack-openpgp/src/test/java/org/jivesoftware/smackx/ox/PainlessOpenPgpProviderTest.java
@@ -47,29 +47,27 @@ import org.jivesoftware.smackx.ox.store.filebased.FileBasedOpenPgpStore;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.JidTestUtil;
+import org.pgpainless.key.OpenPgpFingerprint;
 import org.pgpainless.key.OpenPgpV4Fingerprint;
 import org.pgpainless.key.protection.UnprotectedKeysProtector;
 import org.pgpainless.key.util.KeyRingUtils;
 
 public class PainlessOpenPgpProviderTest extends SmackTestSuite {
 
-    private static final File storagePath;
+    private static File storagePath;
     private static final BareJid alice = JidTestUtil.BARE_JID_1;
     private static final BareJid bob = JidTestUtil.BARE_JID_2;
 
-    static {
+    @BeforeEach
+    @AfterEach
+    public void deletePath() throws IOException {
         storagePath = new File(org.apache.commons.io.FileUtils.getTempDirectory(), "smack-painlessprovidertest");
-    }
-
-    @BeforeClass
-    @AfterClass
-    public static void deletePath() throws IOException {
         org.apache.commons.io.FileUtils.deleteDirectory(storagePath);
     }
 
@@ -142,7 +140,7 @@ public class PainlessOpenPgpProviderTest extends SmackTestSuite {
         // Decrypt and Verify
         decrypted = bobProvider.decryptAndOrVerify(bobConnection, encrypted.getElement(), bobSelf, aliceForBob);
 
-        OpenPgpV4Fingerprint decryptionFingerprint = decrypted.getMetadata().getDecryptionKey().getFingerprint();
+        OpenPgpFingerprint decryptionFingerprint = decrypted.getMetadata().getDecryptionKey().getFingerprint();
         assertTrue(bobSelf.getSecretKeys().contains(decryptionFingerprint.getKeyId()));
         assertTrue(decrypted.getMetadata().containsVerifiedSignatureFrom(alicePubKeys));
 

--- a/smack-openpgp/src/test/resources/logback-test.xml
+++ b/smack-openpgp/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%blue(%-5level) %green(%logger{35}) - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%blue(%-5level) %green(%logger{35}) - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDERR" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
Hey!

This PR bumps Smacks dependency on PGPainless to 0.2.19.

Among the noteworthy changes is the fact that PGPainless now makes use of slf4j.
For JUnit tests, I chose logback as a logging backend, feel free to change this to whatever logging backend Smack is preferring inside of tests :)

A full log of all changes that went into PGPainless throughout its release cycle can be found [here](https://github.com/pgpainless/pgpainless/blob/master/CHANGELOG.md).