### PR TITLE
[disco] Fix memory leak in ServiceDiscoveryManager

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/ServiceDiscoveryManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/ServiceDiscoveryManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2003-2007 Jive Software, 2018-2020 Florian Schmaus.
+ * Copyright 2003-2007 Jive Software, 2018-2022 Florian Schmaus.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -933,6 +933,10 @@ public final class ServiceDiscoveryManager extends Manager {
      * Notify the {@link EntityCapabilitiesChangedListener} about changed capabilities.
      */
     private synchronized void renewEntityCapsVersion() {
+        if (entityCapabilitiesChangedListeners.isEmpty()) {
+            return;
+        }
+
         renewEntityCapsRequested++;
         if (renewEntityCapsScheduledAction != null) {
             boolean canceled = renewEntityCapsScheduledAction.cancel();

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/ServiceDiscoveryManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/disco/ServiceDiscoveryManager.java
@@ -941,9 +941,12 @@ public final class ServiceDiscoveryManager extends Manager {
             }
         }
 
-        final XMPPConnection connection = connection();
-
         renewEntityCapsScheduledAction = scheduleBlocking(() -> {
+            final XMPPConnection connection = connection();
+            if (connection == null) {
+                return;
+            }
+
             renewEntityCapsPerformed.incrementAndGet();
 
             DiscoverInfoBuilder discoverInfoBuilder = DiscoverInfo.builder("synthetized-disco-info-response")


### PR DESCRIPTION
The lambda we schedule in 25ms captures a strong reference to the
XMPPConnection. However the lambda is part of the scheduled action,
which we save in the renewEntityCapsScheduledAction field. This causes
a memory leak, since the ServiceDiscoveryManager now holds a strong
reference to its XMPPConnection.

Fix this by obtaining the strong reference to the XMPPConnection, if
one still exists, within the lambda.

Fixes SMACK-926.

Reported-by: Damian Minkov <damencho@jitsi.org>