### PR TITLE
fix: Bosh configuration when bosh URI contains IP address.

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/BOSHConfiguration.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/BOSHConfiguration.java
@@ -77,7 +77,9 @@ public final class BOSHConfiguration extends ConnectionConfiguration {
     }
 
     public URI getURI() throws URISyntaxException {
-        return new URI((https ? "https://" : "http://") + this.host + ":" + this.port + file);
+        return new URI((https ? "https://" : "http://")
+            + (this.host != null ? this.host : this.hostAddress)
+                + ":" + this.port + file);
     }
 
     public Map<String, String> getHttpHeaders() {


### PR DESCRIPTION
In a case where bosh url contains ip address in ConnectionConfiguration:
https://github.com/igniterealtime/Smack/blob/70abd8a18269c7fc0686ca75977fd48acf8d0a1b/smack-core/src/main/java/org/jivesoftware/smack/ConnectionConfiguration.java#L829
only hostAddress is set and host is null, which results an attempt to connect to https://null:443/http-bind.
