### PR TITLE
Sint tagging

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -111,6 +111,10 @@ public final class Configuration {
 
     private final Map<String, Set<String>> disabledTestsMap;
 
+    public final Set<String> enabledSpecifications;
+
+    public final Set<String> disabledSpecifications;
+
     public final String defaultConnectionNickname;
 
     public final Set<String> enabledConnections;
@@ -181,6 +185,8 @@ public final class Configuration {
         this.enabledTestsMap = convertTestsToMap(enabledTests);
         this.disabledTests =  CollectionUtil.nullSafeUnmodifiableSet(builder.disabledTests);
         this.disabledTestsMap = convertTestsToMap(disabledTests);
+        this.enabledSpecifications = CollectionUtil.nullSafeUnmodifiableSet(builder.enabledSpecifications);
+        this.disabledSpecifications = CollectionUtil.nullSafeUnmodifiableSet(builder.disabledSpecifications);
         this.defaultConnectionNickname = builder.defaultConnectionNickname;
         this.enabledConnections = builder.enabledConnections;
         this.disabledConnections = builder.disabledConnections;
@@ -251,6 +257,10 @@ public final class Configuration {
         private Set<String> enabledTests;
 
         private Set<String> disabledTests;
+
+        private Set<String> enabledSpecifications;
+
+        private Set<String> disabledSpecifications;
 
         private String defaultConnectionNickname;
 
@@ -375,6 +385,16 @@ public final class Configuration {
 
         public Builder setDisabledTests(String disabledTestsString) {
             disabledTests = getTestSetFrom(disabledTestsString);
+            return this;
+        }
+
+        public Builder setEnabledSpecifications(String enabledSpecificationsString) {
+            enabledSpecifications = getSpecificationSetFrom(enabledSpecificationsString);
+            return this;
+        }
+
+        public Builder setDisabledSpecifications(String disabledSpecificationsString) {
+            disabledSpecifications = getSpecificationSetFrom(disabledSpecificationsString);
             return this;
         }
 
@@ -523,6 +543,8 @@ public final class Configuration {
         builder.setDebugger(properties.getProperty("debugger"));
         builder.setEnabledTests(properties.getProperty("enabledTests"));
         builder.setDisabledTests(properties.getProperty("disabledTests"));
+        builder.setEnabledSpecifications(properties.getProperty("enabledSpecifications"));
+        builder.setDisabledSpecifications(properties.getProperty("disabledSpecifications"));
         builder.setDefaultConnection(properties.getProperty("defaultConnection"));
         builder.setEnabledConnections(properties.getProperty("enabledConnections"));
         builder.setDisabledConnections(properties.getProperty("disabledConnections"));
@@ -585,6 +607,10 @@ public final class Configuration {
             }
             return s;
         });
+    }
+
+    private static Set<String> getSpecificationSetFrom(String input) {
+        return split(input, Configuration::normalizeSpecification);
     }
 
     private static Map<String, Set<String>> convertTestsToMap(Set<String> tests) {
@@ -695,4 +721,34 @@ public final class Configuration {
         return contains(method, disabledTestsMap);
     }
 
+    public boolean isSpecificationEnabled(String specification) {
+        if (enabledSpecifications.isEmpty()) {
+            return true;
+        }
+
+        if (specification == null) {
+            return false;
+        }
+
+        return enabledSpecifications.contains(normalizeSpecification(specification));
+    }
+
+    public boolean isSpecificationDisabled(String specification) {
+        if (disabledSpecifications.isEmpty()) {
+            return false;
+        }
+
+        if (specification == null) {
+            return false;
+        }
+
+        return disabledSpecifications.contains(normalizeSpecification(specification));
+    }
+
+    static String normalizeSpecification(String specification) {
+        if (specification == null || specification.isBlank()) {
+            return null;
+        }
+        return specification.replaceAll("\\s", "").toUpperCase();
+    }
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,6 +73,7 @@ import org.igniterealtime.smack.inttest.Configuration.AccountRegistration;
 import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.BeforeClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.reflections.Reflections;
 import org.reflections.scanners.MethodAnnotationsScanner;
 import org.reflections.scanners.MethodParameterScanner;
@@ -128,10 +131,21 @@ public class SmackIntegrationTestFramework {
         final int exitStatus;
         if (failedTests > 0) {
             LOGGER.warning("💀 The following " + failedTests + " tests failed! 💀");
+            final SortedSet<String> bySpecification = new TreeSet<>();
             for (FailedTest failedTest : testRunResult.failedIntegrationTests) {
                 final Throwable cause = failedTest.failureReason;
                 LOGGER.log(Level.SEVERE, failedTest.concreteTest + " failed: " + cause, cause);
+                if (failedTest.concreteTest.method.isAnnotationPresent(SpecificationReference.class)) {
+                    final String specificationReference = getSpecificationReference(failedTest.concreteTest.method);
+                    if (specificationReference != null) {
+                        bySpecification.add("- " + specificationReference + " (as tested by '" + failedTest.concreteTest + "')");
+                    }
+                }
             }
+            if (!bySpecification.isEmpty()) {
+                LOGGER.log(Level.SEVERE, "The failed tests correspond to the following specifications:" + System.lineSeparator() + String.join(System.lineSeparator(), bySpecification));
+            }
+
             exitStatus = 2;
         } else {
             LOGGER.info("All possible Smack Integration Tests completed successfully. \\o/");
@@ -147,6 +161,24 @@ public class SmackIntegrationTestFramework {
         }
 
         System.exit(exitStatus);
+    }
+
+    private static String getSpecificationReference(Method method) {
+        final SpecificationReference spec = method.getDeclaringClass().getAnnotation(SpecificationReference.class);
+        if (spec == null || spec.document().isBlank()) {
+            return null;
+        }
+        String line = spec.document().trim();
+
+        final SmackIntegrationTest test = method.getAnnotation(SmackIntegrationTest.class);
+        if (!test.section().isBlank()) {
+            line += " section " + test.section().trim();
+        }
+        if (!test.quote().isBlank()) {
+            line += ":\t\"" + test.quote().trim() + "\"";
+        }
+        assert !line.isBlank();
+        return line;
     }
 
     public SmackIntegrationTestFramework(Configuration configuration) {
@@ -293,6 +325,26 @@ public class SmackIntegrationTestFramework {
 
             if (config.isClassDisabled(testClass)) {
                 DisabledTestClass disabledTestClass = new DisabledTestClass(testClass, "Skipping test class " + testClassName + " because it is disalbed");
+                testRunResult.disabledTestClasses.add(disabledTestClass);
+                continue;
+            }
+
+            final String specification;
+            if (testClass.isAnnotationPresent(SpecificationReference.class)) {
+                final SpecificationReference specificationReferenceAnnotation = testClass.getAnnotation(SpecificationReference.class);
+                specification = Configuration.normalizeSpecification(specificationReferenceAnnotation.document());
+            } else {
+                specification = null;
+            }
+
+            if (!config.isSpecificationEnabled(specification)) {
+                DisabledTestClass disabledTestClass = new DisabledTestClass(testClass, "Skipping test method " + testClass + " because it tests a specification ('" + specification + "') that is not enabled");
+                testRunResult.disabledTestClasses.add(disabledTestClass);
+                continue;
+            }
+
+            if (config.isSpecificationDisabled(specification)) {
+                DisabledTestClass disabledTestClass = new DisabledTestClass(testClass, "Skipping test method " + testClass + " because it tests a specification ('" + specification + "') that is disabled");
                 testRunResult.disabledTestClasses.add(disabledTestClass);
                 continue;
             }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/annotations/SpecificationReference.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/annotations/SpecificationReference.java
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2015-2019 Florian Schmaus
+ * Copyright 2024 Guus der Kinderen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,27 +22,20 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Reference to a specific part of a specification.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface SmackIntegrationTest {
-
-    boolean onlyDefaultConnectionType() default false;
-
-    int connectionCount() default -1;
+@Target(ElementType.TYPE)
+public @interface SpecificationReference {
 
     /**
-     * Unique identifier for a section (or paragraph) of the document referenced by {@link SpecificationReference},
-     * such as '6.2.1'.
+     * Unique identifier for a specification document, such as 'RFC 6120' or 'XEP-0485'.
      *
-     * @return a document section identifier
+     * @return a document identifier
      */
-    String section() default "";
-
-    /**
-     * A quotation of relevant text from the section referenced by {@link #section()}.
-     *
-     * @return human-readable text from the references document and section.
-     */
-    String quote() default "";
+    String document();
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
@@ -136,6 +136,14 @@
  * <td>List of disabled tests</td>
  * </tr>
  * <tr>
+ * <td>enabledSpecifications</td>
+ * <td>List of specifications for which to enable tests</td>
+ * </tr>
+ * <tr>
+ * <td>disabledSpecifications</td>
+ * <td>List of specificatinos for which to disable tests</td>
+ * </tr>
+ * <tr>
  * <td>defaultConnection</td>
  * <td>Nickname of the default connection</td>
  * </tr>
@@ -186,6 +194,20 @@
  * </pre>
  * <p>
  * would run all tests defined in the <code>SoftwareInfoIntegrationTest</code> class.
+ * </p>
+ * <p>
+ * Use <code>enabledSpecifications</code> to run all tests that assert implementation of functionality that is described
+ * in standards identified by the provided specification-reference.
+ * </p>
+ * <p>
+ * For example:
+ * </p>
+ *
+ * <pre>
+ * $ gradle integrationTest -Dsinttest.enabledSpecifications=XEP-0045
+ * </pre>
+ * <p>
+ * would run all tests that are annotated to verify functionality specified in XEP-0045: "Multi-User Chat".
  * </p>
  * <h2>Overview of the components</h2>
  * <p>

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/caps/EntityCapsTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/caps/EntityCapsTest.java
@@ -51,7 +51,9 @@ import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.BeforeClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 
+@SpecificationReference(document = "XEP-0115")
 public class EntityCapsTest extends AbstractSmackIntegrationTest {
 
     private final EntityCapsManager ecmTwo;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/chatstate/ChatStateIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/chatstate/ChatStateIntegrationTest.java
@@ -27,8 +27,10 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 
+@SpecificationReference(document = "XEP-0085")
 public class ChatStateIntegrationTest extends AbstractSmackIntegrationTest {
 
     // Listener for composing chat state

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandIntegrationTest.java
@@ -36,7 +36,9 @@ import org.jivesoftware.smackx.xdata.packet.DataForm;
 import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 
+@SpecificationReference(document = "XEP-0050")
 public class AdHocCommandIntegrationTest extends AbstractSmackIntegrationTest {
 
     public AdHocCommandIntegrationTest(SmackIntegrationTestEnvironment environment) {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferIntegrationTest.java
@@ -31,8 +31,10 @@ import org.jivesoftware.smackx.filetransfer.FileTransfer.Status;
 import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
 
+@SpecificationReference(document = "XEP-0096")
 public class FileTransferIntegrationTest extends AbstractSmackIntegrationTest {
 
     private static final int MAX_FT_DURATION = 360;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
@@ -34,11 +34,13 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.junit.jupiter.api.Assertions;
 import org.jxmpp.util.XmppDateTime;
 
+@SpecificationReference(document = "XEP-0080")
 public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
 
     private final GeoLocationManager glm1;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadIntegrationTest.java
@@ -36,7 +36,9 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 
+@SpecificationReference(document = "XEP-0363")
 public class HttpFileUploadIntegrationTest extends AbstractSmackIntegrationTest {
 
     private static final int FILE_SIZE = 1024 * 128;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTControlIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTControlIntegrationTest.java
@@ -33,10 +33,12 @@ import org.jivesoftware.smackx.iot.control.element.SetData;
 import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.jxmpp.jid.Jid;
 
+@SpecificationReference(document = "XEP-0347")
 public class IoTControlIntegrationTest extends AbstractSmackIntegrationTest {
 
     private final IoTControlManager IoTControlManagerOne;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTDataIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTDataIntegrationTest.java
@@ -37,8 +37,10 @@ import org.jivesoftware.smackx.iot.data.element.TimestampElement;
 import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 
+@SpecificationReference(document = "XEP-0347")
 public class IoTDataIntegrationTest extends AbstractSmackIntegrationTest {
 
     private final IoTDataManager iotDataManagerOne;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTDiscoveryIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTDiscoveryIntegrationTest.java
@@ -34,8 +34,10 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.jxmpp.jid.Jid;
 
+@SpecificationReference(document = "XEP-0347")
 public class IoTDiscoveryIntegrationTest extends AbstractSmackIntegrationTest {
 
     private final IoTDiscoveryManager discoveryManagerOne;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/iqversion/VersionIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/iqversion/VersionIntegrationTest.java
@@ -28,7 +28,9 @@ import org.jivesoftware.smackx.iqversion.packet.Version;
 import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 
+@SpecificationReference(document = "XEP-0092")
 public class VersionIntegrationTest extends AbstractSmackIntegrationTest {
 
     public VersionIntegrationTest(SmackIntegrationTestEnvironment environment) {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mam/MamIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mam/MamIntegrationTest.java
@@ -42,9 +42,11 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.jxmpp.jid.EntityBareJid;
 
+@SpecificationReference(document = "XEP-0313")
 public class MamIntegrationTest extends AbstractSmackIntegrationTest {
 
     private final MamManager mamManagerConTwo;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
@@ -30,10 +30,12 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.junit.jupiter.api.Assertions;
 
+@SpecificationReference(document = "XEP-0107")
 public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
 
     private final MoodManager mm1;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatEntityIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatEntityIntegrationTest.java
@@ -34,10 +34,12 @@ import org.jivesoftware.smackx.disco.packet.DiscoverItems;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.parts.Resourcepart;
 
+@SpecificationReference(document = "XEP-0045")
 public class MultiUserChatEntityIntegrationTest extends AbstractMultiUserChatIntegrationTest {
 
     public MultiUserChatEntityIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -47,18 +49,14 @@ public class MultiUserChatEntityIntegrationTest extends AbstractMultiUserChatInt
     }
 
     /**
-     * Asserts that a MUC service can have its features discovered
-     *
-     * <p>From XEP-0045 § 6.2:</p>
-     * <blockquote>
-     * An entity may wish to discover if a service implements the Multi-User Chat protocol; in order to do so, it
-     * sends a service discovery information ("disco#info") query to the MUC service's JID. The service MUST return
-     * its identity and the features it supports.
-     * </blockquote>
+     * Asserts that a MUC service can have its features discovered.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "6.2", quote =
+        "An entity may wish to discover if a service implements the Multi-User Chat protocol; in order to do so, it " +
+        "sends a service discovery information (\"disco#info\") query to the MUC service's JID. The service MUST " +
+        "return its identity and the features it supports.")
     public void mucTestForDiscoveringFeatures() throws Exception {
         DiscoverInfo info = mucManagerOne.getMucServiceDiscoInfo(mucManagerOne.getMucServiceDomains().get(0));
         assertTrue(info.getIdentities().size() > 0);
@@ -68,17 +66,13 @@ public class MultiUserChatEntityIntegrationTest extends AbstractMultiUserChatInt
     /**
      * Asserts that a MUC Service lists its public rooms.
      *
-     * <p>From XEP-0045 § 6.3:</p>
-     * <blockquote>
-     * The service discovery items ("disco#items") protocol enables an entity to query a service for a list of
-     * associated items, which in the case of a chat service would consist of the specific chat rooms hosted by the
-     * service. The service SHOULD return a full list of the public rooms it hosts (i.e., not return any rooms that
-     * are hidden).
-     * </blockquote>
-     *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "6.3", quote =
+        "The service discovery items (\"disco#items\") protocol enables an entity to query a service for a list of " +
+        "associated items, which in the case of a chat service would consist of the specific chat rooms hosted by the" +
+        "service. The service SHOULD return a full list of the public rooms it hosts (i.e., not return any rooms that" +
+        "are hidden).")
     public void mucTestForDiscoveringRooms() throws Exception {
         EntityBareJid mucAddressPublic = getRandomRoom("smack-inttest-publicroom");
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddressPublic);
@@ -104,15 +98,11 @@ public class MultiUserChatEntityIntegrationTest extends AbstractMultiUserChatInt
     /**
      * Asserts that a MUC Service returns disco info for a room.
      *
-     * <p>From XEP-0045 § 6.4:</p>
-     * <blockquote>
-     * Using the disco#info protocol, an entity may also query a specific chat room for more detailed information
-     * about the room....The room MUST return its identity and SHOULD return the features it supports
-     * </blockquote>
-     *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "6.4", quote =
+        "Using the disco#info protocol, an entity may also query a specific chat room for more detailed information " +
+        "about the room....The room MUST return its identity and SHOULD return the features it supports")
     public void mucTestForDiscoveringRoomInfo() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-discoinfo");
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
@@ -133,16 +123,12 @@ public class MultiUserChatEntityIntegrationTest extends AbstractMultiUserChatInt
     /**
      * Asserts that a MUC Service returns disco info for a room's items.
      *
-     * <p>From XEP-0045 § 6.5:</p>
-     * <blockquote>
-     * An entity MAY also query a specific chat room for its associated items. An implementation MAY return a list
-     * of existing occupants if that information is publicly available, or return no list at all if this information is
-     * kept private.
-     * </blockquote>
-     *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "6.5", quote =
+        "An entity MAY also query a specific chat room for its associated items. An implementation MAY return a list " +
+        "of existing occupants if that information is publicly available, or return no list at all if this " +
+        "information is kept private.")
     public void mucTestForDiscoveringRoomItems() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-discoitems");
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
@@ -162,15 +148,11 @@ public class MultiUserChatEntityIntegrationTest extends AbstractMultiUserChatInt
      * Asserts that a non-occupant receives a Bad Request error when attempting to query an occupant by their
      * occupant JID.
      *
-     * <p>From XEP-0045 § 6.6:</p>
-     * <blockquote>
-     * If a non-occupant attempts to send a disco request to an address of the form &lt;room@service/nick&gt;, a MUC service
-     * MUST return a &lt;bad-request/&gt; error
-     * </blockquote>
-     *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "6.6", quote =
+        "If a non-occupant attempts to send a disco request to an address of the form <room@service/nick>, a MUC " +
+        "service MUST return a <bad-request> error")
     public void mucTestForRejectingDiscoOnRoomOccupantByNonOccupant() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-discoitems");
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatIntegrationTest.java
@@ -34,11 +34,13 @@ import org.jivesoftware.smackx.muc.packet.MUCUser;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.parts.Resourcepart;
 
+@SpecificationReference(document = "XEP-0045")
 public class MultiUserChatIntegrationTest extends AbstractMultiUserChatIntegrationTest {
 
     public MultiUserChatIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -50,15 +52,11 @@ public class MultiUserChatIntegrationTest extends AbstractMultiUserChatIntegrati
     /**
      * Asserts that when a user joins a room, they are themselves included on the list of users notified (self-presence).
      *
-     * <p>From XEP-0045 § 7.2.2:</p>
-     * <blockquote>
-     * ...the service MUST also send presence from the new participant's occupant JID to the full JIDs of all the
-     * occupants (including the new occupant)
-     * </blockquote>
-     *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "7.2.2", quote =
+        "... the service MUST also send presence from the new participant's occupant JID to the full JIDs of all the " +
+        "occupants (including the new occupant)")
     public void mucJoinTest() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-join");
 
@@ -80,16 +78,12 @@ public class MultiUserChatIntegrationTest extends AbstractMultiUserChatIntegrati
     /**
      * Asserts that when a user leaves a room, they are themselves included on the list of users notified (self-presence).
      *
-     * <p>From XEP-0045 § 7.14:</p>
-     * <blockquote>
-     * The service MUST then send a presence stanzas of type "unavailable" from the departing user's occupant JID to
-     * the departing occupant's full JIDs, including a status code of "110" to indicate that this notification is
-     * "self-presence"
-     * </blockquote>
-     *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "7.14", quote =
+        "The service MUST then send a presence stanzas of type \"unavailable\" from the departing user's occupant " +
+        "JID to the departing occupant's full JIDs, including a status code of \"110\" to indicate that this " +
+        "notification is \"self-presence\"")
     public void mucLeaveTest() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-leave");
 
@@ -144,18 +138,15 @@ public class MultiUserChatIntegrationTest extends AbstractMultiUserChatIntegrati
     }
 
 
-     /**
-     * Asserts that a user is notified when a room is destroyed
-     *
-     * <p>From XEP-0045 § 10.9:</p>
-     * <blockquote>
-     * A room owner MUST be able to destroy a room, especially if the room is persistent... The room removes all users from the room... and destroys the room
-     * </blockquote>
+    /**
+     * Asserts that a user is notified when a room is destroyed.
      *
      * @throws TimeoutException when roomDestroyed event doesn't get fired
      * @throws Exception when other errors occur
      */
-     @SmackIntegrationTest
+    @SmackIntegrationTest(section = "10.9", quote =
+        "A room owner MUST be able to destroy a room, especially if the room is persistent... The room removes all " +
+        "users from the room... and destroys the room")
     public void mucDestroyTest() throws TimeoutException, Exception {
 
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-destroy");
@@ -190,7 +181,4 @@ public class MultiUserChatIntegrationTest extends AbstractMultiUserChatIntegrati
         assertEquals(0, muc.getOccupantsCount());
         assertNull(muc.getNickname());
     }
-
-
-
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatLowLevelIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatLowLevelIntegrationTest.java
@@ -33,11 +33,13 @@ import org.igniterealtime.smack.inttest.AbstractSmackLowLevelIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Localpart;
 import org.jxmpp.jid.parts.Resourcepart;
 
+@SpecificationReference(document = "XEP-0048")
 public class MultiUserChatLowLevelIntegrationTest extends AbstractSmackLowLevelIntegrationTest {
 
     public MultiUserChatLowLevelIntegrationTest(SmackIntegrationTestEnvironment environment) throws Exception {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatRolesAffiliationsPrivilegesIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatRolesAffiliationsPrivilegesIntegrationTest.java
@@ -32,6 +32,7 @@ import org.jivesoftware.smackx.muc.packet.MUCUser;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
@@ -40,6 +41,7 @@ import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 
 
+@SpecificationReference(document = "XEP-0045")
 public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends AbstractMultiUserChatIntegrationTest{
 
     public MultiUserChatRolesAffiliationsPrivilegesIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -49,23 +51,14 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who undergoes a role change receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 5.1.3:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the occupant's role to reflect the change and communicate the change
-     * to all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 9.6:</p>
-     * <blockquote>
-     * The service MUST then send updated presence from this individual to all occupants, indicating the addition of
-     * moderator status...
-     * </blockquote>
+     * Asserts that a user who undergoes a role change receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.1.3", quote =
+        "(§ 5.1.3)... a MUC service implementation MUST change the occupant's role to reflect the change and " +
+        "communicate the change to all occupants [...] (§ 9.6) The service MUST then send updated presence from this " +
+        "individual to all occupants, indicating the addition of moderator status...")
     public void mucRoleTestForReceivingModerator() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -97,23 +90,14 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who is present when another user undergoes a role change receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 5.1.3:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the occupant's role to reflect the change and communicate the change
-     * to all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 9.6:</p>
-     * <blockquote>
-     * The service MUST then send updated presence from this individual to all occupants, indicating the addition of
-     * moderator status...
-     * </blockquote>
+     * Asserts that a user who is present when another user undergoes a role change receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "9.6", quote =
+        "(§ 5.1.3)... a MUC service implementation MUST change the occupant's role to reflect the change and " +
+        "communicate the change to all occupants [...] (§ 9.6) The service MUST then send updated presence from this " +
+        "individual to all occupants, indicating the addition of moderator status...")
     public void mucRoleTestForWitnessingModerator() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -146,23 +130,14 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who undergoes a role change receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 5.1.3:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the occupant's role to reflect the change and communicate the change
-     * to all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 9.7:</p>
-     * <blockquote>
-     * The service MUST then send updated presence from this individual to all occupants, indicating the removal of
-     * moderator status...
-     * </blockquote>
+     * Asserts that a user who undergoes a role change receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.1.3", quote =
+        "(§ 5.1.3)... a MUC service implementation MUST change the occupant's role to reflect the change and " +
+        "communicate the change to all occupants [...] (§ 9.7) The service MUST then send updated presence from this " +
+        "individual to all occupants, indicating the removal of moderator status...")
     public void mucRoleTestForRemovingModerator() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -192,23 +167,14 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who is present when another user undergoes a role change receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 5.1.3:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the occupant's role to reflect the change and communicate the change
-     * to all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 9.7:</p>
-     * <blockquote>
-     * The service MUST then send updated presence from this individual to all occupants, indicating the removal of
-     * moderator status...
-     * </blockquote>
+     * Asserts that a user who is present when another user undergoes a role change receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "9.7", quote =
+        "(§ 5.1.3)... a MUC service implementation MUST change the occupant's role to reflect the change and " +
+        "communicate the change to all occupants [...] (§ 9.7) The service MUST then send updated presence from this " +
+        "individual to all occupants, indicating the removal of moderator status...")
     public void mucRoleTestForWitnessingModeratorRemoval() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -241,23 +207,14 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user in an unmoderated room who undergoes an afilliation change receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 5.1.3:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the occupant's role to reflect the change and communicate the change
-     * to all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 8.4:</p>
-     * <blockquote>
-     * The service MUST then send updated presence from this individual to all occupants, indicating the removal of
-     * voice privileges...
-     * </blockquote>
+     * Asserts that a user in an unmoderated room who undergoes an afilliation change receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.1.3", quote =
+        "(§ 5.1.3)... a MUC service implementation MUST change the occupant's role to reflect the change and " +
+        "communicate the change to all occupants [...] (§ 8.4) The service MUST then send updated presence from " +
+        "this individual to all occupants, indicating the removal of voice privileges...")
     public void mucRoleTestForRevokingVoice() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -285,23 +242,14 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who is present when another user undergoes a role change receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 5.1.3:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the occupant's role to reflect the change and communicate the change
-     * to all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 8.4:</p>
-     * <blockquote>
-     * The service MUST then send updated presence from this individual to all occupants, indicating the removal of
-     * voice privileges...
-     * </blockquote>
+     * Asserts that a user who is present when another user undergoes a role change receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "8.4", quote =
+        "(§ 5.1.3)... a MUC service implementation MUST change the occupant's role to reflect the change and " +
+        "communicate the change to all occupants [...] (§ 8.4) The service MUST then send updated presence from " +
+        "this individual to all occupants, indicating the removal of voice privileges...")
     public void mucRoleTestForWitnessingRevokingVoice() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -333,23 +281,14 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who undergoes an affiliation change receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 5.2.2:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the user's affiliation to reflect the change and communicate that
-     * to all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 10.6:</p>
-     * <blockquote>
-     * If the user is in the room, the service MUST then send updated presence from this individual to all occupants,
-     * indicating the granting of admin status...
-     * </blockquote>
+     * Asserts that a user who undergoes an affiliation change receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.2.2", quote =
+        "(§ 5.2.2) ... a MUC service implementation MUST change the user's affiliation to reflect the change and " +
+        "communicate that to all occupants [...] (§ 10.6) If the user is in the room, the service MUST then send " +
+        "updated presence from this individual to all occupants, indicating the granting of admin status...")
     public void mucAffiliationTestForReceivingAdmin() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -381,23 +320,14 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
 
     /**
      * Asserts that a user who is present when another user undergoes an affiliation change receives that change as a
-     * presence update
-     *
-     * <p>From XEP-0045 § 5.2.2:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the user's affiliation to reflect the change and communicate that
-     * to all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 10.6:</p>
-     * <blockquote>
-     * If the user is in the room, the service MUST then send updated presence from this individual to all occupants,
-     * indicating the granting of admin status...
-     * </blockquote>
+     * presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "10.6", quote =
+        "(§ 5.2.2) ... a MUC service implementation MUST change the user's affiliation to reflect the change and " +
+        "communicate that to all occupants [...] (§ 10.6) If the user is in the room, the service MUST then send " +
+        "updated presence from this individual to all occupants, indicating the granting of admin status...")
     public void mucAffiliationTestForWitnessingAdmin() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -429,23 +359,15 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who undergoes an affiliation change receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 5.2.2:</p>
-     * <blockquote>
-     * ...a MUC service implementation MUST change the user's affiliation to reflect the change and communicate that to
-     * all occupants...
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 10.7:</p>
-     * <blockquote>
-     * If the user is in the room, the service MUST then send updated presence from this individual to all occupants,
-     * indicating the loss of admin status by sending a presence element...
-     * </blockquote>
+     * Asserts that a user who undergoes an affiliation change receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "10.7", quote =
+        "(§ 5.2.2) ... a MUC service implementation MUST change the user's affiliation to reflect the change and " +
+        "communicate that to all occupants [...] (§ 10.6) If the user is in the room, the service MUST then send " +
+        "updated presence from this individual to all occupants, indicating the loss of admin status by sending a " +
+        "presence element...")
     public void mucAffiliationTestForRemovingAdmin() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -491,7 +413,11 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "10.7", quote =
+        "(§ 5.2.2) ... a MUC service implementation MUST change the user's affiliation to reflect the change and " +
+        "communicate that to all occupants [...] (§ 10.6) If the user is in the room, the service MUST then send " +
+        "updated presence from this individual to all occupants, indicating the loss of admin status by sending a " +
+        "presence element...")
     public void mucAffiliationTestForWitnessingAdminRemoval() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -524,21 +450,16 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who gets kicked receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 8.2:</p>
-     * <blockquote>
-     * The kick is performed based on the occupant's room nickname and is completed by setting the role of a
-     * participant or visitor to a value of "none".
-     *
-     * The service MUST remove the kicked occupant by sending a presence stanza of type "unavailable" to each kicked
-     * occupant, including status code 307 in the extended presence information, optionally along with the reason (if
-     * provided) and the roomnick or bare JID of the user who initiated the kick.
-     * </blockquote>
+     * Asserts that a user who gets kicked receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "8.2", quote =
+        "The kick is performed based on the occupant's room nickname and is completed by setting the role of a " +
+        "participant or visitor to a value of \"none\". The service MUST remove the kicked occupant by sending a " +
+        "presence stanza of type \"unavailable\" to each kicked occupant, including status code 307 in the extended " +
+        "presence information, optionally along with the reason (if provided) and the roomnick or bare JID of the " +
+        "user who initiated the kick.")
     public void mucPresenceTestForGettingKicked() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -572,19 +493,15 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a user who is present when another user gets kicked receives that change as a presence update
-     *
-     * <p>From XEP-0045 § 8.2:</p>
-     * <blockquote>
-     * ...the service MUST then inform all of the remaining occupants that the kicked occupant is no longer in the room
-     * by sending presence stanzas of type "unavailable" from the individual's roomnick (&lt;room@service/nick&gt;) to all
-     * the remaining occupants (just as it does when occupants exit the room of their own volition), including the
-     * status code and optionally the reason and actor.
-     * </blockquote>
+     * Asserts that a user who is present when another user gets kicked receives that change as a presence update.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "8.2", quote =
+        "...the service MUST then inform all of the remaining occupants that the kicked occupant is no longer in the " +
+        "room by sending presence stanzas of type \"unavailable\" from the individual's roomnick " +
+        "(<room@service/nick>) to all the remaining occupants (just as it does when occupants exit the room of their " +
+        "own volition), including the status code and optionally the reason and actor.")
     public void mucPresenceTestForWitnessingKick() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -624,16 +541,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     /**
      * Asserts that an affiliation is persistent between visits to the room.
      *
-     * <p>From XEP-0045 § 5.2:</p>
-     * <blockquote>
-     * These affiliations are long-lived in that they persist across a user's visits to the room and are not affected
-     * by happenings in the room...Affiliations are granted, revoked, and maintained based on the user's bare JID, not
-     * the nick as with roles.
-     * </blockquote>
-     *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.2", quote =
+        "These affiliations are long-lived in that they persist across a user's visits to the room and are not " +
+        "affected by happenings in the room...Affiliations are granted, revoked, and maintained based on the user's " +
+        "bare JID, not the nick as with roles.")
     public void mucTestPersistentAffiliation() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -665,24 +578,16 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a moderator cannot revoke voice from an owner
-     *
-     * <p>From XEP-0045 § 5.1.1:</p>
-     * <blockquote>
-     * A moderator MUST NOT be able to revoke voice privileges from an admin or owner
-     * </blockquote>
-     *
-     * <p>From XEP-0045 § 8.4:</p>
-     * <blockquote>
-     * A moderator MUST NOT be able to revoke voice from a user whose affiliation is at or above the moderator's level.
-     * In addition, a service MUST NOT allow the voice privileges of an admin or owner to be removed by anyone. If a
-     * moderator attempts to revoke voice privileges from such a user, the service MUST deny the request and return a
-     * &lt;not-allowed/&gt; error to the sender along with the offending item(s)
-     * </blockquote>
+     * Asserts that a moderator cannot revoke voice from an owner.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.1.1", quote =
+        "A moderator MUST NOT be able to revoke voice privileges from an admin or owner [...] (§ 8.4) A moderator " +
+        "MUST NOT be able to revoke voice from a user whose affiliation is at or above the moderator's level. In " +
+        "addition, a service MUST NOT allow the voice privileges of an admin or owner to be removed by anyone. If a " +
+        "moderator attempts to revoke voice privileges from such a user, the service MUST deny the request and return " +
+        "a <not-allowed/> error to the sender along with the offending item(s)")
     public void mucTestModeratorCannotRevokeVoiceFromOwner() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -708,16 +613,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
      * Asserts that a moderator cannot revoke moderator privileges from a moderator with a higher affiliation
      * than themselves.
      *
-     * <p>From XEP-0045 § 5.1.3 and §5.2.1:</p>
-     * <blockquote>
-     * A moderator SHOULD NOT be allowed to revoke moderation privileges from someone with a higher affiliation than
-     * themselves (i.e., an unaffiliated moderator SHOULD NOT be allowed to revoke moderation privileges from an admin
-     * or an owner, and an admin SHOULD NOT be allowed to revoke moderation privileges from an owner)
-     * </blockquote>
-     *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.1.3", quote =
+        "A moderator SHOULD NOT be allowed to revoke moderation privileges from someone with a higher affiliation " +
+        "than themselves (i.e., an unaffiliated moderator SHOULD NOT be allowed to revoke moderation privileges from " +
+        "an admin or an owner, and an admin SHOULD NOT be allowed to revoke moderation privileges from an owner)")
     public void mucTestModeratorCannotBeRevokedFromHigherAffiliation() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest");
 
@@ -755,16 +656,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that an unmoderated room assigns the correct default roles for a given affiliation
-     *
-     * <p>From XEP-0045 § 5.1.2:</p>
-     * <blockquote>
-     * ...the initial default roles that a service SHOULD set based on the user's affiliation...
-     * </blockquote>
+     * Asserts that an unmoderated room assigns the correct default roles for a given affiliation.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.1.2", quote =
+        "...the initial default roles that a service SHOULD set based on the user's affiliation...")
     public void mucTestDefaultRoleForAffiliationInUnmoderatedRoom() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-unmoderatedroles");
 
@@ -804,16 +701,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a moderated room assigns the correct default roles for a given affiliation
-     *
-     * <p>From XEP-0045 § 5.1.2:</p>
-     * <blockquote>
-     * ...the initial default roles that a service SHOULD set based on the user's affiliation...
-     * </blockquote>
+     * Asserts that a moderated room assigns the correct default roles for a given affiliation.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.1.2", quote =
+        "...the initial default roles that a service SHOULD set based on the user's affiliation...")
     public void mucTestDefaultRoleForAffiliationInModeratedRoom() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-moderatedroles");
 
@@ -864,16 +757,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
     }
 
     /**
-     * Asserts that a members-only room assigns the correct default roles for a given affiliation
-     *
-     * <p>From XEP-0045 § 5.1.2:</p>
-     * <blockquote>
-     * ...the initial default roles that a service SHOULD set based on the user's affiliation...
-     * </blockquote>
+     * Asserts that a members-only room assigns the correct default roles for a given affiliation.
      *
      * @throws Exception when errors occur
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5.1.2", quote =
+        "...the initial default roles that a service SHOULD set based on the user's affiliation...")
     public void mucTestDefaultRoleForAffiliationInMembersOnlyRoom() throws Exception {
         EntityBareJid mucAddress = getRandomRoom("smack-inttest-membersonlyroles");
 

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/MessageEncryptionIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/MessageEncryptionIntegrationTest.java
@@ -29,12 +29,14 @@ import org.jivesoftware.smackx.omemo.element.OmemoBundleElement;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 
 /**
  * Simple OMEMO message encryption integration test.
  * During this test Alice sends an encrypted message to Bob. Bob decrypts it and sends a response to Alice.
  * It is checked whether the messages can be decrypted, and if used up pre-keys result in renewed bundles.
  */
+@SpecificationReference(document = "XEP-0384")
 public class MessageEncryptionIntegrationTest extends AbstractTwoUsersOmemoIntegrationTest {
 
     public MessageEncryptionIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoMamDecryptionTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoMamDecryptionTest.java
@@ -35,11 +35,13 @@ import org.jivesoftware.smackx.omemo.util.MessageOrOmemoMessage;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 
 /**
  * This test sends a message from Alice to Bob, while Bob has automatic decryption disabled.
  * Then Bob fetches his Mam archive and decrypts the result.
  */
+@SpecificationReference(document = "XEP-0384")
 public class OmemoMamDecryptionTest extends AbstractTwoUsersOmemoIntegrationTest {
     public OmemoMamDecryptionTest(SmackIntegrationTestEnvironment environment)
             throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, InterruptedException,

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/ReadOnlyDeviceIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/ReadOnlyDeviceIntegrationTest.java
@@ -32,7 +32,9 @@ import org.jivesoftware.smackx.omemo.exceptions.UndecidedOmemoIdentityException;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 
+@SpecificationReference(document = "XEP-0384")
 public class ReadOnlyDeviceIntegrationTest extends AbstractTwoUsersOmemoIntegrationTest {
 
     public ReadOnlyDeviceIntegrationTest(SmackIntegrationTestEnvironment environment) throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, InterruptedException, SmackException.NoResponseException, TestNotPossibleException {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/SessionRenegotiationIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/SessionRenegotiationIntegrationTest.java
@@ -24,7 +24,9 @@ import org.jivesoftware.smack.packet.MessageBuilder;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 
+@SpecificationReference(document = "XEP-0384")
 public class SessionRenegotiationIntegrationTest extends AbstractTwoUsersOmemoIntegrationTest {
 
     public SessionRenegotiationIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox/OXSecretKeyBackupIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox/OXSecretKeyBackupIntegrationTest.java
@@ -48,9 +48,11 @@ import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.BeforeClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.pgpainless.key.OpenPgpV4Fingerprint;
 import org.pgpainless.key.protection.UnprotectedKeysProtector;
 
+@SpecificationReference(document = "XEP-0374")
 public class OXSecretKeyBackupIntegrationTest extends AbstractOpenPgpIntegrationTest {
 
     private static final String sessionId = StringUtils.randomString(10);
@@ -101,7 +103,7 @@ public class OXSecretKeyBackupIntegrationTest extends AbstractOpenPgpIntegration
         org.apache.commons.io.FileUtils.deleteDirectory(beforePath);
     }
 
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "5")
     public void test() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException,
             NoSuchProviderException, IOException, InterruptedException, PubSubException.NotALeafNodeException,
             SmackException.NoResponseException, SmackException.NotConnectedException, XMPPException.XMPPErrorException,

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/ox_im/OXInstantMessagingIntegrationTest.java
@@ -39,11 +39,13 @@ import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.BeforeClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.pgpainless.decryption_verification.OpenPgpMetadata;
 import org.pgpainless.key.OpenPgpV4Fingerprint;
 import org.pgpainless.key.protection.UnprotectedKeysProtector;
 
+@SpecificationReference(document = "XEP-0374")
 public class OXInstantMessagingIntegrationTest extends AbstractOpenPgpIntegrationTest {
 
     private static final String sessionId = StringUtils.randomString(10);

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/ping/PingIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/ping/PingIntegrationTest.java
@@ -35,8 +35,10 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.jxmpp.jid.Jid;
 
+@SpecificationReference(document = "XEP-0199")
 public class PingIntegrationTest extends AbstractSmackIntegrationTest {
 
     public PingIntegrationTest(SmackIntegrationTestEnvironment environment) {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/pubsub/PubSubIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/pubsub/PubSubIntegrationTest.java
@@ -34,8 +34,10 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.jxmpp.jid.DomainBareJid;
 
+@SpecificationReference(document = "XEP-0060")
 public class PubSubIntegrationTest extends AbstractSmackIntegrationTest {
 
     private final PubSubManager pubSubManagerOne;
@@ -83,19 +85,8 @@ public class PubSubIntegrationTest extends AbstractSmackIntegrationTest {
     }
 
     /**
-
-     */
-
-    /**
      * Asserts that an error is returned when a publish request to a node that is both
      * 'notification-only' as well as 'transient' contains an item element.
-     *
-     * <p>From XEP-0060 § 7.1.3.6:</p>
-     * <blockquote>
-     * If the event type is notification + transient and the publisher provides an item,
-     * the service MUST bounce the publication request with a &lt;bad-request/&gt; error
-     * and a pubsub-specific error condition of &lt;item-forbidden/&gt;.
-     * </blockquote>
      *
      * @throws NoResponseException if there was no response from the remote entity.
      * @throws XMPPErrorException if there was an XMPP error returned.
@@ -104,7 +95,9 @@ public class PubSubIntegrationTest extends AbstractSmackIntegrationTest {
      * @see <a href="https://xmpp.org/extensions/xep-0060.html#publisher-publish-error-badrequest">
      *     7.1.3.6 Request Does Not Match Configuration</a>
      */
-    @SmackIntegrationTest
+    @SmackIntegrationTest(section = "7.1.3.6", quote =
+        "If the event type is notification + transient and the publisher provides an item, the service MUST bounce " +
+        "the publication request with a <bad-request/> error and a pubsub-specific error condition of <item-forbidden/>.")
     public void transientNotificationOnlyNodeWithItemTest() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         final String nodename = "sinttest-transient-notificationonly-withitem-nodename-" + testRunId;
         final String itemId = "sinttest-transient-notificationonly-withitem-itemid-" + testRunId;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/softwareInfo/SoftwareInfoIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/softwareInfo/SoftwareInfoIntegrationTest.java
@@ -33,8 +33,10 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.BeforeClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 
+@SpecificationReference(document = "XEP-0232")
 public class SoftwareInfoIntegrationTest extends AbstractSmackIntegrationTest {
 
     public final SoftwareInfoManager sim1;

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
@@ -32,10 +32,12 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.junit.jupiter.api.Assertions;
 
+@SpecificationReference(document = "XEP-0118")
 public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
 
     private final UserTuneManager utm1;


### PR DESCRIPTION
A new annotation is introduced (`SpecificationReference`) that can be used to annotate a SINT test.

These properties are available in the annotation:
- `document`: Iidentifier for a specification document, such as 'RFC 6120' or 'XEP-0485'
- `section`: Identifier for a section (or paragraph), such as '6.2.1'
- `quote`: A quotation of relevant text from the section

The SINT execution framework is modified so that two new configuration options are available:
- `enabledSpecifications`
- `disabledSpecifications`

These operate on the value of the `document` property of the annotation. Their usage is comparable
to that of the pre-existing `enabledTests` and `disabledTest` configuration options.

Execution output now includes the document, section and quote that's on the annotated test, when
the test fails. This allows an end-user to easily correspond a test failure with a particular
specification.