### PR TITLE
Improve handling of expanded Websocket 'open' element

### DIFF
--- a/smack-websocket/src/main/java/org/jivesoftware/smack/websocket/impl/AbstractWebSocket.java
+++ b/smack-websocket/src/main/java/org/jivesoftware/smack/websocket/impl/AbstractWebSocket.java
@@ -95,7 +95,9 @@ public abstract class AbstractWebSocket {
     static String getStreamFromOpenElement(String openElement) {
         String streamElement = openElement.replaceFirst("\\A<open ", "<stream:stream ")
                                           .replace("urn:ietf:params:xml:ns:xmpp-framing", "jabber:client")
-                                          .replaceFirst("/>\\s*\\z", " xmlns:stream='http://etherx.jabber.org/streams'>");
+                                          .replaceFirst("/>\\s*\\z", " xmlns:stream='http://etherx.jabber.org/streams'>")
+                                          .replaceFirst("></open>\\s*\\z", " xmlns:stream='http://etherx.jabber.org/streams'>");
+
         return streamElement;
     }
 

--- a/smack-websocket/src/test/java/org/jivesoftware/smack/websocket/impl/AbstractWebSocketTest.java
+++ b/smack-websocket/src/test/java/org/jivesoftware/smack/websocket/impl/AbstractWebSocketTest.java
@@ -24,18 +24,20 @@ import org.junit.jupiter.api.Test;
 
 public final class AbstractWebSocketTest {
     private static final String OPEN_ELEMENT = "<open from='localhost.org' id='aov9ihhmmn' xmlns='urn:ietf:params:xml:ns:xmpp-framing' xml:lang='en' version='1.0'/>";
+    private static final String OPEN_ELEMENT_EXPANDED = "<open from='localhost.org' id='aov9ihhmmn' xmlns='urn:ietf:params:xml:ns:xmpp-framing' xml:lang='en' version='1.0'></open>";
     private static final String OPEN_STREAM = "<stream:stream from='localhost.org' id='aov9ihhmmn' xmlns='jabber:client' xml:lang='en' version='1.0' xmlns:stream='http://etherx.jabber.org/streams'>";
     private static final String CLOSE_ELEMENT = "<close xmlns='urn:ietf:params:xml:ns:xmpp-framing'/>";
 
     @Test
     public void getStreamFromOpenElementTest() {
-        String generatedOpenStream = AbstractWebSocket.getStreamFromOpenElement(OPEN_ELEMENT);
-        assertEquals(generatedOpenStream, OPEN_STREAM);
+        assertEquals(OPEN_STREAM, AbstractWebSocket.getStreamFromOpenElement(OPEN_ELEMENT));
+        assertEquals(OPEN_STREAM, AbstractWebSocket.getStreamFromOpenElement(OPEN_ELEMENT_EXPANDED));
     }
 
     @Test
     public void isOpenElementTest() {
         assertTrue(AbstractWebSocket.isOpenElement(OPEN_ELEMENT));
+        assertTrue(AbstractWebSocket.isOpenElement(OPEN_ELEMENT_EXPANDED));
         assertFalse(AbstractWebSocket.isOpenElement(OPEN_STREAM));
     }
 


### PR DESCRIPTION
Prior to this fix, Smack requires the 'open' element send on a websocket connection to be collapsed. With the change in this commit, an expanded (eg: `<open ...></open>`) element can also be used.

fixes SMACK-935