### PR TITLE
Websocket implicit discovery should use common ports

### DIFF
--- a/smack-websocket/src/main/java/org/jivesoftware/smack/websocket/XmppWebSocketTransportModule.java
+++ b/smack-websocket/src/main/java/org/jivesoftware/smack/websocket/XmppWebSocketTransportModule.java
@@ -223,15 +223,16 @@ public final class XmppWebSocketTransportModule
                 }
 
                 if (moduleDescriptor.isImplicitWebSocketEndpointEnabled()) {
-                    String urlWithoutScheme = "://" + host + ":5443/ws";
-
-                    SecureWebSocketRemoteConnectionEndpoint implicitSecureEndpoint = SecureWebSocketRemoteConnectionEndpoint.from(
-                                    WebSocketRemoteConnectionEndpoint.SECURE_WEB_SOCKET_SCHEME + urlWithoutScheme);
-                    result.discoveredSecureEndpoints.add(implicitSecureEndpoint);
-
-                    InsecureWebSocketRemoteConnectionEndpoint implicitInsecureEndpoint = InsecureWebSocketRemoteConnectionEndpoint.from(
-                                    WebSocketRemoteConnectionEndpoint.INSECURE_WEB_SOCKET_SCHEME + urlWithoutScheme);
-                    result.discoveredInsecureEndpoints.add(implicitInsecureEndpoint);
+                    for (final int securePort : new int[] {5443, 5281, 7443}) {
+                        SecureWebSocketRemoteConnectionEndpoint implicitSecureEndpoint = SecureWebSocketRemoteConnectionEndpoint.from(
+                            WebSocketRemoteConnectionEndpoint.SECURE_WEB_SOCKET_SCHEME + "://" + host + ":" + securePort + "/ws");
+                        result.discoveredSecureEndpoints.add(implicitSecureEndpoint);
+                    }
+                    for (final int insecurePort : new int[] {5443, 5280, 7070}) {
+                        InsecureWebSocketRemoteConnectionEndpoint implicitInsecureEndpoint = InsecureWebSocketRemoteConnectionEndpoint.from(
+                            WebSocketRemoteConnectionEndpoint.INSECURE_WEB_SOCKET_SCHEME + "://" + host + ":" + insecurePort + "/ws");
+                        result.discoveredInsecureEndpoints.add(implicitInsecureEndpoint);
+                    }
                 }
 
                 final LookupConnectionEndpointsResult endpointsResult;


### PR DESCRIPTION
When enabled, the websocket implementation will attempt to use two implicit endpoints, using these URLs:
- `wss://[host]:5443/ws`
- `ws://[host]:5443/ws`

These endpoints should include ports that are used by default by known implementations, such as 5280/5281 (Prosody) and 7070/7443 (Openfire).