### PR TITLE
[sinttest] Trim externally-provided configuration

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -488,7 +488,7 @@ public final class Configuration {
             }
             key = key.substring(SINTTEST.length());
             String value = (String) entry.getValue();
-            properties.put(key, value);
+            properties.put(key.trim(), value.trim());
         }
 
         Builder builder = builder();


### PR DESCRIPTION
Smack integration test configuration is provided externally. Guard against accidental whitespace inclusion by trimming values.