### PR TITLE
Bump libsignal-protocol-java to 2.8.1

### DIFF
--- a/smack-omemo-signal/build.gradle
+++ b/smack-omemo-signal/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 	api project(":smack-im")
 	api project(":smack-extensions")
 	api project(":smack-omemo")
-	implementation 'org.whispersystems:signal-protocol-java:2.6.2'
+	implementation 'org.whispersystems:signal-protocol-java:2.8.1'
 
 	testFixturesApi(testFixtures(project(":smack-core")))
 	testImplementation project(path: ":smack-omemo", configuration: "testRuntime")

--- a/smack-omemo-signal/src/main/java/org/jivesoftware/smackx/omemo/signal/SignalOmemoStoreConnector.java
+++ b/smack-omemo-signal/src/main/java/org/jivesoftware/smackx/omemo/signal/SignalOmemoStoreConnector.java
@@ -123,6 +123,22 @@ public class SignalOmemoStoreConnector
     }
 
     @Override
+    public IdentityKey getIdentity(SignalProtocolAddress address) {
+        OmemoDevice device;
+        try {
+            device = asOmemoDevice(address);
+        } catch (XmppStringprepException e) {
+            throw new AssertionError(e);
+        }
+
+        try {
+            return omemoStore.loadOmemoIdentityKey(getOurDevice(), device);
+        } catch (IOException | CorruptedOmemoKeyException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
     public PreKeyRecord loadPreKey(int i) throws InvalidKeyIdException {
         PreKeyRecord preKey;
         try {


### PR DESCRIPTION
This PR bumps libsignal-protocol-java from 2.6.2 to 2.81.

Unfortunately, libsignal-protocol-java is EOL since February 2022. However, I'm not yet aware of any security issues that came up since then.
In the long run, it might make sense to migrate to [libsignal](https://github.com/signalapp/libsignal) which is intended as a replacement for libsignal-protocol-java (see #565). Its written in Rust and exposes Java bindings.