### PR TITLE
Inform ourselves of presence info.

### DIFF
--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/Roster.java
@@ -947,7 +947,8 @@ public final class Roster extends Manager {
     }
 
     /**
-     * Returns true if the specified XMPP address is an entry in the roster.
+     * Returns true if the specified XMPP address is an entry in the roster, or is
+     * a resource of the logged in user.
      *
      * @param jid the XMPP address of the user (eg "jsmith@example.com"). The
      *             address must be a bare JID e.g. "domain/resource" or
@@ -955,7 +956,9 @@ public final class Roster extends Manager {
      * @return true if the XMPP address is an entry in the roster.
      */
     public boolean contains(BareJid jid) {
-        return getEntry(jid) != null;
+        RosterEntry entry = getEntry(jid);
+        EntityFullJid user = connection().getUser();
+        return entry != null || (user != null && jid.isParentOf(user));
     }
 
     /**

--- a/smack-im/src/test/java/org/jivesoftware/smack/roster/RosterTest.java
+++ b/smack-im/src/test/java/org/jivesoftware/smack/roster/RosterTest.java
@@ -518,6 +518,32 @@ public class RosterTest extends InitSmackIm {
         assertSame("Wrong number of roster entries.", 4, roster.getEntries().size());
     }
 
+    @Test
+    public void testContactBelongsToRoster() throws Exception {
+        assertNotNull("Can't get the roster from the provided connection!", roster);
+        initRoster();
+
+        // Verify the contact belongs to roster
+        final BareJid contactJID = JidCreate.entityBareFrom("romeo@example.net");
+        assertTrue("Contact doesn't belong to the roster.", roster.contains(contactJID));
+
+        // Verify the non-existent contact does not belong to roster
+        final BareJid nonExistentContactJID = JidCreate.entityBareFrom("juliet@example.net");
+        assertFalse("Non-existent contact found in the roster.", roster.contains(nonExistentContactJID));
+    }
+
+    @Test
+    public void testAccountBelongsToRoster() {
+        // Verify the connection account belongs to roster
+        final BareJid accountJID = connection.getUser().asBareJid();
+        assertTrue("Connection account doesn't belong to the connected roster.", roster.contains(accountJID));
+
+        connection.instantShutdown();
+
+        // Verify the connection account no longer belongs to the roster now it has been disconnected.
+        assertFalse("Connection account erroneously belongs to the disconnected roster.", roster.contains(accountJID));
+    }
+
     /**
      * Remove all roster entries by iterating trough {@link Roster#getEntries()}
      * and simulating receiving roster pushes from the server.


### PR DESCRIPTION
Treat resources belonging to the logged in user as being in the roster, so clients are informed about presence changes on the same account.

This MR adds the above function and two UTs to check the existing behaviour of the `Roster.contains()`, and verify the new function. 
