### PR TITLE
[core] Add AbstractXMPPConnection.TRUELY_ASYNC_SENDS

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackConfiguration.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2003-2007 Jive Software, 2018-2020 Florian Schmaus.
+ * Copyright 2003-2007 Jive Software, 2018-2022 Florian Schmaus.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -387,4 +387,14 @@ public final class SmackConfiguration {
             }
         }
     }
+
+    /**
+     * If enabled, causes {@link AbstractXMPPConnection} to create a thread for every asynchronous send operation. This
+     * is meant to work-around a shortcoming of Smack 4.4, where certain send operations are not asynchronous even if
+     * they should be. This is an expert setting, do not toggle if you do not understand the consequences or have been
+     * told to do so. Note that it is expected that this will not be needed in future Smack versions.
+     *
+     * @since 4.4.6
+     */
+    public static boolean TRUELY_ASYNC_SENDS = false;
 }


### PR DESCRIPTION
This option is meant a quick and dirty hack until
XMPPConnection.sendStanza() throws a dedicated Exception in case the
connection's outgoing queue is full.