### PR TITLE
[xdata] Fix NPE in FillableForm

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/FillableForm.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/FillableForm.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2020 Florian Schmaus
+ * Copyright 2020-2024 Florian Schmaus
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ public class FillableForm extends FilledForm {
         }
 
         Set<String> requiredFields = new HashSet<>();
+        List<FormField> requiredFieldsWithDefaultValue = new ArrayList<>();
         for (FormField formField : dataForm.getFields()) {
             if (formField.isRequired()) {
                 String fieldName = formField.getFieldName();
@@ -61,13 +62,17 @@ public class FillableForm extends FilledForm {
 
                 if (formField.hasValueSet()) {
                     // This is a form field with a default value.
-                    write(formField);
+                    requiredFieldsWithDefaultValue.add(formField);
                 } else {
                     missingRequiredFields.add(fieldName);
                 }
             }
         }
         this.requiredFields = Collections.unmodifiableSet(requiredFields);
+
+        for (FormField field : requiredFieldsWithDefaultValue) {
+            write(field);
+        }
     }
 
     protected void writeListMulti(String fieldName, List<? extends CharSequence> values) {


### PR DESCRIPTION
Calling write() in FillableForm's constructor causes a NPE because write() makes use of requiredFields which has not been set at this time. Furthermore, write() makes use of missingRequiredFields, which is also populated in that loop. Therefore, we have to delay the invocation of write() until requiredFields got set.

Thanks to Dan Caseley for reporting this.

Reported-by: Dan Caseley <dan@caseley.me.uk>