### PR TITLE
Prevent password enforcement for SASL GSSAPI

### DIFF
--- a/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLGSSAPIMechanism.java
+++ b/smack-sasl-javax/src/main/java/org/jivesoftware/smack/sasl/javax/SASLGSSAPIMechanism.java
@@ -66,4 +66,8 @@ public class SASLGSSAPIMechanism extends SASLJavaXMechanism {
         return new SASLGSSAPIMechanism();
     }
 
+    @Override
+    public boolean requiresPassword() {
+        return false;
+    }
 }


### PR DESCRIPTION
Similar fix as 9b339efbc1cf ("Prevent password enforcement for SASL
anonymous") just for SASL GSSAPI.

Fixes: 92f4aadfdc45 ("[sasl] Avoid mechanisms that need a password when none is available")