### PR TITLE
[websocket-java11] Prevent infinite recursion in disconnect()

### DIFF
--- a/smack-websocket-java11/src/main/java/org/jivesoftware/smack/websocket/java11/Java11WebSocket.java
+++ b/smack-websocket-java11/src/main/java/org/jivesoftware/smack/websocket/java11/Java11WebSocket.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2021 Florian Schmaus
+ * Copyright 2021-2023 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,11 +139,13 @@ public final class Java11WebSocket extends AbstractWebSocket {
 
     @Override
     public void disconnect(int code, String message) {
-        CompletableFuture<WebSocket> completableFuture = webSocket.sendClose(code, message);
         try {
-            completableFuture.get();
+            if (!webSocket.isOutputClosed()) {
+                CompletableFuture<WebSocket> completableFuture = webSocket.sendClose(code, message);
+                completableFuture.get();
+            }
         } catch (ExecutionException e) {
-            onWebSocketFailure(e);
+            LOGGER.log(Level.WARNING, "Failed to send final close when disconnecting " + this, e);
         } catch (InterruptedException e) {
             // This thread should never be interrupted, as it is a Smack internal thread.
             throw new AssertionError(e);

--- a/smack-websocket/src/main/java/org/jivesoftware/smack/websocket/impl/AbstractWebSocket.java
+++ b/smack-websocket/src/main/java/org/jivesoftware/smack/websocket/impl/AbstractWebSocket.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2020 Aditya Borikar, 2020-2021 Florian Schmaus
+ * Copyright 2020 Aditya Borikar, 2020-2023 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,4 +156,9 @@ public abstract class AbstractWebSocket {
     }
 
     public abstract SSLSession getSSLSession();
+
+    @Override
+    public final String toString() {
+        return getClass().getSimpleName() + "[" + connectionInternal.connection + "]";
+    }
 }


### PR DESCRIPTION
Guus reports the following infinite recursing causing a StackOverflowError:

```
Exception in thread "main" java.lang.StackOverflowError
	at org.jivesoftware.smack.websocket.java11.Java11WebSocket.disconnect(Java11WebSocket.java:142)
	at org.jivesoftware.smack.websocket.XmppWebSocketTransportModule$XmppWebSocketTransport.disconnect(XmppWebSocketTransportModule.java:265)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection$CloseConnectionState.transitionInto(ModularXmppClientToServerConnection.java:1086)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection.attemptEnterState(ModularXmppClientToServerConnection.java:472)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection.walkStateGraphInternal(ModularXmppClientToServerConnection.java:399)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection.walkStateGraph(ModularXmppClientToServerConnection.java:339)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection.shutdown(ModularXmppClientToServerConnection.java:551)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection.instantShutdown(ModularXmppClientToServerConnection.java:530)
	at org.jivesoftware.smack.AbstractXMPPConnection.notifyConnectionError(AbstractXMPPConnection.java:1024)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection.access$100(ModularXmppClientToServerConnection.java:134)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection$1.notifyConnectionError(ModularXmppClientToServerConnection.java:185)
	at org.jivesoftware.smack.websocket.impl.AbstractWebSocket.onWebSocketFailure(AbstractWebSocket.java:128)
	at org.jivesoftware.smack.websocket.java11.Java11WebSocket.onWebSocketFailure(Java11WebSocket.java:162)
	at org.jivesoftware.smack.websocket.java11.Java11WebSocket.disconnect(Java11WebSocket.java:146)
	at org.jivesoftware.smack.websocket.XmppWebSocketTransportModule$XmppWebSocketTransport.disconnect(XmppWebSocketTransportModule.java:265)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection$CloseConnectionState.transitionInto(ModularXmppClientToServerConnection.java:1086)
	at org.jivesoftware.smack.c2s.ModularXmppClientToServerConnection.attemptEnterState(ModularXmppClientToServerConnection.java:472)
...
```

This is because `sendClose()` in Java11WebSocket. `disconnect()` throws, potentially because the output stream is already closed. We previously would feed the exception into the `onWebSocketFailure(Exception)` machinery, which would then again attempt a disconnect.

Since a failed `sendClose()` is nothing that needs special handling, we simply log the exception as error. Furthermore, we only issue `sendClose()` if the WebSocket's output is still open, i.e., if there is a chance that it actually works.

Reported-by: Guus der Kinderen <guus@goodbytes.nl>