### PR TITLE
[bosh] Fix BOSHConfiguration.getURI()

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/BOSHConfiguration.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/BOSHConfiguration.java
@@ -77,7 +77,7 @@ public final class BOSHConfiguration extends ConnectionConfiguration {
     }
 
     public URI getURI() throws URISyntaxException {
-        String uri = https ? "https://" : "http://" + getHostString() + ":" + this.port + file;
+        String uri = (https ? "https://" : "http://") + getHostString() + ":" + this.port + file;
         return new URI(uri);
     }
 


### PR DESCRIPTION
Reported-by: Damian Minkov <damencho@jitsi.org>
Fixes: aa441d743cb0 ("[bosh] Use ConnectionConfiguration.getHostString() in BOSHConfiguration")