### PR TITLE
[commands] Fix LocalCommand next() and complete() paramter type

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/AdHocCommand.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/AdHocCommand.java
@@ -24,7 +24,7 @@ import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.packet.StanzaError;
 
 import org.jivesoftware.smackx.commands.packet.AdHocCommandData;
-import org.jivesoftware.smackx.xdata.form.FillableForm;
+import org.jivesoftware.smackx.xdata.form.FormReader;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 
 import org.jxmpp.jid.Jid;
@@ -73,7 +73,7 @@ import org.jxmpp.jid.Jid;
  * @author Gabriel Guardincerri
  *
  */
-public abstract class AdHocCommand {
+public abstract class AdHocCommand<F extends FormReader> {
     // TODO: Analyze the redesign of command by having an ExecutionResponse as a
     // TODO: result to the execution of every action. That result should have all the
     // TODO: information related to the execution, e.g. the form to fill. Maybe this
@@ -230,7 +230,7 @@ public abstract class AdHocCommand {
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    public abstract void next(FillableForm response) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException;
+    public abstract void next(F response) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException;
 
     /**
      * Completes the command execution with the information provided in the
@@ -246,7 +246,7 @@ public abstract class AdHocCommand {
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    public abstract void complete(FillableForm response) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException;
+    public abstract void complete(F response) throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException;
 
     /**
      * Goes to the previous stage. The requester is asking to re-send the

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandManager.java
@@ -52,7 +52,7 @@ import org.jivesoftware.smackx.disco.AbstractNodeInformationProvider;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
 import org.jivesoftware.smackx.disco.packet.DiscoverInfo;
 import org.jivesoftware.smackx.disco.packet.DiscoverItems;
-import org.jivesoftware.smackx.xdata.form.FillableForm;
+import org.jivesoftware.smackx.xdata.form.Form;
 import org.jivesoftware.smackx.xdata.packet.DataForm;
 
 import org.jxmpp.jid.Jid;
@@ -464,7 +464,8 @@ public final class AdHocCommandManager extends Manager {
                     if (Action.next.equals(action)) {
                         command.incrementStage();
                         DataForm dataForm = requestData.getForm();
-                        command.next(new FillableForm(dataForm));
+                        Form filledForm = new Form(dataForm);
+                        command.next(filledForm);
                         if (command.isLastStage()) {
                             // If it is the last stage then the command is
                             // completed
@@ -478,7 +479,8 @@ public final class AdHocCommandManager extends Manager {
                     else if (Action.complete.equals(action)) {
                         command.incrementStage();
                         DataForm dataForm = requestData.getForm();
-                        command.complete(new FillableForm(dataForm));
+                        Form filledForm = new Form(dataForm);
+                        command.complete(filledForm);
                         response.setStatus(Status.completed);
                         // Remove the completed session
                         executingCommands.remove(sessionId);

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/LocalCommand.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/LocalCommand.java
@@ -18,6 +18,7 @@
 package org.jivesoftware.smackx.commands;
 
 import org.jivesoftware.smackx.commands.packet.AdHocCommandData;
+import org.jivesoftware.smackx.xdata.form.FilledForm;
 
 import org.jxmpp.jid.Jid;
 
@@ -39,7 +40,7 @@ import org.jxmpp.jid.Jid;
  *
  * @author Gabriel Guardincerri
  */
-public abstract class LocalCommand extends AdHocCommand {
+public abstract class LocalCommand extends AdHocCommand<FilledForm> {
 
     /**
      * The time stamp of first invocation of the command. Used to implement the session timeout.

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/LocalCommand.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/LocalCommand.java
@@ -19,6 +19,7 @@ package org.jivesoftware.smackx.commands;
 
 import org.jivesoftware.smackx.commands.packet.AdHocCommandData;
 import org.jivesoftware.smackx.xdata.form.FilledForm;
+import org.jivesoftware.smackx.xdata.packet.DataForm;
 
 import org.jxmpp.jid.Jid;
 
@@ -40,7 +41,7 @@ import org.jxmpp.jid.Jid;
  *
  * @author Gabriel Guardincerri
  */
-public abstract class LocalCommand extends AdHocCommand<FilledForm> {
+public abstract class LocalCommand<F extends FilledForm> extends AdHocCommand<F> {
 
     /**
      * The time stamp of first invocation of the command. Used to implement the session timeout.
@@ -166,4 +167,7 @@ public abstract class LocalCommand extends AdHocCommand<FilledForm> {
     void decrementStage() {
         currentStage--;
     }
+
+    abstract F filledFormFromSubmitDataForm(DataForm dataForm);
+
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/LocalCommandFactory.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/LocalCommandFactory.java
@@ -41,6 +41,6 @@ public interface LocalCommandFactory {
      * @throws InvocationTargetException if a reflection-based method or constructor invocation threw.
      * @throws IllegalArgumentException if an illegal argument was given.
      */
-    LocalCommand getInstance() throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException;
+    LocalCommand<?> getInstance() throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException;
 
 }

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/RemoteCommand.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/commands/RemoteCommand.java
@@ -42,7 +42,7 @@ import org.jxmpp.jid.Jid;
  * @author Gabriel Guardincerri
  *
  */
-public class RemoteCommand extends AdHocCommand {
+public class RemoteCommand extends AdHocCommand<FillableForm> {
 
     /**
      * The connection that is used to execute this command


### PR DESCRIPTION
The form for those methods in case of LocalCommand must be FilledForm, as we receive a filled form (form type=submit) from the remote entity.

Fixes SMACK-933.