### PR TITLE
fix: Fix XmlStringBuilder caching.

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/XmlStringBuilder.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/XmlStringBuilder.java
@@ -597,7 +597,13 @@ public class XmlStringBuilder implements Appendable, CharSequence, Element {
     @Override
     public XmlStringBuilder append(CharSequence csq) {
         assert csq != null;
-        sb.append(csq);
+        if (csq instanceof XmlStringBuilder) {
+            sb.append(((XmlStringBuilder) csq).sb);
+        } else if (csq instanceof LazyStringBuilder) {
+            sb.append((LazyStringBuilder) csq);
+        } else {
+            sb.append(csq);
+        }
         return this;
     }
 


### PR DESCRIPTION
`XmlStringBuilder.append(Element)` calls into the generic `append(CharSequence)` method which breaks the caching.

As a result we see `IQ.toString()` taking a very long time (over 8 seconds for some ~60KB IQs from a real system). Here's a test to demonstrate (see post below)

Note that `PacketWriter` uses `XmlStringBuilder.write()` and never calls `toString()` and its performance isn't affected.