### PR TITLE
sint: add assertion implementation to SimpleResultSyncPoint

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/AbstractSmackIntTest.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/AbstractSmackIntTest.java
@@ -33,6 +33,11 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 import org.jivesoftware.smack.filter.StanzaFilter;
 
+import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
+
+import org.junit.jupiter.api.Assertions;
+import org.opentest4j.AssertionFailedError;
+
 public abstract class AbstractSmackIntTest {
 
     protected static final Logger LOGGER = Logger.getLogger(AbstractSmackIntTest.class.getName());
@@ -89,5 +94,19 @@ public abstract class AbstractSmackIntTest {
             httpsUrlConnection.setSSLSocketFactory(sinttestConfiguration.sslContextFactory.createSslContext().getSocketFactory());
         }
         return urlConnection;
+    }
+
+    public <R> R assertResult(ResultSyncPoint<R, ?> syncPoint, String message) throws InterruptedException, AssertionFailedError {
+        return assertResult(syncPoint, timeout, message);
+    }
+
+    public static <R> R assertResult(ResultSyncPoint<R, ?> syncPoint, long timeout, String message) throws InterruptedException, AssertionFailedError {
+        try {
+            return syncPoint.waitForResult(timeout);
+        } catch (InterruptedException e) {
+            throw e;
+        } catch (Exception e) {
+            return Assertions.fail(message, e);
+        }
     }
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/SimpleResultSyncPoint.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/SimpleResultSyncPoint.java
@@ -16,8 +16,6 @@
  */
 package org.igniterealtime.smack.inttest.util;
 
-import org.junit.jupiter.api.Assertions;
-
 public class SimpleResultSyncPoint extends ResultSyncPoint<Void, Exception> {
 
     public void signal() {
@@ -30,15 +28,5 @@ public class SimpleResultSyncPoint extends ResultSyncPoint<Void, Exception> {
 
     public void signalFailure(String failureMessage) {
         signal(new Exception(failureMessage));
-    }
-
-    public static void assertSuccess(SimpleResultSyncPoint resultSyncPoint, long timeout, String message) throws InterruptedException {
-        try {
-            resultSyncPoint.waitForResult(timeout);
-        } catch (InterruptedException e) {
-            throw e;
-        } catch (Exception e) {
-            Assertions.fail(message, e);
-        }
     }
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/SimpleResultSyncPoint.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/SimpleResultSyncPoint.java
@@ -18,10 +18,10 @@ package org.igniterealtime.smack.inttest.util;
 
 import org.junit.jupiter.api.Assertions;
 
-public class SimpleResultSyncPoint extends ResultSyncPoint<Boolean, Exception> {
+public class SimpleResultSyncPoint extends ResultSyncPoint<Void, Exception> {
 
     public void signal() {
-        signal(Boolean.TRUE);
+        signal((Void) null);
     }
 
     public void signalFailure() {

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/SimpleResultSyncPoint.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/SimpleResultSyncPoint.java
@@ -16,6 +16,8 @@
  */
 package org.igniterealtime.smack.inttest.util;
 
+import org.junit.jupiter.api.Assertions;
+
 public class SimpleResultSyncPoint extends ResultSyncPoint<Boolean, Exception> {
 
     public void signal() {
@@ -28,5 +30,15 @@ public class SimpleResultSyncPoint extends ResultSyncPoint<Boolean, Exception> {
 
     public void signalFailure(String failureMessage) {
         signal(new Exception(failureMessage));
+    }
+
+    public static void assertSuccess(SimpleResultSyncPoint ResultSyncPoint, long timeout, String message) throws InterruptedException {
+        try {
+            ResultSyncPoint.waitForResult(timeout);
+        } catch (InterruptedException e) {
+            throw e;
+        } catch (Exception e) {
+            Assertions.fail(message, e);
+        }
     }
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/SimpleResultSyncPoint.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/SimpleResultSyncPoint.java
@@ -32,9 +32,9 @@ public class SimpleResultSyncPoint extends ResultSyncPoint<Boolean, Exception> {
         signal(new Exception(failureMessage));
     }
 
-    public static void assertSuccess(SimpleResultSyncPoint ResultSyncPoint, long timeout, String message) throws InterruptedException {
+    public static void assertSuccess(SimpleResultSyncPoint resultSyncPoint, long timeout, String message) throws InterruptedException {
         try {
-            ResultSyncPoint.waitForResult(timeout);
+            resultSyncPoint.waitForResult(timeout);
         } catch (InterruptedException e) {
             throw e;
         } catch (Exception e) {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/LowLevelRosterIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/LowLevelRosterIntegrationTest.java
@@ -63,10 +63,7 @@ public class LowLevelRosterIntegrationTest extends AbstractSmackLowLevelIntegrat
         // conOne.
         conTwo.disconnect();
 
-        Boolean result = offlineTriggered.waitForResult(timeout);
-        if (!result) {
-            throw new Exception("presenceUnavailable() was not called");
-        }
+        SimpleResultSyncPoint.assertSuccess(offlineTriggered, timeout, "presenceUnavailable() was not called");
     }
 
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/LowLevelRosterIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/LowLevelRosterIntegrationTest.java
@@ -63,7 +63,7 @@ public class LowLevelRosterIntegrationTest extends AbstractSmackLowLevelIntegrat
         // conOne.
         conTwo.disconnect();
 
-        SimpleResultSyncPoint.assertSuccess(offlineTriggered, timeout, "presenceUnavailable() was not called");
+        assertResult(offlineTriggered, "presenceUnavailable() was not called");
     }
 
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/RosterIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/RosterIntegrationTest.java
@@ -16,8 +16,6 @@
  */
 package org.jivesoftware.smack.roster;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Collection;
 import java.util.concurrent.TimeoutException;
 
@@ -101,7 +99,7 @@ public class RosterIntegrationTest extends AbstractSmackIntegrationTest {
         try {
             rosterOne.createItemAndRequestSubscription(conTwo.getUser().asBareJid(), conTwosRosterName, null);
 
-            assertTrue(addedAndSubscribed.waitForResult(2 * connection.getReplyTimeout()));
+            SimpleResultSyncPoint.assertSuccess(addedAndSubscribed, 2 * connection.getReplyTimeout(), "Did not receive expected roster item.");
         }
         finally {
             rosterTwo.removeSubscribeListener(subscribeListener);

--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/RosterIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/RosterIntegrationTest.java
@@ -99,7 +99,7 @@ public class RosterIntegrationTest extends AbstractSmackIntegrationTest {
         try {
             rosterOne.createItemAndRequestSubscription(conTwo.getUser().asBareJid(), conTwosRosterName, null);
 
-            SimpleResultSyncPoint.assertSuccess(addedAndSubscribed, 2 * connection.getReplyTimeout(), "Did not receive expected roster item.");
+            assertResult(addedAndSubscribed, 2 * connection.getReplyTimeout(), "Did not receive expected roster item.");
         }
         finally {
             rosterTwo.removeSubscribeListener(subscribeListener);


### PR DESCRIPTION
By using an assertion, a test that uses a SimpleResultSyncPoint can now fail in a way equal to other test failures. This allows for failure messages to be defined.

Example usage:
```java
SimpleResultSyncPoint.assertSuccess(activeSyncPoint, timeout,
    "Expected " + conTwo.getUser() + " to receive an 'active' chat state from " +
     conOne + " (but they did not).");
```