### PR TITLE
Bump pgpainless-core to 1.3.1

### DIFF
--- a/smack-openpgp/build.gradle
+++ b/smack-openpgp/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	api project(':smack-extensions')
 	api project(':smack-experimental')
 
-	api 'org.pgpainless:pgpainless-core:1.1.1'
+	api 'org.pgpainless:pgpainless-core:1.3.1'
 
 	testImplementation "org.bouncycastle:bcprov-jdk15on:${bouncyCastleVersion}"
 

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/element/OpenPgpElement.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/element/OpenPgpElement.java
@@ -26,6 +26,7 @@ import org.jivesoftware.smack.packet.Stanza;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.util.XmlStringBuilder;
 
+import org.jivesoftware.smack.util.stringencoder.Base64;
 import org.jivesoftware.smackx.ox.util.Util;
 
 /**
@@ -51,7 +52,8 @@ public class OpenPgpElement implements ExtensionElement {
     }
 
     public InputStream toInputStream() {
-        return new ByteArrayInputStream(base64EncodedOpenPgpMessage.getBytes(Util.UTF8));
+        return new ByteArrayInputStream(
+                Base64.decode(base64EncodedOpenPgpMessage.getBytes(Util.UTF8)));
     }
 
     /**

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/store/abstr/AbstractOpenPgpKeyStore.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/store/abstr/AbstractOpenPgpKeyStore.java
@@ -19,7 +19,6 @@ package org.jivesoftware.smackx.ox.store.abstr;
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -247,7 +246,7 @@ public abstract class AbstractOpenPgpKeyStore implements OpenPgpKeyStore {
 
     @Override
     public PGPSecretKeyRing generateKeyRing(BareJid owner)
-            throws PGPException, NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
-        return PGPainless.generateKeyRing().modernKeyRing("xmpp:" + owner.toString(), null);
+            throws PGPException, NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        return PGPainless.generateKeyRing().modernKeyRing("xmpp:" + owner.toString());
     }
 }


### PR DESCRIPTION
This PR bumps PGPainless to 1.3.0.

As always, the changes that went into the release can be found here:
https://github.com/pgpainless/pgpainless/blob/main/CHANGELOG.md