### PR TITLE
Use XMPP connection as local socks5 address

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.PipedReader;
 import java.io.PipedWriter;
 import java.io.Writer;
+import java.net.InetAddress;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -312,6 +313,11 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
             throwNotConnectedExceptionIfAppropriate();
             throw new OutgoingQueueFullException();
         }
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return null;
     }
 
     @Override

--- a/smack-core/src/main/java/org/jivesoftware/smack/XMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/XMPPConnection.java
@@ -16,6 +16,7 @@
  */
 package org.jivesoftware.smack;
 
+import java.net.InetAddress;
 import java.util.concurrent.TimeUnit;
 
 import javax.xml.namespace.QName;
@@ -159,6 +160,14 @@ public interface XMPPConnection {
      * @return the full XMPP address of the user logged in.
      */
     EntityFullJid getUser();
+
+    /**
+     * Returns the local address currently in use for this connection, or <code>null</code> if
+     * this is invalid for the type of underlying connection.
+     *
+     * @return the local address currently in use for this connection
+     */
+    InetAddress getLocalAddress();
 
     /**
      * Returns the stream ID for this connection, which is the value set by the server

--- a/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/c2s/ModularXmppClientToServerConnection.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.smack.c2s;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1126,6 +1127,11 @@ public final class ModularXmppClientToServerConnection extends AbstractXMPPConne
         WalkStateGraphContext walkStateGraphContext = buildNewWalkTo(
                         ConnectedButUnauthenticatedStateDescriptor.class).build();
         walkStateGraph(walkStateGraphContext);
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return null;
     }
 
     private Map<String, Object> getFilterStats() {

--- a/smack-core/src/testFixtures/java/org/jivesoftware/smack/DummyConnection.java
+++ b/smack-core/src/testFixtures/java/org/jivesoftware/smack/DummyConnection.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.smack;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.Date;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
@@ -137,6 +138,11 @@ public class DummyConnection extends AbstractXMPPConnection {
         if (!enqueued) {
             throw new OutgoingQueueFullException();
         }
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return null;
     }
 
     /**

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -1938,4 +1938,20 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         this.bundleAndDeferCallback = bundleAndDeferCallback;
     }
 
+
+    /**
+     * Returns the local address currently in use for this connection.
+     *
+     * @return the local address
+     */
+    @Override
+    public InetAddress getLocalAddress() {
+        final Socket socket = this.socket;
+        if (socket == null) return null;
+
+        InetAddress localAddress = socket.getLocalAddress();
+        if (localAddress.isAnyLocalAddress()) return null;
+
+        return localAddress;
+    }
 }


### PR DESCRIPTION
The default local address is often just "the first address found in the list of addresses read from the OS" and this might mean an internal IP address that cannot reach external servers. So wherever possible use the same IP address being used to connect to the XMPP server because this local address has a better chance of being suitable.

This MR adds the above behaviour, and two UTs to test that we use the local XMPP connection IP when connected, and the previous behaviour when not. 