### PR TITLE
[sinttest] Fix IBR usage (and fix typos)

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
@@ -285,7 +285,7 @@ public class XmppConnectionManager {
             if (unsuccessfullyDeletedAccountsCount == 0) {
                 LOGGER.info("Successfully deleted all created accounts ✔");
             } else {
-                LOGGER.warning("Could not delete all created accounts, " + unsuccessfullyDeletedAccountsCount + " remainaing");
+                LOGGER.warning("Could not delete all created accounts, " + unsuccessfullyDeletedAccountsCount + " remaining");
             }
         }
 
@@ -364,11 +364,11 @@ public class XmppConnectionManager {
             break;
         case inBandRegistration:
             if (!accountManager.supportsAccountCreation()) {
-                throw new UnsupportedOperationException("Account creation/registation is not supported");
+                throw new UnsupportedOperationException("Account creation/registration is not supported");
             }
             Set<String> requiredAttributes = accountManager.getAccountAttributes();
             if (requiredAttributes.size() > 4) {
-                throw new IllegalStateException("Unkown required attributes");
+                throw new IllegalStateException("Unknown required attributes");
             }
             Map<String, String> additionalAttributes = new HashMap<>();
             additionalAttributes.put("name", "Smack Integration Test");

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/XmppConnectionManager.java
@@ -184,20 +184,18 @@ public class XmppConnectionManager {
 
         switch (sinttestConfiguration.accountRegistration) {
         case serviceAdministration:
-        case inBandRegistration:
             accountRegistrationConnection = defaultConnectionDescriptor.construct(sinttestConfiguration);
             accountRegistrationConnection.connect();
             accountRegistrationConnection.login(sinttestConfiguration.adminAccountUsername,
                             sinttestConfiguration.adminAccountPassword);
-
-            if (sinttestConfiguration.accountRegistration == AccountRegistration.inBandRegistration) {
-
-                adminManager = null;
-                accountManager = AccountManager.getInstance(accountRegistrationConnection);
-            } else {
-                adminManager = ServiceAdministrationManager.getInstanceFor(accountRegistrationConnection);
-                accountManager = null;
-            }
+            adminManager = ServiceAdministrationManager.getInstanceFor(accountRegistrationConnection);
+            accountManager = null;
+            break;
+        case inBandRegistration:
+            accountRegistrationConnection = defaultConnectionDescriptor.construct(sinttestConfiguration);
+            accountRegistrationConnection.connect();
+            adminManager = null;
+            accountManager = AccountManager.getInstance(accountRegistrationConnection);
             break;
         case disabled:
             accountRegistrationConnection = null;


### PR DESCRIPTION
Prior to this change, the Smack Integration Test are configured to use In-Band Registration when no admin credentials are provided. However, when trying to apply In-Band Registration, the (missing) admin credentials are used, leading to an error.

In this PR, usage of the admin credentials is prevented when IBR is in use.

Additionally, some typos in a log message and two exception messages are fixed in a separate commit.