### PR TITLE
Replace legacy IQProvider with IqProvider

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/BindIQProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/BindIQProvider.java
@@ -19,6 +19,7 @@ package org.jivesoftware.smack.provider;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.Bind;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -27,10 +28,10 @@ import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 
-public class BindIQProvider extends IQProvider<Bind> {
+public class BindIQProvider extends IqProvider<Bind> {
 
     @Override
-    public Bind parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public Bind parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         String name;
         Bind bind = null;
         outerloop: while (true) {

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/IQProviderInfo.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/IQProviderInfo.java
@@ -28,7 +28,7 @@ import org.jivesoftware.smack.packet.IQ;
 public final class IQProviderInfo extends AbstractProviderInfo {
 
     /**
-     * Defines an IQ provider which implements the <code>IQProvider</code> interface.
+     * Defines an IQ provider which implements the {@link IqProvider} interface.
      *
      * @param elementName Element that provider parses.
      * @param namespace Namespace that provider parses.

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/IntrospectionProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/IntrospectionProvider.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -42,7 +43,7 @@ public class IntrospectionProvider{
      */
     // TODO: Remove in Smack 4.6.
     @Deprecated
-    public abstract static class IQIntrospectionProvider<I extends IQ> extends IQProvider<I> {
+    public abstract static class IQIntrospectionProvider<I extends IQ> extends IqProvider<I> {
         private final Class<I> elementClass;
 
         protected IQIntrospectionProvider(Class<I> elementClass) {
@@ -51,7 +52,7 @@ public class IntrospectionProvider{
 
         @SuppressWarnings("unchecked")
         @Override
-        public I parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public I parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             try {
                 return (I) parseWithIntrospection(elementClass, parser, initialDepth);
             }

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/IqProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/IqProvider.java
@@ -23,9 +23,17 @@ import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
+import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
+/**
+ * An abstract class for parsing custom {@link IQ} packets. Each IqProvider must be registered with the {@link
+ * ProviderManager} for it to be used. Every implementation of this abstract class <b>must</b> have a public,
+ * no-argument constructor.
+ *
+ * @param <I> the {@link IQ} that is parsed by implementations.
+ */
 public abstract class IqProvider<I extends IQ> extends AbstractProvider<I> {
 
     public final I parse(XmlPullParser parser, IqData iqCommon)
@@ -40,6 +48,8 @@ public abstract class IqProvider<I extends IQ> extends AbstractProvider<I> {
 
         I i = wrapExceptions(() -> parse(parser, initialDepth, iqData, xmlEnvironment));
 
+        // Parser should be at end tag of the consumed/parsed element
+        ParserUtils.forwardToEndTagOfDepth(parser, initialDepth);
         return i;
     }
 

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/LegacyIQProvider.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/LegacyIQProvider.java
@@ -37,8 +37,11 @@ import org.jivesoftware.smack.xml.XmlPullParserException;
  * abstract class <b>must</b> have a public, no-argument constructor.
  *
  * @author Matt Tucker
+ * @deprecated Use {@link IqProvider} instead
  */
-public abstract class IQProvider<I extends IQ> extends IqProvider<I> {
+@Deprecated
+// TODO: Remove in Smack 4.6.
+public abstract class LegacyIQProvider<I extends IQ> extends IqProvider<I> {
 
     public final I parse(XmlPullParser parser) throws IOException, XmlPullParserException, SmackParsingException {
         return parse(parser, (XmlEnvironment) null);

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/ProviderFileLoader.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/ProviderFileLoader.java
@@ -30,7 +30,7 @@ import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 /**
- * Loads the {@link IQProvider} and {@link ExtensionElementProvider} information from a standard provider file in preparation
+ * Loads the {@link IqProvider} and {@link ExtensionElementProvider} information from a standard provider file in preparation
  * for loading into the {@link ProviderManager}.
  *
  * @author Robin Collier
@@ -76,7 +76,7 @@ public class ProviderFileLoader implements ProviderLoader {
                                 switch (typeName) {
                                 case "iqProvider":
                                     // Attempt to load the provider class and then create
-                                    // a new instance if it's an IQProvider. Otherwise, if it's
+                                    // a new instance if it's an IqProvider. Otherwise, if it's
                                     // an IQ class, add the class object itself, then we'll use
                                     // reflection later to create instances of the class.
                                     // Add the provider to the map.
@@ -85,7 +85,7 @@ public class ProviderFileLoader implements ProviderLoader {
                                         iqProviders.add(new IQProviderInfo(elementName, namespace, iqProvider));
                                     }
                                     else {
-                                        exceptions.add(new IllegalArgumentException(className + " is not a IQProvider"));
+                                        exceptions.add(new IllegalArgumentException(className + " is not a IqProvider"));
                                     }
                                     break;
                                 case "extensionProvider":

--- a/smack-core/src/main/java/org/jivesoftware/smack/provider/ProviderManager.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/provider/ProviderManager.java
@@ -34,11 +34,11 @@ import org.jivesoftware.smack.util.XmppElementUtil;
 /**
  * Manages providers for parsing custom XML sub-documents of XMPP packets. Two types of
  * providers exist:<ul>
- *      <li>IQProvider -- parses IQ requests into Java objects.
+ *      <li>IqProvider -- parses IQ requests into Java objects.
  *      <li>PacketExtension -- parses XML sub-documents attached to packets into
  *          PacketExtension instances.</ul>
  *
- * <b>IQProvider</b><p>
+ * <b>IqProvider</b><p>
  *
  * By default, Smack only knows how to process IQ packets with sub-packets that
  * are in a few namespaces such as:<ul>
@@ -63,8 +63,8 @@ import org.jivesoftware.smack.util.XmppElementUtil;
  *
  * Each IQ provider is associated with an element name and a namespace. If multiple provider
  * entries attempt to register to handle the same namespace, the first entry loaded from the
- * classpath will take precedence. The IQ provider class can either implement the IQProvider
- * interface, or extend the IQ class. In the former case, each IQProvider is responsible for
+ * classpath will take precedence. The IQ provider class can either implement the IqProvider
+ * interface, or extend the IQ class. In the former case, each IqProvider is responsible for
  * parsing the raw XML stream to create an IQ instance. In the latter case, bean introspection
  * is used to try to automatically set properties of the IQ instance using the values found
  * in the IQ stanza XML. For example, an XMPP time stanza resembles the following:
@@ -173,11 +173,11 @@ public final class ProviderManager {
     }
 
     /**
-     * Returns an unmodifiable collection of all IQProvider instances. Each object
-     * in the collection will either be an IQProvider instance, or a Class object
-     * that implements the IQProvider interface.
+     * Returns an unmodifiable collection of all IqProvider instances. Each object
+     * in the collection will either be an IqProvider instance, or a Class object
+     * that implements the IqProvider interface.
      *
-     * @return all IQProvider instances.
+     * @return all IqProvider instances.
      */
     public static List<IqProvider<IQ>> getIQProviders() {
         List<IqProvider<IQ>> providers = new ArrayList<>(iqProviders.size());
@@ -186,7 +186,7 @@ public final class ProviderManager {
     }
 
     /**
-     * Adds an IQ provider (must be an instance of IQProvider or Class object that is an IQ)
+     * Adds an IQ provider (must be an instance of IqProvider or Class object that is an IQ)
      * with the specified element name and name space. The provider will override any providers
      * loaded through the classpath.
      *

--- a/smack-core/src/test/java/org/jivesoftware/smack/provider/ProviderConfigTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/provider/ProviderConfigTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.util.FileUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -60,10 +61,10 @@ public class ProviderConfigTest {
         Assert.assertNotNull(ProviderManager.getIQProvider("provider", "test:file_provider"));
     }
 
-    public static class TestIQProvider extends IQProvider<IQ> {
+    public static class TestIQProvider extends IqProvider<IQ> {
 
         @Override
-        public IQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+        public IQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
             return null;
         }
 

--- a/smack-core/src/test/java/org/jivesoftware/smack/provider/ProviderManagerTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/provider/ProviderManagerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.jivesoftware.smack.SmackConfiguration;
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
@@ -37,10 +38,10 @@ public class ProviderManagerTest {
         assertTrue(SmackConfiguration.isSmackInitialized());
     }
 
-    public static class TestIQProvider extends IQProvider<IQ> {
+    public static class TestIQProvider extends IqProvider<IQ> {
 
         @Override
-        public IQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+        public IQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
             return null;
         }
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/dox/provider/DnsIqProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/dox/provider/DnsIqProvider.java
@@ -18,18 +18,19 @@ package org.jivesoftware.smackx.dox.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
 import org.jivesoftware.smackx.dox.element.DnsIq;
 
-public class DnsIqProvider extends IQProvider<DnsIq> {
+public class DnsIqProvider extends IqProvider<DnsIq> {
 
     @Override
-    public DnsIq parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+    public DnsIq parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
             throws XmlPullParserException, IOException, SmackParsingException {
         String base64DnsMessage = parser.nextText();
         return new DnsIq(base64DnsMessage);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/provider/AbstractHttpOverXmppProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/provider/AbstractHttpOverXmppProvider.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 
 import org.jivesoftware.smack.packet.NamedElement;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -35,7 +35,7 @@ import org.jivesoftware.smackx.shim.provider.HeadersProvider;
  * @author Andriy Tsykholyas
  * @see <a href="http://xmpp.org/extensions/xep-0332.html">XEP-0332: HTTP over XMPP transport</a>
  */
-public abstract class AbstractHttpOverXmppProvider<H extends AbstractHttpOverXmpp> extends IQProvider<H> {
+public abstract class AbstractHttpOverXmppProvider<H extends AbstractHttpOverXmpp> extends IqProvider<H> {
 
     private static final String ELEMENT_DATA = "data";
     private static final String ELEMENT_TEXT = "text";

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/provider/HttpOverXmppReqProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/provider/HttpOverXmppReqProvider.java
@@ -18,6 +18,7 @@ package org.jivesoftware.smackx.hoxt.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.util.ParserUtils;
@@ -40,7 +41,7 @@ public class HttpOverXmppReqProvider extends AbstractHttpOverXmppProvider<HttpOv
     private static final String ATTRIBUTE_MAX_CHUNK_SIZE = "maxChunkSize";
 
     @Override
-    public HttpOverXmppReq parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws IOException, XmlPullParserException, SmackParsingException {
+    public HttpOverXmppReq parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws IOException, XmlPullParserException, SmackParsingException {
         HttpOverXmppReq.Builder builder = HttpOverXmppReq.builder();
         builder.setResource(parser.getAttributeValue("", ATTRIBUTE_RESOURCE));
         builder.setVersion(parser.getAttributeValue("", ATTRIBUTE_VERSION));

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/provider/HttpOverXmppRespProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/hoxt/provider/HttpOverXmppRespProvider.java
@@ -18,6 +18,7 @@ package org.jivesoftware.smackx.hoxt.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -39,7 +40,7 @@ public class HttpOverXmppRespProvider extends AbstractHttpOverXmppProvider<HttpO
     private static final String ATTRIBUTE_STATUS_CODE = "statusCode";
 
     @Override
-    public HttpOverXmppResp parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws IOException, XmlPullParserException, SmackParsingException {
+    public HttpOverXmppResp parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws IOException, XmlPullParserException, SmackParsingException {
         String version = parser.getAttributeValue("", ATTRIBUTE_VERSION);
         String statusMessage = parser.getAttributeValue("", ATTRIBUTE_STATUS_MESSAGE);
         String statusCodeString = parser.getAttributeValue("", ATTRIBUTE_STATUS_CODE);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/httpfileupload/provider/SlotProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/httpfileupload/provider/SlotProvider.java
@@ -21,8 +21,9 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -38,10 +39,10 @@ import org.jivesoftware.smackx.httpfileupload.element.Slot_V0_2;
  * @author Grigory Fedorov
  * @see <a href="http://xmpp.org/extensions/xep-0363.html">XEP-0363: HTTP File Upload</a>
  */
-public class SlotProvider extends IQProvider<Slot> {
+public class SlotProvider extends IqProvider<Slot> {
 
     @Override
-    public Slot parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public Slot parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         final String namespace = parser.getNamespace();
 
         final UploadService.Version version = HttpFileUploadManager.namespaceToVersion(namespace);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/control/provider/IoTSetRequestProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/control/provider/IoTSetRequestProvider.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -32,10 +33,10 @@ import org.jivesoftware.smackx.iot.control.element.SetDoubleData;
 import org.jivesoftware.smackx.iot.control.element.SetIntData;
 import org.jivesoftware.smackx.iot.control.element.SetLongData;
 
-public class IoTSetRequestProvider extends IQProvider<IoTSetRequest> {
+public class IoTSetRequestProvider extends IqProvider<IoTSetRequest> {
 
     @Override
-    public IoTSetRequest parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public IoTSetRequest parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         List<SetData> data = new ArrayList<>(4);
         outerloop: while (true) {
             final XmlPullParser.Event eventType = parser.next();

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/control/provider/IoTSetResponseProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/control/provider/IoTSetResponseProvider.java
@@ -16,16 +16,17 @@
  */
 package org.jivesoftware.smackx.iot.control.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.iot.control.element.IoTSetResponse;
 
-public class IoTSetResponseProvider extends IQProvider<IoTSetResponse> {
+public class IoTSetResponseProvider extends IqProvider<IoTSetResponse> {
 
     @Override
-    public IoTSetResponse parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+    public IoTSetResponse parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
         return new IoTSetResponse();
     }
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/data/provider/IoTDataReadOutAcceptedProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/data/provider/IoTDataReadOutAcceptedProvider.java
@@ -18,17 +18,18 @@ package org.jivesoftware.smackx.iot.data.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.iot.data.element.IoTDataReadOutAccepted;
 
-public class IoTDataReadOutAcceptedProvider extends IQProvider<IoTDataReadOutAccepted> {
+public class IoTDataReadOutAcceptedProvider extends IqProvider<IoTDataReadOutAccepted> {
 
     @Override
-    public IoTDataReadOutAccepted parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws IOException {
+    public IoTDataReadOutAccepted parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws IOException {
         int seqNr = ParserUtils.getIntegerAttributeOrThrow(parser, "seqnr", "IoT data request <accepted/> without sequence number");
         boolean queued = ParserUtils.getBooleanAttribute(parser, "queued", false);
         return new IoTDataReadOutAccepted(seqNr, queued);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/data/provider/IoTDataRequestProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/data/provider/IoTDataRequestProvider.java
@@ -18,17 +18,18 @@ package org.jivesoftware.smackx.iot.data.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.iot.data.element.IoTDataRequest;
 
-public class IoTDataRequestProvider extends IQProvider<IoTDataRequest> {
+public class IoTDataRequestProvider extends IqProvider<IoTDataRequest> {
 
     @Override
-    public IoTDataRequest parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws IOException {
+    public IoTDataRequest parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws IOException {
         int seqNr = ParserUtils.getIntegerAttributeOrThrow(parser, "seqnr", "IoT data request without sequence number");
         boolean momentary = ParserUtils.getBooleanAttribute(parser, "momentary", false);
         return new IoTDataRequest(seqNr, momentary);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTClaimedProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTClaimedProvider.java
@@ -16,8 +16,9 @@
  */
 package org.jivesoftware.smackx.iot.discovery.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
@@ -28,10 +29,10 @@ import org.jivesoftware.smackx.iot.parser.NodeInfoParser;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-public class IoTClaimedProvider extends IQProvider<IoTClaimed> {
+public class IoTClaimedProvider extends IqProvider<IoTClaimed> {
 
     @Override
-    public IoTClaimed parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmppStringprepException {
+    public IoTClaimed parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmppStringprepException {
         Jid jid = ParserUtils.getJidAttribute(parser);
         NodeInfo nodeInfo = NodeInfoParser.parse(parser);
         return new IoTClaimed(jid, nodeInfo);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTDisownProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTDisownProvider.java
@@ -16,8 +16,9 @@
  */
 package org.jivesoftware.smackx.iot.discovery.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
@@ -28,10 +29,10 @@ import org.jivesoftware.smackx.iot.parser.NodeInfoParser;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-public class IoTDisownProvider extends IQProvider<IoTDisown> {
+public class IoTDisownProvider extends IqProvider<IoTDisown> {
 
     @Override
-    public IoTDisown parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmppStringprepException {
+    public IoTDisown parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmppStringprepException {
         Jid jid = ParserUtils.getJidAttribute(parser);
         NodeInfo nodeInfo = NodeInfoParser.parse(parser);
         return new IoTDisown(jid, nodeInfo);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTDisownedProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTDisownedProvider.java
@@ -16,18 +16,19 @@
  */
 package org.jivesoftware.smackx.iot.discovery.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.iot.discovery.element.IoTDisowned;
 import org.jivesoftware.smackx.iot.element.NodeInfo;
 import org.jivesoftware.smackx.iot.parser.NodeInfoParser;
 
-public class IoTDisownedProvider extends IQProvider<IoTDisowned> {
+public class IoTDisownedProvider extends IqProvider<IoTDisowned> {
 
     @Override
-    public IoTDisowned parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+    public IoTDisowned parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
         NodeInfo nodeInfo = NodeInfoParser.parse(parser);
         return new IoTDisowned(nodeInfo);
     }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTRegisterProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTRegisterProvider.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -31,10 +32,10 @@ import org.jivesoftware.smackx.iot.discovery.element.Tag;
 import org.jivesoftware.smackx.iot.element.NodeInfo;
 import org.jivesoftware.smackx.iot.parser.NodeInfoParser;
 
-public class IoTRegisterProvider extends IQProvider<IoTRegister> {
+public class IoTRegisterProvider extends IqProvider<IoTRegister> {
 
     @Override
-    public IoTRegister parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public IoTRegister parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         boolean selfOwned = ParserUtils.getBooleanAttribute(parser, "selfOwned", false);
         NodeInfo nodeInfo = NodeInfoParser.parse(parser);
         List<Tag> tags = new ArrayList<>();

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTRemoveProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTRemoveProvider.java
@@ -18,8 +18,9 @@ package org.jivesoftware.smackx.iot.discovery.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
@@ -30,10 +31,10 @@ import org.jivesoftware.smackx.iot.parser.NodeInfoParser;
 import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.Jid;
 
-public class IoTRemoveProvider extends IQProvider<IoTRemove> {
+public class IoTRemoveProvider extends IqProvider<IoTRemove> {
 
     @Override
-    public IoTRemove parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws IOException {
+    public IoTRemove parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws IOException {
         Jid jid = ParserUtils.getJidAttribute(parser);
         if (jid.hasResource()) {
             // TODO: Should be SmackParseException.

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTRemovedProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTRemovedProvider.java
@@ -16,18 +16,19 @@
  */
 package org.jivesoftware.smackx.iot.discovery.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.iot.discovery.element.IoTRemoved;
 import org.jivesoftware.smackx.iot.element.NodeInfo;
 import org.jivesoftware.smackx.iot.parser.NodeInfoParser;
 
-public class IoTRemovedProvider extends IQProvider<IoTRemoved> {
+public class IoTRemovedProvider extends IqProvider<IoTRemoved> {
 
     @Override
-    public IoTRemoved parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+    public IoTRemoved parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
         NodeInfo nodeInfo = NodeInfoParser.parse(parser);
         return new IoTRemoved(nodeInfo);
     }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTUnregisterProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/discovery/provider/IoTUnregisterProvider.java
@@ -16,18 +16,19 @@
  */
 package org.jivesoftware.smackx.iot.discovery.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.iot.discovery.element.IoTUnregister;
 import org.jivesoftware.smackx.iot.element.NodeInfo;
 import org.jivesoftware.smackx.iot.parser.NodeInfoParser;
 
-public class IoTUnregisterProvider extends IQProvider<IoTUnregister> {
+public class IoTUnregisterProvider extends IqProvider<IoTUnregister> {
 
     @Override
-    public IoTUnregister parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+    public IoTUnregister parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
         NodeInfo nodeInfo = NodeInfoParser.parse(parser);
         return new IoTUnregister(nodeInfo);
     }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/provider/ClearCacheProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/provider/ClearCacheProvider.java
@@ -16,16 +16,17 @@
  */
 package org.jivesoftware.smackx.iot.provisioning.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.iot.provisioning.element.ClearCache;
 
-public class ClearCacheProvider extends IQProvider<ClearCache> {
+public class ClearCacheProvider extends IqProvider<ClearCache> {
 
     @Override
-    public ClearCache parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+    public ClearCache parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
         return new ClearCache();
     }
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/provider/ClearCacheResponseProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/provider/ClearCacheResponseProvider.java
@@ -16,16 +16,17 @@
  */
 package org.jivesoftware.smackx.iot.provisioning.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.iot.provisioning.element.ClearCacheResponse;
 
-public class ClearCacheResponseProvider extends IQProvider<ClearCacheResponse> {
+public class ClearCacheResponseProvider extends IqProvider<ClearCacheResponse> {
 
     @Override
-    public ClearCacheResponse parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+    public ClearCacheResponse parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
         return new ClearCacheResponse();
     }
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/provider/IoTIsFriendProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/provider/IoTIsFriendProvider.java
@@ -16,8 +16,9 @@
  */
 package org.jivesoftware.smackx.iot.provisioning.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
@@ -26,10 +27,10 @@ import org.jivesoftware.smackx.iot.provisioning.element.IoTIsFriend;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-public class IoTIsFriendProvider extends IQProvider<IoTIsFriend> {
+public class IoTIsFriendProvider extends IqProvider<IoTIsFriend> {
 
     @Override
-    public IoTIsFriend parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmppStringprepException {
+    public IoTIsFriend parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmppStringprepException {
         Jid jid = ParserUtils.getJidAttribute(parser);
         return new IoTIsFriend(jid);
     }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/provider/IoTIsFriendResponseProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/iot/provisioning/provider/IoTIsFriendResponseProvider.java
@@ -16,8 +16,9 @@
  */
 package org.jivesoftware.smackx.iot.provisioning.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
@@ -27,10 +28,10 @@ import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-public class IoTIsFriendResponseProvider extends IQProvider<IoTIsFriendResponse> {
+public class IoTIsFriendResponseProvider extends IqProvider<IoTIsFriendResponse> {
 
     @Override
-    public IoTIsFriendResponse parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmppStringprepException {
+    public IoTIsFriendResponse parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmppStringprepException {
         Jid jid = ParserUtils.getJidAttribute(parser);
         BareJid bareJid = jid.asBareJid();
         boolean result = ParserUtils.getBooleanAttribute(parser, "result");

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/jid_prep/provider/JidPrepIqProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/jid_prep/provider/JidPrepIqProvider.java
@@ -18,18 +18,19 @@ package org.jivesoftware.smackx.jid_prep.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
 import org.jivesoftware.smackx.jid_prep.element.JidPrepIq;
 
-public class JidPrepIqProvider extends IQProvider<JidPrepIq> {
+public class JidPrepIqProvider extends IqProvider<JidPrepIq> {
 
     @Override
-    public JidPrepIq parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+    public JidPrepIq parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                     throws XmlPullParserException, IOException, SmackParsingException {
         String jid = parser.nextText();
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamFinIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamFinIQProvider.java
@@ -18,9 +18,10 @@ package org.jivesoftware.smackx.mam.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -38,10 +39,10 @@ import org.jivesoftware.smackx.rsm.provider.RSMSetProvider;
  * @author Fernando Ramirez
  *
  */
-public class MamFinIQProvider extends IQProvider<MamFinIQ> {
+public class MamFinIQProvider extends IqProvider<MamFinIQ> {
 
     @Override
-    public MamFinIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public MamFinIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
         MamElementFactory elementFactory = MamElementFactory.forParser(parser);
         String queryId = parser.getAttributeValue("", "queryid");
         boolean complete = ParserUtils.getBooleanAttribute(parser, "complete", false);

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamPrefsIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamPrefsIQProvider.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -40,12 +41,12 @@ import org.jxmpp.jid.impl.JidCreate;
  * @author Fernando Ramirez
  *
  */
-public class MamPrefsIQProvider extends IQProvider<MamPrefsIQ> {
+public class MamPrefsIQProvider extends IqProvider<MamPrefsIQ> {
 
     public static final MamPrefsIQProvider INSTANCE = new MamPrefsIQProvider();
 
     @Override
-    public MamPrefsIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public MamPrefsIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         MamElementFactory elementFactory =  MamElementFactory.forParser(parser);
         String defaultBehaviorString = parser.getAttributeValue("", "default");
         DefaultBehavior defaultBehavior = null;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamQueryIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/mam/provider/MamQueryIQProvider.java
@@ -18,9 +18,10 @@ package org.jivesoftware.smackx.mam.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -37,10 +38,10 @@ import org.jivesoftware.smackx.xdata.provider.DataFormProvider;
  * @author Fernando Ramirez
  *
  */
-public class MamQueryIQProvider extends IQProvider<MamQueryIQ> {
+public class MamQueryIQProvider extends IqProvider<MamQueryIQ> {
 
     @Override
-    public MamQueryIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+    public MamQueryIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                     throws XmlPullParserException, IOException, SmackParsingException {
         MamElementFactory elementFactory = MamElementFactory.forParser(parser);
         DataForm dataForm = null;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightAffiliationsIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightAffiliationsIQProvider.java
@@ -19,8 +19,9 @@ package org.jivesoftware.smackx.muclight.provider;
 import java.io.IOException;
 import java.util.HashMap;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -36,10 +37,10 @@ import org.jxmpp.jid.impl.JidCreate;
  * @author Fernando Ramirez
  *
  */
-public class MUCLightAffiliationsIQProvider extends IQProvider<MUCLightAffiliationsIQ> {
+public class MUCLightAffiliationsIQProvider extends IqProvider<MUCLightAffiliationsIQ> {
 
     @Override
-    public MUCLightAffiliationsIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public MUCLightAffiliationsIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         String version = null;
         HashMap<Jid, MUCLightAffiliation> occupants = new HashMap<>();
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightBlockingIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightBlockingIQProvider.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.util.HashMap;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -37,10 +38,10 @@ import org.jxmpp.stringprep.XmppStringprepException;
  * @author Fernando Ramirez
  *
  */
-public class MUCLightBlockingIQProvider extends IQProvider<MUCLightBlockingIQ> {
+public class MUCLightBlockingIQProvider extends IqProvider<MUCLightBlockingIQ> {
 
     @Override
-    public MUCLightBlockingIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public MUCLightBlockingIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         HashMap<Jid, Boolean> rooms = null;
         HashMap<Jid, Boolean> users = null;
 

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightConfigurationIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightConfigurationIQProvider.java
@@ -19,8 +19,9 @@ package org.jivesoftware.smackx.muclight.provider;
 import java.io.IOException;
 import java.util.HashMap;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -33,10 +34,10 @@ import org.jivesoftware.smackx.muclight.element.MUCLightConfigurationIQ;
  * @author Fernando Ramirez
  *
  */
-public class MUCLightConfigurationIQProvider extends IQProvider<MUCLightConfigurationIQ> {
+public class MUCLightConfigurationIQProvider extends IqProvider<MUCLightConfigurationIQ> {
 
     @Override
-    public MUCLightConfigurationIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public MUCLightConfigurationIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         String version = null;
         String roomName = null;
         String subject = null;

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightInfoIQProvider.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/muclight/provider/MUCLightInfoIQProvider.java
@@ -19,8 +19,9 @@ package org.jivesoftware.smackx.muclight.provider;
 import java.io.IOException;
 import java.util.HashMap;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -37,10 +38,10 @@ import org.jxmpp.jid.impl.JidCreate;
  * @author Fernando Ramirez
  *
  */
-public class MUCLightInfoIQProvider extends IQProvider<MUCLightInfoIQ> {
+public class MUCLightInfoIQProvider extends IqProvider<MUCLightInfoIQ> {
 
     @Override
-    public MUCLightInfoIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public MUCLightInfoIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         String version = null;
         String roomName = null;
         String subject = null;

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/hoxt/provider/AbstractHttpOverXmppProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/hoxt/provider/AbstractHttpOverXmppProviderTest.java
@@ -63,7 +63,7 @@ public class AbstractHttpOverXmppProviderTest {
         HttpOverXmppRespProvider provider = new HttpOverXmppRespProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(string);
 
-        IQ iq = provider.parse(parser);
+        IQ iq = provider.parse(parser, null);
         assertTrue(iq instanceof HttpOverXmppResp);
         HttpOverXmppResp body = (HttpOverXmppResp) iq;
 
@@ -83,7 +83,7 @@ public class AbstractHttpOverXmppProviderTest {
         HttpOverXmppReqProvider provider = new HttpOverXmppReqProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(string);
 
-        IQ iq = provider.parse(parser);
+        IQ iq = provider.parse(parser, null);
         assertTrue(iq instanceof HttpOverXmppReq);
         HttpOverXmppReq body = (HttpOverXmppReq) iq;
 
@@ -205,7 +205,7 @@ public class AbstractHttpOverXmppProviderTest {
         HttpOverXmppRespProvider provider = new HttpOverXmppRespProvider();
         XmlPullParser parser = SmackTestUtil.getParserFor(string, tag, parserKind);
 
-        IQ iq = provider.parse(parser);
+        IQ iq = provider.parse(parser, null);
         assertTrue(iq instanceof HttpOverXmppResp);
         return (HttpOverXmppResp) iq;
     }

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/hoxt/provider/HttpOverXmppReqProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/hoxt/provider/HttpOverXmppReqProviderTest.java
@@ -70,7 +70,7 @@ public class HttpOverXmppReqProviderTest {
     private static HttpOverXmppReq parseReq(String string) throws Exception {
         HttpOverXmppReqProvider provider = new HttpOverXmppReqProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(string);
-        IQ iq = provider.parse(parser);
+        IQ iq = provider.parse(parser, null);
         assertTrue(iq instanceof HttpOverXmppReq);
         return  (HttpOverXmppReq) iq;
     }

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/hoxt/provider/HttpOverXmppRespProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/hoxt/provider/HttpOverXmppRespProviderTest.java
@@ -39,7 +39,7 @@ public class HttpOverXmppRespProviderTest {
         HttpOverXmppRespProvider provider = new HttpOverXmppRespProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(string);
 
-        IQ iq = provider.parse(parser);
+        IQ iq = provider.parse(parser, null);
         assertTrue(iq instanceof HttpOverXmppResp);
         HttpOverXmppResp resp = (HttpOverXmppResp) iq;
 
@@ -54,7 +54,7 @@ public class HttpOverXmppRespProviderTest {
         HttpOverXmppRespProvider provider = new HttpOverXmppRespProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(string);
 
-        IQ iq = provider.parse(parser);
+        IQ iq = provider.parse(parser, null);
         assertTrue(iq instanceof HttpOverXmppResp);
         HttpOverXmppResp resp = (HttpOverXmppResp) iq;
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamFinProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamFinProviderTest.java
@@ -40,7 +40,7 @@ public class MamFinProviderTest extends MamTest {
     @Test
     public void checkMamFinProvider() throws Exception {
         XmlPullParser parser = PacketParserUtils.getParserFor(exmapleMamFinXml);
-        MamFinIQ mamFinIQ = new MamFinIQProvider().parse(parser);
+        MamFinIQ mamFinIQ = new MamFinIQProvider().parse(parser, null);
 
         assertFalse(mamFinIQ.isComplete());
         assertTrue(mamFinIQ.isStable());

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamPrefIQProviderTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/mam/MamPrefIQProviderTest.java
@@ -60,21 +60,21 @@ public class MamPrefIQProviderTest extends MamTest {
     public void checkMamPrefsIQProvider(XmlPullParserKind parserKind)
                     throws XmlPullParserException, IOException, SmackParsingException {
         XmlPullParser parser1 = SmackTestUtil.getParserFor(exampleMamPrefsIQ1, parserKind);
-        MamPrefsIQ mamPrefIQ1 = MamPrefsIQProvider.INSTANCE.parse(parser1);
+        MamPrefsIQ mamPrefIQ1 = MamPrefsIQProvider.INSTANCE.parse(parser1, null);
 
         assertEquals(IQ.Type.set, mamPrefIQ1.getType());
         assertEquals(mamPrefIQ1.getAlwaysJids().get(0).toString(), "romeo@montague.lit");
         assertEquals(mamPrefIQ1.getNeverJids().get(0).toString(), "montague@montague.lit");
 
         XmlPullParser parser2 = SmackTestUtil.getParserFor(exampleMamPrefsIQ2, parserKind);
-        MamPrefsIQ mamPrefIQ2 = MamPrefsIQProvider.INSTANCE.parse(parser2);
+        MamPrefsIQ mamPrefIQ2 = MamPrefsIQProvider.INSTANCE.parse(parser2, null);
         assertEquals(IQ.Type.set, mamPrefIQ2.getType());
         assertEquals(mamPrefIQ2.getAlwaysJids().get(0).toString(), "romeo@montague.lit");
         assertEquals(mamPrefIQ2.getAlwaysJids().get(1).toString(), "montague@montague.lit");
         assertTrue(mamPrefIQ2.getNeverJids().isEmpty());
 
         XmlPullParser parser3 = SmackTestUtil.getParserFor(exampleMamPrefsIQ3, parserKind);
-        MamPrefsIQ mamPrefIQ3 = MamPrefsIQProvider.INSTANCE.parse(parser3);
+        MamPrefsIQ mamPrefIQ3 = MamPrefsIQProvider.INSTANCE.parse(parser3, null);
         assertEquals(IQ.Type.set, mamPrefIQ3.getType());
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/provider/BlockContactsIQProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/provider/BlockContactsIQProvider.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -37,10 +38,10 @@ import org.jxmpp.jid.Jid;
  * @see <a href="http://xmpp.org/extensions/xep-0191.html">XEP-0191: Blocking
  *      Command</a>
  */
-public class BlockContactsIQProvider extends IQProvider<BlockContactsIQ> {
+public class BlockContactsIQProvider extends IqProvider<BlockContactsIQ> {
 
     @Override
-    public BlockContactsIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public BlockContactsIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         List<Jid> jids = new ArrayList<>();
 
         outerloop: while (true) {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/provider/BlockListIQProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/provider/BlockListIQProvider.java
@@ -21,8 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -38,10 +39,10 @@ import org.jxmpp.jid.Jid;
  * @see <a href="http://xmpp.org/extensions/xep-0191.html">XEP-0191: Blocking
  *      Command</a>
  */
-public class BlockListIQProvider extends IQProvider<BlockListIQ> {
+public class BlockListIQProvider extends IqProvider<BlockListIQ> {
 
     @Override
-    public BlockListIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public BlockListIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         List<Jid> jids = null;
 
         outerloop: while (true) {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/provider/UnblockContactsIQProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/blocking/provider/UnblockContactsIQProvider.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -37,10 +38,10 @@ import org.jxmpp.jid.impl.JidCreate;
  * @see <a href="http://xmpp.org/extensions/xep-0191.html">XEP-0191: Blocking
  *      Command</a>
  */
-public class UnblockContactsIQProvider extends IQProvider<UnblockContactsIQ> {
+public class UnblockContactsIQProvider extends IqProvider<UnblockContactsIQ> {
 
     @Override
-    public UnblockContactsIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public UnblockContactsIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         List<Jid> jids = null;
 
         outerloop: while (true) {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bob/provider/BoBIQProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bob/provider/BoBIQProvider.java
@@ -18,8 +18,9 @@ package org.jivesoftware.smackx.bob.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.Pair;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -35,10 +36,10 @@ import org.jivesoftware.smackx.bob.element.BoBIQ;
  * @see <a href="http://xmpp.org/extensions/xep-0231.html">XEP-0231: Bits of
  *      Binary</a>
  */
-public class BoBIQProvider extends IQProvider<BoBIQ> {
+public class BoBIQProvider extends IqProvider<BoBIQ> {
 
     @Override
-    public BoBIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public BoBIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         Pair<ContentId, BoBData> parserResult = BoBProviderUtil.parseContentIdAndBobData(parser, initialDepth,
                         xmlEnvironment);
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/provider/CloseIQProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/provider/CloseIQProvider.java
@@ -16,8 +16,9 @@
  */
 package org.jivesoftware.smackx.bytestreams.ibb.provider;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 
 import org.jivesoftware.smackx.bytestreams.ibb.packet.Close;
@@ -27,10 +28,10 @@ import org.jivesoftware.smackx.bytestreams.ibb.packet.Close;
  *
  * @author Henning Staib
  */
-public class CloseIQProvider extends IQProvider<Close> {
+public class CloseIQProvider extends IqProvider<Close> {
 
     @Override
-    public Close parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+    public Close parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) {
         String sid = parser.getAttributeValue("", "sid");
         return new Close(sid);
     }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/provider/DataPacketProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/provider/DataPacketProvider.java
@@ -19,6 +19,7 @@ package org.jivesoftware.smackx.bytestreams.ibb.provider;
 import java.io.IOException;
 
 import org.jivesoftware.smack.datatypes.UInt16;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.parsing.SmackParsingException.RequiredAttributeMissingException;
@@ -37,12 +38,12 @@ import org.jivesoftware.smackx.bytestreams.ibb.packet.DataPacketExtension;
  */
 public class DataPacketProvider {
 
-    public static class IQProvider extends org.jivesoftware.smack.provider.IQProvider<Data> {
+    public static class IQProvider extends org.jivesoftware.smack.provider.IqProvider<Data> {
 
         private static final PacketExtensionProvider packetExtensionProvider = new PacketExtensionProvider();
 
         @Override
-        public Data parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+        public Data parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                         throws IOException, XmlPullParserException, SmackParsingException {
             DataPacketExtension data = packetExtensionProvider.parse(parser);
             return new Data(data);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/provider/OpenIQProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/provider/OpenIQProvider.java
@@ -19,8 +19,9 @@ package org.jivesoftware.smackx.bytestreams.ibb.provider;
 import java.io.IOException;
 import java.util.Locale;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -32,10 +33,10 @@ import org.jivesoftware.smackx.bytestreams.ibb.packet.Open;
  *
  * @author Henning Staib
  */
-public class OpenIQProvider extends IQProvider<Open> {
+public class OpenIQProvider extends IqProvider<Open> {
 
     @Override
-    public Open parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public Open parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         String sessionID = parser.getAttributeValue("", "sid");
         int blockSize = Integer.parseInt(parser.getAttributeValue("", "block-size"));
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/provider/BytestreamsProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/provider/BytestreamsProvider.java
@@ -18,8 +18,9 @@ package org.jivesoftware.smackx.bytestreams.socks5.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -34,10 +35,10 @@ import org.jxmpp.jid.Jid;
  *
  * @author Alexander Wenckus
  */
-public class BytestreamsProvider extends IQProvider<Bytestream> {
+public class BytestreamsProvider extends IqProvider<Bytestream> {
 
     @Override
-    public Bytestream parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+    public Bytestream parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                     throws XmlPullParserException, IOException {
         boolean done = false;
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/provider/AdHocCommandDataProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/provider/AdHocCommandDataProvider.java
@@ -19,11 +19,12 @@ package org.jivesoftware.smackx.commands.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -39,10 +40,10 @@ import org.jivesoftware.smackx.xdata.provider.DataFormProvider;
  *
  * @author Gabriel Guardincerri
  */
-public class AdHocCommandDataProvider extends IQProvider<AdHocCommandData> {
+public class AdHocCommandDataProvider extends IqProvider<AdHocCommandData> {
 
     @Override
-    public AdHocCommandData parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public AdHocCommandData parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
         boolean done = false;
         AdHocCommandData adHocCommandData = new AdHocCommandData();
         DataFormProvider dataFormProvider = new DataFormProvider();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/provider/DiscoverItemsProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/provider/DiscoverItemsProvider.java
@@ -19,8 +19,9 @@ package org.jivesoftware.smackx.disco.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -34,10 +35,10 @@ import org.jxmpp.jid.Jid;
 *
 * @author Gaston Dombiak
 */
-public class DiscoverItemsProvider extends IQProvider<DiscoverItems> {
+public class DiscoverItemsProvider extends IqProvider<DiscoverItems> {
 
     @Override
-    public DiscoverItems parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+    public DiscoverItems parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                     throws XmlPullParserException, IOException {
         DiscoverItems discoverItems = new DiscoverItems();
         boolean done = false;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqlast/packet/LastActivity.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqlast/packet/LastActivity.java
@@ -20,8 +20,9 @@ package org.jivesoftware.smackx.iqlast.packet;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -100,10 +101,10 @@ public class LastActivity extends IQ {
      *
      * @author Derek DeMoro
      */
-    public static class Provider extends IQProvider<LastActivity> {
+    public static class Provider extends IqProvider<LastActivity> {
 
         @Override
-        public LastActivity parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public LastActivity parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             LastActivity lastActivity = new LastActivity();
             String seconds = parser.getAttributeValue("", "seconds");
             if (seconds != null) {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqprivate/PrivateDataManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqprivate/PrivateDataManager.java
@@ -31,9 +31,10 @@ import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.StanzaError.Condition;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -234,10 +235,10 @@ public final class PrivateDataManager extends Manager {
     /**
      * An IQ provider to parse IQ results containing private data.
      */
-    public static class PrivateDataIQProvider extends IQProvider<PrivateDataIQ> {
+    public static class PrivateDataIQProvider extends IqProvider<PrivateDataIQ> {
 
         @Override
-        public PrivateDataIQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+        public PrivateDataIQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                         throws XmlPullParserException, IOException {
             PrivateData privateData = null;
             boolean done = false;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqregister/provider/RegistrationProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqregister/provider/RegistrationProvider.java
@@ -23,20 +23,21 @@ import java.util.List;
 import java.util.Map;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlElement;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
 import org.jivesoftware.smackx.iqregister.packet.Registration;
 
-public class RegistrationProvider extends IQProvider<Registration> {
+public class RegistrationProvider extends IqProvider<Registration> {
 
     @Override
-    public Registration parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public Registration parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
         String instruction = null;
         Map<String, String> fields = new HashMap<>();
         List<XmlElement> packetExtensions = new LinkedList<>();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/provider/MUCAdminProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/provider/MUCAdminProvider.java
@@ -19,8 +19,9 @@ package org.jivesoftware.smackx.muc.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -31,10 +32,10 @@ import org.jivesoftware.smackx.muc.packet.MUCAdmin;
  *
  * @author Gaston Dombiak
  */
-public class MUCAdminProvider extends IQProvider<MUCAdmin> {
+public class MUCAdminProvider extends IqProvider<MUCAdmin> {
 
     @Override
-    public MUCAdmin parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+    public MUCAdmin parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                     throws XmlPullParserException, IOException {
         MUCAdmin mucAdmin = new MUCAdmin();
         boolean done = false;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/provider/MUCOwnerProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/provider/MUCOwnerProvider.java
@@ -19,9 +19,10 @@ package org.jivesoftware.smackx.muc.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -33,10 +34,10 @@ import org.jivesoftware.smackx.muc.packet.MUCOwner;
  *
  * @author Gaston Dombiak
  */
-public class MUCOwnerProvider extends IQProvider<MUCOwner> {
+public class MUCOwnerProvider extends IqProvider<MUCOwner> {
 
     @Override
-    public MUCOwner parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public MUCOwner parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
         MUCOwner mucOwner = new MUCOwner();
         boolean done = false;
         while (!done) {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/offline/packet/OfflineMessageRequest.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/offline/packet/OfflineMessageRequest.java
@@ -23,8 +23,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -197,11 +198,11 @@ public class OfflineMessageRequest extends IQ {
         }
     }
 
-    public static class Provider extends IQProvider<OfflineMessageRequest> {
+    public static class Provider extends IqProvider<OfflineMessageRequest> {
 
         @Override
         public OfflineMessageRequest parse(XmlPullParser parser,
-                        int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException,
+                        int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException,
                         IOException {
             OfflineMessageRequest request = new OfflineMessageRequest();
             boolean done = false;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/ping/provider/PingProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/ping/provider/PingProvider.java
@@ -18,17 +18,18 @@ package org.jivesoftware.smackx.ping.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
 import org.jivesoftware.smackx.ping.packet.Ping;
 
-public class PingProvider extends IQProvider<Ping> {
+public class PingProvider extends IqProvider<Ping> {
 
     @Override
-    public Ping parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public Ping parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         // No need to use the ping constructor with arguments. IQ will already
         // have filled out all relevant fields ('from', 'to', 'id').
         return new Ping();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/provider/PrivacyProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/privacy/provider/PrivacyProvider.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import org.jivesoftware.smack.datatypes.UInt32;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -37,10 +38,10 @@ import org.jivesoftware.smackx.privacy.packet.PrivacyItem;
  *
  * @author Francisco Vives
  */
-public class PrivacyProvider extends IQProvider<Privacy> {
+public class PrivacyProvider extends IqProvider<Privacy> {
 
     @Override
-    public Privacy parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+    public Privacy parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                     throws XmlPullParserException, IOException {
         Privacy privacy = new Privacy();
         boolean done = false;

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/provider/PubSubProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/provider/PubSubProvider.java
@@ -19,9 +19,10 @@ package org.jivesoftware.smackx.pubsub.provider;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -35,9 +36,9 @@ import org.jivesoftware.smackx.pubsub.packet.PubSubNamespace;
  *
  * @author Robin Collier
  */
-public class PubSubProvider extends IQProvider<PubSub> {
+public class PubSubProvider extends IqProvider<PubSub> {
     @Override
-    public PubSub parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public PubSub parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
         String namespace = parser.getNamespace();
         PubSubNamespace pubSubNamespace = PubSubNamespace.valueOfFromXmlns(namespace);
         PubSub pubsub = new PubSub(pubSubNamespace);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/search/UserSearch.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/search/UserSearch.java
@@ -23,10 +23,11 @@ import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.SimpleIQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -124,11 +125,11 @@ public class UserSearch extends SimpleIQ {
     /**
      * Internal Search service Provider.
      */
-    public static class Provider extends IQProvider<IQ> {
+    public static class Provider extends IqProvider<IQ> {
 
         // FIXME this provider does return two different types of IQs
         @Override
-        public IQ parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+        public IQ parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
             UserSearch search = null;
             SimpleUserSearch simpleUserSearch = new SimpleUserSearch();
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/sharedgroups/packet/SharedGroupsInfo.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/sharedgroups/packet/SharedGroupsInfo.java
@@ -21,8 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -67,10 +68,10 @@ public class SharedGroupsInfo extends IQ {
     /**
      * Internal Search service Provider.
      */
-    public static class Provider extends IQProvider<SharedGroupsInfo> {
+    public static class Provider extends IqProvider<SharedGroupsInfo> {
 
         @Override
-        public SharedGroupsInfo parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+        public SharedGroupsInfo parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                         throws XmlPullParserException, IOException {
             SharedGroupsInfo groupsInfo = new SharedGroupsInfo();
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/si/provider/StreamInitiationProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/si/provider/StreamInitiationProvider.java
@@ -22,9 +22,10 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -41,11 +42,11 @@ import org.jxmpp.util.XmppDateTime;
  * @author Alexander Wenckus
  *
  */
-public class StreamInitiationProvider extends IQProvider<StreamInitiation> {
+public class StreamInitiationProvider extends IqProvider<StreamInitiation> {
     private static final Logger LOGGER = Logger.getLogger(StreamInitiationProvider.class.getName());
 
     @Override
-    public StreamInitiation parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public StreamInitiation parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
         // si
         String id = parser.getAttributeValue("", "id");
         String mimeType = parser.getAttributeValue("", "mime-type");

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
@@ -18,8 +18,9 @@ package org.jivesoftware.smackx.vcardtemp.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -33,7 +34,7 @@ import org.jivesoftware.smackx.vcardtemp.packet.VCard;
  * @author Derek DeMoro
  * @author Chris Deering
  */
-public class VCardProvider extends IQProvider<VCard> {
+public class VCardProvider extends IqProvider<VCard> {
 
     // @formatter:off
     private static final String[] ADR = new String[] {
@@ -68,7 +69,7 @@ public class VCardProvider extends IQProvider<VCard> {
     // @formatter:on
 
     @Override
-    public VCard parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public VCard parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         VCard vCard = new VCard();
         String name = null;
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/provider/DataFormProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/provider/DataFormProvider.java
@@ -115,7 +115,7 @@ public class DataFormProvider extends ExtensionElementProvider<DataForm> {
                 // See XEP-133 Example 32 for a corner case where the data form contains this extension.
                 case RosterPacket.ELEMENT:
                     if (namespace.equals(RosterPacket.NAMESPACE)) {
-                        dataForm.addExtensionElement(RosterPacketProvider.INSTANCE.parse(parser));
+                        dataForm.addExtensionElement(RosterPacketProvider.INSTANCE.parse(parser, null));
                     }
                     break;
                 // See XEP-141 Data Forms Layout

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/provider/OpenIQProviderTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/bytestreams/ibb/provider/OpenIQProviderTest.java
@@ -53,7 +53,7 @@ public class OpenIQProviderTest extends SmackTestSuite {
 
         OpenIQProvider oip = new OpenIQProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(control);
-        Open open = oip.parse(parser);
+        Open open = oip.parse(parser, null);
 
         assertEquals(StanzaType.IQ, open.getStanza());
     }
@@ -69,7 +69,7 @@ public class OpenIQProviderTest extends SmackTestSuite {
 
         OpenIQProvider oip = new OpenIQProvider();
         XmlPullParser parser = PacketParserUtils.getParserFor(control);
-        Open open = oip.parse(parser);
+        Open open = oip.parse(parser, null);
 
         assertEquals(StanzaType.MESSAGE, open.getStanza());
     }

--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/provider/RosterPacketProvider.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/provider/RosterPacketProvider.java
@@ -19,8 +19,9 @@ package org.jivesoftware.smack.roster.provider;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.roster.packet.RosterPacket;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -29,12 +30,12 @@ import org.jivesoftware.smack.xml.XmlPullParserException;
 import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.impl.JidCreate;
 
-public class RosterPacketProvider extends IQProvider<RosterPacket> {
+public class RosterPacketProvider extends IqProvider<RosterPacket> {
 
     public static final RosterPacketProvider INSTANCE = new RosterPacketProvider();
 
     @Override
-    public RosterPacket parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public RosterPacket parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         RosterPacket roster = new RosterPacket();
         String version = parser.getAttributeValue("", "ver");
         roster.setVersion(version);

--- a/smack-jingle-old/src/integration-test/java/org/jivesoftware/smackx/jingle/provider/JingleProviderTest.java
+++ b/smack-jingle-old/src/integration-test/java/org/jivesoftware/smackx/jingle/provider/JingleProviderTest.java
@@ -19,7 +19,7 @@ import org.jivesoftware.smack.SmackConfiguration;
 import org.jivesoftware.smack.filter.PacketFilter;
 import org.jivesoftware.smack.filter.StanzaTypeFilter;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.provider.ProviderManager;
 import org.jivesoftware.smack.test.SmackTestCase;
 import org.jivesoftware.smackx.jingle.packet.Jingle;

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/RTPBridge.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/RTPBridge.java
@@ -30,8 +30,9 @@ import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.provider.ProviderManager;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -330,10 +331,10 @@ public class RTPBridge extends IQ {
      *
      * @author Thiago Rocha
      */
-    public static class Provider extends IQProvider<RTPBridge> {
+    public static class Provider extends IqProvider<RTPBridge> {
 
         @Override
-        public RTPBridge parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+        public RTPBridge parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                         throws XmlPullParserException,
                         IOException {
 

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/STUN.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/nat/STUN.java
@@ -27,9 +27,10 @@ import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.SimpleIQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.provider.ProviderManager;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -118,10 +119,10 @@ public class STUN extends SimpleIQ {
      *
      * @author Thiago Rocha
      */
-    public static class Provider extends IQProvider<STUN> {
+    public static class Provider extends IqProvider<STUN> {
 
         @Override
-        public STUN parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+        public STUN parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                         throws XmlPullParserException,
                         IOException {
 

--- a/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/provider/JingleProvider.java
+++ b/smack-jingle-old/src/main/java/org/jivesoftware/smackx/jingleold/provider/JingleProvider.java
@@ -19,10 +19,11 @@ package org.jivesoftware.smackx.jingleold.provider;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -41,7 +42,7 @@ import org.jxmpp.jid.Jid;
  *
  * @author Alvaro Saurin
  */
-public class JingleProvider extends IQProvider<Jingle> {
+public class JingleProvider extends IqProvider<Jingle> {
 
     /**
      * Parse a iq/jingle element.
@@ -50,7 +51,7 @@ public class JingleProvider extends IQProvider<Jingle> {
      * @throws SmackParsingException if the Smack parser (provider) encountered invalid input.
      */
     @Override
-    public Jingle parse(XmlPullParser parser, int intialDepth, XmlEnvironment xmlEnvironment) throws IOException, XmlPullParserException, SmackParsingException {
+    public Jingle parse(XmlPullParser parser, int intialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws IOException, XmlPullParserException, SmackParsingException {
 
         Jingle jingle = new Jingle();
         String sid;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/agent/OfferConfirmation.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/agent/OfferConfirmation.java
@@ -22,9 +22,10 @@ import java.io.IOException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.SimpleIQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -61,10 +62,10 @@ public class OfferConfirmation extends SimpleIQ {
         con.sendStanza(packet);
     }
 
-    public static class Provider extends IQProvider<OfferConfirmation> {
+    public static class Provider extends IqProvider<OfferConfirmation> {
 
         @Override
-        public OfferConfirmation parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+        public OfferConfirmation parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                         throws XmlPullParserException, IOException {
             final OfferConfirmation confirmation = new OfferConfirmation();
 

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/forms/WorkgroupForm.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/forms/WorkgroupForm.java
@@ -19,10 +19,11 @@ package org.jivesoftware.smackx.workgroup.ext.forms;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.SimpleIQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -48,10 +49,10 @@ public class WorkgroupForm extends SimpleIQ {
      *
      * @author Derek DeMoro
      */
-    public static class InternalProvider extends IQProvider<WorkgroupForm> {
+    public static class InternalProvider extends IqProvider<WorkgroupForm> {
 
         @Override
-        public WorkgroupForm parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+        public WorkgroupForm parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
             WorkgroupForm answer = new WorkgroupForm();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/history/AgentChatHistory.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/history/AgentChatHistory.java
@@ -24,8 +24,9 @@ import java.util.Date;
 import java.util.List;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -91,10 +92,10 @@ public class AgentChatHistory extends IQ {
     /**
      * Stanza extension provider for AgentHistory packets.
      */
-    public static class InternalProvider extends IQProvider<AgentChatHistory> {
+    public static class InternalProvider extends IqProvider<AgentChatHistory> {
 
         @Override
-        public AgentChatHistory parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public AgentChatHistory parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             if (parser.getEventType() != XmlPullParser.Event.START_ELEMENT) {
                 throw new IllegalStateException("Parser not in proper position, or bad XML.");
             }

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/history/ChatMetadata.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/history/ChatMetadata.java
@@ -23,8 +23,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -81,10 +82,10 @@ public class ChatMetadata extends IQ {
      *
      * @author Derek DeMoro
      */
-    public static class Provider extends IQProvider<ChatMetadata> {
+    public static class Provider extends IqProvider<ChatMetadata> {
 
         @Override
-        public ChatMetadata parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+        public ChatMetadata parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                         throws XmlPullParserException, IOException {
             final ChatMetadata chatM = new ChatMetadata();
 

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/macros/Macros.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/macros/Macros.java
@@ -20,8 +20,9 @@ package org.jivesoftware.smackx.workgroup.ext.macros;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -96,10 +97,10 @@ public class Macros extends IQ {
      *
      * @author Derek DeMoro
      */
-    public static class InternalProvider extends IQProvider<Macros> {
+    public static class InternalProvider extends IqProvider<Macros> {
 
         @Override
-        public Macros parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public Macros parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             Macros macroGroup = new Macros();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/notes/ChatNotes.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/ext/notes/ChatNotes.java
@@ -20,8 +20,9 @@ package org.jivesoftware.smackx.workgroup.ext.notes;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -81,10 +82,10 @@ public class ChatNotes extends IQ {
      *
      * @author Derek DeMoro
      */
-    public static class Provider extends IQProvider<ChatNotes> {
+    public static class Provider extends IqProvider<ChatNotes> {
 
         @Override
-        public ChatNotes parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public ChatNotes parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             ChatNotes chatNotes = new ChatNotes();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/AgentInfo.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/AgentInfo.java
@@ -20,8 +20,9 @@ package org.jivesoftware.smackx.workgroup.packet;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -104,10 +105,10 @@ public class AgentInfo extends IQ {
      *
      * @author Gaston Dombiak
      */
-    public static class Provider extends IQProvider<AgentInfo> {
+    public static class Provider extends IqProvider<AgentInfo> {
 
         @Override
-        public AgentInfo parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public AgentInfo parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             AgentInfo answer = new AgentInfo();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/AgentStatusRequest.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/AgentStatusRequest.java
@@ -24,8 +24,9 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -111,10 +112,10 @@ public class AgentStatusRequest extends IQ {
     /**
      * Stanza extension provider for AgentStatusRequest packets.
      */
-    public static class Provider extends IQProvider<AgentStatusRequest> {
+    public static class Provider extends IqProvider<AgentStatusRequest> {
 
         @Override
-        public AgentStatusRequest parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public AgentStatusRequest parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             AgentStatusRequest statusRequest = new AgentStatusRequest();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/AgentWorkgroups.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/AgentWorkgroups.java
@@ -24,8 +24,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -103,10 +104,10 @@ public class AgentWorkgroups extends IQ {
      *
      * @author Gaston Dombiak
      */
-    public static class Provider extends IQProvider<AgentWorkgroups> {
+    public static class Provider extends IqProvider<AgentWorkgroups> {
 
         @Override
-        public AgentWorkgroups parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public AgentWorkgroups parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             final Jid agentJID = ParserUtils.getJidAttribute(parser);
             List<String> workgroups = new ArrayList<>();
 

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/MonitorPacket.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/MonitorPacket.java
@@ -19,8 +19,9 @@ package org.jivesoftware.smackx.workgroup.packet;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -75,10 +76,10 @@ public class MonitorPacket extends IQ {
     /**
      * Stanza extension provider for Monitor Packets.
      */
-    public static class InternalProvider extends IQProvider<MonitorPacket> {
+    public static class InternalProvider extends IqProvider<MonitorPacket> {
 
         @Override
-        public MonitorPacket parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public MonitorPacket parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             MonitorPacket packet = new MonitorPacket();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OccupantsInfo.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OccupantsInfo.java
@@ -27,8 +27,9 @@ import java.util.Set;
 import java.util.TimeZone;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -132,10 +133,10 @@ public class OccupantsInfo extends IQ {
     /**
      * Stanza extension provider for AgentStatusRequest packets.
      */
-    public static class Provider extends IQProvider<OccupantsInfo> {
+    public static class Provider extends IqProvider<OccupantsInfo> {
 
         @Override
-        public OccupantsInfo parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+        public OccupantsInfo parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                         throws XmlPullParserException, IOException, ParseException {
             OccupantsInfo occupantsInfo = new OccupantsInfo(parser.getAttributeValue("", "roomID"));
 

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OfferRequestProvider.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OfferRequestProvider.java
@@ -23,9 +23,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
@@ -45,14 +46,14 @@ import org.jxmpp.jid.Jid;
  *
  * @author loki der quaeler
  */
-public class OfferRequestProvider extends IQProvider<IQ> {
+public class OfferRequestProvider extends IqProvider<IQ> {
     // FIXME It seems because OfferRequestPacket is also defined here, we can
     // not add it as generic to the provider, the provider and the packet should
     // be split, but since this is legacy code, I don't think that this will
     // happen anytime soon.
 
     @Override
-    public OfferRequestPacket parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public OfferRequestPacket parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
         XmlPullParser.Event eventType = parser.getEventType();
         String sessionID = null;
         int timeout = -1;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OfferRevokeProvider.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/OfferRevokeProvider.java
@@ -20,8 +20,9 @@ package org.jivesoftware.smackx.workgroup.packet;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -33,10 +34,10 @@ import org.jxmpp.jid.Jid;
  *
  * @author loki der quaeler
  */
-public class OfferRevokeProvider extends IQProvider<IQ> {
+public class OfferRevokeProvider extends IqProvider<IQ> {
 
     @Override
-    public OfferRevokePacket parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+    public OfferRevokePacket parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
         // The parser will be positioned on the opening IQ tag, so get the JID attribute.
         Jid userJID = ParserUtils.getJidAttribute(parser);
         // Default the userID to the JID.

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/TranscriptProvider.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/TranscriptProvider.java
@@ -21,10 +21,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -34,10 +35,10 @@ import org.jivesoftware.smack.xml.XmlPullParserException;
  *
  * @author Gaston Dombiak
  */
-public class TranscriptProvider extends IQProvider<Transcript> {
+public class TranscriptProvider extends IqProvider<Transcript> {
 
     @Override
-    public Transcript parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+    public Transcript parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
         String sessionID = parser.getAttributeValue("", "sessionID");
         List<Stanza> packets = new ArrayList<>();
 

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/TranscriptSearch.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/TranscriptSearch.java
@@ -19,10 +19,11 @@ package org.jivesoftware.smackx.workgroup.packet;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.SimpleIQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
 import org.jivesoftware.smack.parsing.SmackParsingException;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -54,10 +55,10 @@ public class TranscriptSearch extends SimpleIQ {
      *
      * @author Gaston Dombiak
      */
-    public static class Provider extends IQProvider<TranscriptSearch> {
+    public static class Provider extends IqProvider<TranscriptSearch> {
 
         @Override
-        public TranscriptSearch parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
+        public TranscriptSearch parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException, SmackParsingException {
             TranscriptSearch answer = new TranscriptSearch();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/TranscriptsProvider.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/packet/TranscriptsProvider.java
@@ -25,8 +25,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.ParserUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -38,7 +39,7 @@ import org.jxmpp.jid.Jid;
  *
  * @author Gaston Dombiak
  */
-public class TranscriptsProvider extends IQProvider<Transcripts> {
+public class TranscriptsProvider extends IqProvider<Transcripts> {
 
     @SuppressWarnings("DateFormatConstant")
     private static final SimpleDateFormat UTC_FORMAT = new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss");
@@ -47,7 +48,7 @@ public class TranscriptsProvider extends IQProvider<Transcripts> {
     }
 
     @Override
-    public Transcripts parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
+    public Transcripts parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
                     throws XmlPullParserException, IOException, TextParseException, ParseException {
         Jid userID = ParserUtils.getJidAttribute(parser, "userID");
         List<Transcripts.TranscriptSummary> summaries = new ArrayList<>();

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/ChatSettings.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/ChatSettings.java
@@ -24,8 +24,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
 
@@ -123,10 +124,10 @@ public class ChatSettings extends IQ {
     /**
      * Stanza extension provider for AgentStatusRequest packets.
      */
-    public static class InternalProvider extends IQProvider<ChatSettings> {
+    public static class InternalProvider extends IqProvider<ChatSettings> {
 
         @Override
-        public ChatSettings parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public ChatSettings parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             if (parser.getEventType() != XmlPullParser.Event.START_ELEMENT) {
                 throw new IllegalStateException("Parser not in proper position, or bad XML.");
             }

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/GenericSettings.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/GenericSettings.java
@@ -22,8 +22,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -77,10 +78,10 @@ public class GenericSettings extends IQ {
     /**
      * Stanza extension provider for SoundSetting Packets.
      */
-    public static class InternalProvider extends IQProvider<GenericSettings> {
+    public static class InternalProvider extends IqProvider<GenericSettings> {
 
         @Override
-        public GenericSettings parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public GenericSettings parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             GenericSettings setting = new GenericSettings();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/OfflineSettings.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/OfflineSettings.java
@@ -19,9 +19,10 @@ package org.jivesoftware.smackx.workgroup.settings;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.SimpleIQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -104,10 +105,10 @@ public class OfflineSettings extends SimpleIQ {
     /**
      * Stanza extension provider for AgentStatusRequest packets.
      */
-    public static class InternalProvider extends IQProvider<OfflineSettings> {
+    public static class InternalProvider extends IqProvider<OfflineSettings> {
 
         @Override
-        public OfflineSettings parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public OfflineSettings parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             OfflineSettings offlineSettings = new OfflineSettings();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/SearchSettings.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/SearchSettings.java
@@ -18,9 +18,10 @@ package org.jivesoftware.smackx.workgroup.settings;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.SimpleIQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -75,10 +76,10 @@ public class SearchSettings extends SimpleIQ {
     /**
      * Stanza extension provider for AgentStatusRequest packets.
      */
-    public static class InternalProvider extends IQProvider<SearchSettings> {
+    public static class InternalProvider extends IqProvider<SearchSettings> {
 
         @Override
-        public SearchSettings parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public SearchSettings parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             SearchSettings settings = new SearchSettings();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/SoundSettings.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/SoundSettings.java
@@ -19,9 +19,10 @@ package org.jivesoftware.smackx.workgroup.settings;
 
 import java.io.IOException;
 
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.SimpleIQ;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.stringencoder.Base64;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -65,10 +66,10 @@ public class SoundSettings extends SimpleIQ {
     /**
      * Stanza extension provider for SoundSetting Packets.
      */
-    public static class InternalProvider extends IQProvider<SoundSettings> {
+    public static class InternalProvider extends IqProvider<SoundSettings> {
 
         @Override
-        public SoundSettings parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public SoundSettings parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             SoundSettings soundSettings = new SoundSettings();
 
             boolean done = false;

--- a/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/WorkgroupProperties.java
+++ b/smack-legacy/src/main/java/org/jivesoftware/smackx/workgroup/settings/WorkgroupProperties.java
@@ -20,8 +20,9 @@ package org.jivesoftware.smackx.workgroup.settings;
 import java.io.IOException;
 
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.IqData;
 import org.jivesoftware.smack.packet.XmlEnvironment;
-import org.jivesoftware.smack.provider.IQProvider;
+import org.jivesoftware.smack.provider.IqProvider;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.xml.XmlPullParser;
 import org.jivesoftware.smack.xml.XmlPullParserException;
@@ -92,10 +93,10 @@ public class WorkgroupProperties extends IQ {
     /**
      * Stanza extension provider for SoundSetting Packets.
      */
-    public static class InternalProvider extends IQProvider<WorkgroupProperties> {
+    public static class InternalProvider extends IqProvider<WorkgroupProperties> {
 
         @Override
-        public WorkgroupProperties parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        public WorkgroupProperties parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
             WorkgroupProperties props = new WorkgroupProperties();
 
             boolean done = false;


### PR DESCRIPTION
This is an attempt at solving the name conflict with the legacy `IQProvider` and the replacement `IqProvider`, see e.g. https://discourse.igniterealtime.org/t/iqprovider-similar-class-names-update-for-4-5/91469/2

All providers now use `IqProvider`, instead of the other way 'round as in #522. I looked at all `parse` methods to see if they move the parser to the end of the element, but lacking unit tests I'm not sure I really caught everything.

I was wondering if putting `ParserUtils.forwardToEndTagOfDepth(parser, initialDepth);` into `org.jivesoftware.smack.provider.IqProvider#parse(org.jivesoftware.smack.xml.XmlPullParser, org.jivesoftware.smack.packet.IqData, org.jivesoftware.smack.packet.XmlEnvironment)` just before the return would be an option? But I guess you had a reason not to do that in the first place.