### PR TITLE
Bump PGPainless to 1.1.1, Bouncy Castle to 1.70

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ allprojects {
 		smackMinAndroidSdk = 19
 		junitVersion = '5.7.1'
 		commonsIoVersion = '2.6'
-		bouncyCastleVersion = '1.69'
+		bouncyCastleVersion = '1.70'
 		guavaVersion = '30.1-jre'
 		mockitoVersion = '3.7.7'
 		orgReflectionsVersion = '0.9.11'

--- a/smack-openpgp/build.gradle
+++ b/smack-openpgp/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	api project(':smack-extensions')
 	api project(':smack-experimental')
 
-	api 'org.pgpainless:pgpainless-core:1.0.0-rc6'
+	api 'org.pgpainless:pgpainless-core:1.1.1'
 
 	testImplementation "org.bouncycastle:bcprov-jdk15on:${bouncyCastleVersion}"
 


### PR DESCRIPTION
There have been some security related findings surfaced by a recent [security audit](https://gh.pgpainless.org/assets/Audit-PGPainless.pdf). This PR bumps PGPainless to a version that contains fixes for those. As usual, changes can be found in the [changelog](https://github.com/pgpainless/pgpainless/blob/master/CHANGELOG.md).