### PR TITLE
[sinttest] Add UnconnectedConnectionSource for low-level tests

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2018-2021 Florian Schmaus
+ * Copyright 2018-2023 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -419,6 +419,11 @@ public class XmppConnectionManager {
     AbstractXMPPConnection constructConnection()
                     throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         return constructConnection(defaultConnectionDescriptor);
+    }
+
+    AbstractXMPPConnection constructConnectedConnection()
+                    throws InterruptedException, SmackException, IOException, XMPPException {
+        return constructConnectedConnection(defaultConnectionDescriptor);
     }
 
     <C extends AbstractXMPPConnection> C constructConnection(

--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/LoginIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/LoginIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2015-2020 Florian Schmaus
+ * Copyright 2015-2023 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ public class LoginIntegrationTest extends AbstractSmackLowLevelIntegrationTest {
      * Check that the server is returning the correct error when trying to login using an invalid
      * (i.e. non-existent) user.
      *
+     * @param unconnectedConnectionSource the unconnected connections source that is used.
      * @throws InterruptedException if the calling thread was interrupted.
      * @throws XMPPException if an XMPP protocol error was received.
      * @throws IOException if an I/O error occurred.
@@ -50,12 +51,12 @@ public class LoginIntegrationTest extends AbstractSmackLowLevelIntegrationTest {
      * @throws KeyManagementException if there was a key mangement error.
      */
     @SmackIntegrationTest
-    public void testInvalidLogin() throws SmackException, IOException, XMPPException,
+    public void testInvalidLogin(UnconnectedConnectionSource unconnectedConnectionSource) throws SmackException, IOException, XMPPException,
                     InterruptedException, KeyManagementException, NoSuchAlgorithmException {
         final String nonExistentUserString = StringUtils.insecureRandomString(24);
         final String invalidPassword = "invalidPassword";
 
-        AbstractXMPPConnection connection = getUnconnectedConnection();
+        AbstractXMPPConnection connection = unconnectedConnectionSource.getUnconnectedConnection();
         connection.connect();
 
         try {

--- a/smack-integration-test/src/test/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFrameWorkTest.java
+++ b/smack-integration-test/src/test/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFrameWorkTest.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2019-2020 Florian Schmaus
+ * Copyright 2019-2023 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,15 @@
  */
 package org.igniterealtime.smack.inttest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
 import org.jivesoftware.smack.AbstractXMPPConnection;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestFramework.TestMethodParameterType;
 
 import org.junit.jupiter.api.Test;
 
@@ -69,28 +71,42 @@ public class SmackIntegrationTestFrameWorkTest {
     @Test
     public void testValidLowLevelList() {
         Method testMethod = getTestMethod(ValidLowLevelList.class);
-        assertTrue(SmackIntegrationTestFramework.testMethodParametersIsListOfConnections(testMethod,
-                        AbstractXMPPConnection.class));
+        TestMethodParameterType determinedParameterType = SmackIntegrationTestFramework.determineTestMethodParameterType(testMethod, AbstractXMPPConnection.class);
+        assertEquals(TestMethodParameterType.collectionOfConnections, determinedParameterType);
     }
 
     @Test
     public void testInvalidLowLevelList() {
         Method testMethod = getTestMethod(InvalidLowLevelList.class);
-        assertFalse(SmackIntegrationTestFramework.testMethodParametersIsListOfConnections(testMethod,
-                        AbstractXMPPConnection.class));
+        TestMethodParameterType determinedParameterType = SmackIntegrationTestFramework.determineTestMethodParameterType(testMethod, AbstractXMPPConnection.class);
+        assertNull(determinedParameterType);
     }
 
     @Test
     public void testValidLowLevelVarargs() {
         Method testMethod = getTestMethod(ValidLowLevelVarargs.class);
-        assertTrue(SmackIntegrationTestFramework.testMethodParametersVarargsConnections(testMethod,
-                        AbstractXMPPConnection.class));
+        TestMethodParameterType determinedParameterType = SmackIntegrationTestFramework.determineTestMethodParameterType(testMethod, AbstractXMPPConnection.class);
+        assertEquals(TestMethodParameterType.parameterListOfConnections, determinedParameterType);
     }
 
     @Test
     public void testInvalidLowLevelVargs() {
         Method testMethod = getTestMethod(InvalidLowLevelVarargs.class);
-        assertFalse(SmackIntegrationTestFramework.testMethodParametersVarargsConnections(testMethod,
-                        AbstractXMPPConnection.class));
+        TestMethodParameterType determinedParameterType = SmackIntegrationTestFramework.determineTestMethodParameterType(testMethod, AbstractXMPPConnection.class);
+        assertNull(determinedParameterType);
     }
+
+    private static class ValidUnconnectedConnectionSource {
+        @SuppressWarnings("unused")
+        public void test(AbstractSmackLowLevelIntegrationTest.UnconnectedConnectionSource source) {
+        }
+    }
+
+    @Test
+    public void testValidUnconnectedConnectionSource() {
+        Method testMethod = getTestMethod(ValidUnconnectedConnectionSource.class);
+        TestMethodParameterType determinedParameterType = SmackIntegrationTestFramework.determineTestMethodParameterType(testMethod, AbstractXMPPConnection.class);
+        assertEquals(TestMethodParameterType.unconnectedConnectionSource, determinedParameterType);
+    }
+
 }


### PR DESCRIPTION
Previously low-level tests where run, potentially multiple times, with the default connection descriptor.

Reported-by: Guus der Kinderen <guus@goodbytes.nl>