### PR TITLE
Allow configurable ping timeout value

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/ping/PingManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/ping/PingManager.java
@@ -432,7 +432,7 @@ public final class PingManager extends Manager {
             return;
         }
 
-        final long minimumTimeout = TimeUnit.MINUTES.toMillis(2);
+        final long minimumTimeout = TimeUnit.SECONDS.toMillis(pingInterval);
         final long connectionReplyTimeout = connection.getReplyTimeout();
         final long timeout = connectionReplyTimeout > minimumTimeout ? connectionReplyTimeout : minimumTimeout;
 


### PR DESCRIPTION
Currently the minimum ping timeout value is hardcoded to 2 minutes. It would be nice to be able to configure this value. Using pingInterval as this is the lowest impact change to the code.
