### PR TITLE
Add null check for mucUser.

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -276,7 +276,7 @@ public class MultiUserChat {
                         }
                     }
 
-                    Destroy destroy = mucUser.getDestroy();
+                    Destroy destroy = mucUser == null ? null : mucUser.getDestroy();
                     // The room has been destroyed.
                     if (destroy != null) {
                         EntityBareJid alternateMucJid = destroy.getJid();


### PR DESCRIPTION
XEP-0045 requires "unavailable" presence to contain extended presence, but Smack shouldn't throw an exception if it doesn't.

There's an explicit null check on line 260, so accessing the value without a check on 279 is inconsistent. 

