### PR TITLE
[muc] Fix removal of the MUC's main presence interceptor

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -1133,7 +1133,7 @@ public class MultiUserChat {
         if (!removed) return;
         int currentCount = presenceInterceptorCount.decrementAndGet();
         if (currentCount == 0) {
-            connection.removePresenceInterceptor(presenceInterceptor);
+            connection.removePresenceInterceptor(this.presenceInterceptor);
         }
     }
 


### PR DESCRIPTION
On dinamically remove the last existed presence interceptor
we also should to remove the MUC's main presence interceptor from the connection.

Hot fix for SMACK-925.
