### PR TITLE
Bump pgpainless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ allprojects {
 		smackMinAndroidSdk = 19
 		junitVersion = '5.7.1'
 		commonsIoVersion = '2.6'
-		bouncyCastleVersion = '1.71'
+		bouncyCastleVersion = '1.73'
 		guavaVersion = '30.1-jre'
 		mockitoVersion = '3.7.7'
 		orgReflectionsVersion = '0.9.11'

--- a/smack-openpgp/build.gradle
+++ b/smack-openpgp/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	api project(':smack-extensions')
 	api project(':smack-experimental')
 
-	api 'org.pgpainless:pgpainless-core:1.3.1'
+	api 'org.pgpainless:pgpainless-core:1.5.3'
 
 	testImplementation "org.bouncycastle:bcprov-jdk18on:${bouncyCastleVersion}"
 

--- a/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/PainlessOpenPgpProvider.java
+++ b/smack-openpgp/src/main/java/org/jivesoftware/smackx/ox/crypto/PainlessOpenPgpProvider.java
@@ -220,7 +220,7 @@ public class PainlessOpenPgpProvider implements OpenPgpProvider {
         cipherStream.close();
         plainText.close();
 
-        OpenPgpMetadata info = cipherStream.getResult();
+        OpenPgpMetadata info = cipherStream.getMetadata().toLegacyMetadata();
 
         OpenPgpMessage.State state;
         if (info.isSigned()) {


### PR DESCRIPTION
This PR bumps BC from 1.71 to 1.73, and also bumps PGPainless from 1.3.3 to 1.5.3.

Changes since then can be seen in the [CHANGELOG](https://github.com/pgpainless/pgpainless/blob/main/CHANGELOG.md) file of the PGPainless project.

I chose PGPainless 1.5.3 specifically, since 1.5.4 bumps BC to 1.74, which was quickly superseded by BC 1.75 due to Java API compatibility issues and I didn't yet come to creating a PGPainless release using BC 1.75.
Also, I think Smack is probably rather conservative, so BC 1.73 is probably fine :)