### PR TITLE
Smack JingleReason#toXML must include both text and element

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/IQProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/IQProvider.java
@@ -30,7 +30,7 @@ import org.jivesoftware.smack.xml.XmlPullParserException;
 
 /**
  * <p>
- * <b>Deprecation Notice:</b> This class is deprecated, use {@link IQProvider} instead.
+ * <b>Deprecation Notice:</b> This class is deprecated, use {@link IqProvider} instead.
  * </p>
  * An abstract class for parsing custom IQ packets. Each IQProvider must be registered with
  * the ProviderManager class for it to be used. Every implementation of this

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
@@ -132,7 +132,7 @@ public class JingleReason implements XmlElement {
      * @param reason the reason string that we'd like to transport in this packet extension, which may or
      * may not be one of the static strings defined here.
      * @param text an element providing human-readable information about the reason for the action or
-     * <tt>null</tt> if no such information is currently available.
+     * <code>null</code>  if no such information is currently available.
      * @param element any other element that MAY be providing further information or <code>null</code> if no
      * such element has been specified.
      */

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
@@ -133,7 +133,7 @@ public class JingleReason implements XmlElement {
      * may not be one of the static strings defined here.
      * @param text an element providing human-readable information about the reason for the action or
      * <tt>null</tt> if no such information is currently available.
-     * @param element any other element that MAY be providing further information or <tt>null</tt> if no
+     * @param element any other element that MAY be providing further information or <code>null</code> if no
      * such element has been specified.
      */
     public JingleReason(Reason reason, String text, XmlElement element) {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/element/JingleReason.java
@@ -35,6 +35,11 @@ public class JingleReason implements XmlElement {
     public static final String ELEMENT = "reason";
     public static final String NAMESPACE = Jingle.NAMESPACE;
 
+    /**
+     * The name of the text element.
+     */
+    public static final String TEXT_ELEMENT = "text";
+
     public static AlternativeSession AlternativeSession(String sessionId) {
         return new AlternativeSession(sessionId);
     }
@@ -105,13 +110,32 @@ public class JingleReason implements XmlElement {
     }
 
     protected final Reason reason;
+
+    /**
+     * The content of the text element (if any) providing human-readable information about the reason for the action.
+     */
     private final String text;
+
+    /**
+     * XEP-0166 mentions that the "reason" element MAY contain an element qualified by some other
+     * namespace that provides more detailed machine- readable information about the reason for the action.
+     */
     private final XmlElement element;
 
     public JingleReason(Reason reason) {
         this(reason, null, null);
     }
 
+    /**
+     * Creates a new <tt>JingleReason</tt> instance with the specified reason String.
+     *
+     * @param reason the reason string that we'd like to transport in this packet extension, which may or
+     * may not be one of the static strings defined here.
+     * @param text an element providing human-readable information about the reason for the action or
+     * <tt>null</tt> if no such information is currently available.
+     * @param element any other element that MAY be providing further information or <tt>null</tt> if no
+     * such element has been specified.
+     */
     public JingleReason(Reason reason, String text, XmlElement element) {
         this.reason = reason;
         this.text = text;
@@ -141,7 +165,7 @@ public class JingleReason implements XmlElement {
     /**
      * An optional element that provides more detailed machine-readable information about the reason for the action.
      *
-     * @return an elemnet with machine-readable information about this reason or <code>null</code>.
+     * @return an element with machine-readable information about this reason or <code>null</code>.
      * @since 4.4.5
      */
     public XmlElement getElement() {
@@ -155,6 +179,14 @@ public class JingleReason implements XmlElement {
 
         xml.emptyElement(reason);
 
+        // add reason "text" if we have it
+        xml.optElement(TEXT_ELEMENT, text);
+
+        // add the extra element if it has been specified.
+        if (element != null) {
+            xml.append(element.toXML(XmlEnvironment.EMPTY));
+        }
+
         xml.closeElement(this);
         return xml;
     }
@@ -162,7 +194,6 @@ public class JingleReason implements XmlElement {
     public Reason asEnum() {
         return reason;
     }
-
 
     public static class AlternativeSession extends JingleReason {
 
@@ -182,7 +213,7 @@ public class JingleReason implements XmlElement {
         }
 
         @Override
-        public XmlStringBuilder toXML(org.jivesoftware.smack.packet.XmlEnvironment enclosingNamespace) {
+        public XmlStringBuilder toXML(XmlEnvironment enclosingNamespace) {
             XmlStringBuilder xml = new XmlStringBuilder(this, enclosingNamespace);
             xml.rightAngleBracket();
 


### PR DESCRIPTION
The JingleReason#toXML method must include both the optional text string and element XmlElement in the create process.
