### PR TITLE
[sinttest] Assertions to have human readable messages

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/LoginIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/LoginIntegrationTest.java
@@ -64,7 +64,8 @@ public class LoginIntegrationTest extends AbstractSmackLowLevelIntegrationTest {
                             () -> connection.login(nonExistentUserString, invalidPassword));
 
             SaslNonza.SASLFailure saslFailure = saslErrorException.getSASLFailure();
-            assertEquals(SASLError.not_authorized, saslFailure.getSASLError());
+            assertEquals(SASLError.not_authorized, saslFailure.getSASLError(),
+        "Expected the server to return the appropriate SASL failure condition (but it did not)");
         } finally {
             connection.disconnect();
         }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/StreamManagementTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/StreamManagementTest.java
@@ -32,6 +32,7 @@ import org.igniterealtime.smack.inttest.AbstractSmackSpecificLowLevelIntegration
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.jxmpp.jid.EntityFullJid;
 
 public class StreamManagementTest extends AbstractSmackSpecificLowLevelIntegrationTest<XMPPTCPConnection> {
 
@@ -57,7 +58,7 @@ public class StreamManagementTest extends AbstractSmackSpecificLowLevelIntegrati
 
         try {
             send(body1, conOne, conTwo);
-            assertMessageWithBodyReceived(body1, collector);
+            assertMessageWithBodyReceived(body1, collector, conTwo.getUser());
 
             conOne.instantShutdown();
 
@@ -65,10 +66,10 @@ public class StreamManagementTest extends AbstractSmackSpecificLowLevelIntegrati
 
             // Reconnect with xep198
             conOne.connect().login();
-            assertMessageWithBodyReceived(body2, collector);
+            assertMessageWithBodyReceived(body2, collector, conTwo.getUser());
 
             send(body3, conOne, conTwo);
-            assertMessageWithBodyReceived(body3, collector);
+            assertMessageWithBodyReceived(body3, collector, conTwo.getUser());
         }
         finally {
             collector.cancel();
@@ -84,9 +85,9 @@ public class StreamManagementTest extends AbstractSmackSpecificLowLevelIntegrati
         from.sendStanza(message);
     }
 
-    private static void assertMessageWithBodyReceived(String body, StanzaCollector collector) throws InterruptedException {
+    private static void assertMessageWithBodyReceived(String body, StanzaCollector collector, EntityFullJid recipient) throws InterruptedException {
         Message message = collector.nextResult();
-        assertNotNull(message);
-        assertEquals(body, message.getBody());
+        assertNotNull(message, "Expected '" + recipient + "' to receive a message stanza with body '" + body + "', but it didn't receive the message stanza at all.");
+        assertEquals(body, message.getBody(), "Expected '" + recipient + "'to receive a message stanza with a specific body, but it received a message stanza with a different body.");
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/WaitForClosingStreamElementTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/WaitForClosingStreamElementTest.java
@@ -39,6 +39,6 @@ public class WaitForClosingStreamElementTest extends AbstractSmackLowLevelIntegr
         Field closingStreamReceivedField = AbstractXMPPConnection.class.getDeclaredField("closingStreamReceived");
         closingStreamReceivedField.setAccessible(true);
         boolean closingStreamReceived = (boolean) closingStreamReceivedField.get(connection);
-        assertTrue(closingStreamReceived);
+        assertTrue(closingStreamReceived, "Expected to, but did not, receive a closing stream element on connection " + connection);
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/RosterIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/RosterIntegrationTest.java
@@ -16,8 +16,6 @@
  */
 package org.jivesoftware.smack.roster;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Collection;
 import java.util.concurrent.TimeoutException;
 
@@ -78,16 +76,16 @@ public class RosterIntegrationTest extends AbstractSmackIntegrationTest {
                     BareJid bareJid = conTwo.getUser().asBareJid();
                     RosterEntry rosterEntry = rosterOne.getEntry(bareJid);
                     if (rosterEntry == null) {
-                        addedAndSubscribed.signalFailure("No roster entry for " + bareJid);
+                        addedAndSubscribed.signalFailure("Added/Updated entry was not for " + bareJid);
                         return;
                     }
                     String name = rosterEntry.getName();
                     if (StringUtils.isNullOrEmpty(name)) {
-                        addedAndSubscribed.signalFailure("Roster entry without name");
+                        addedAndSubscribed.signalFailure("Added/Updated entry without name");
                         return;
                     }
                     if (!rosterEntry.getName().equals(conTwosRosterName)) {
-                        addedAndSubscribed.signalFailure("Roster name does not match");
+                        addedAndSubscribed.signalFailure("Added/Updated entry name does not match. Expected: " + conTwosRosterName + " but was: " + rosterEntry.getName());
                         return;
                     }
                     if (!rosterEntry.getType().equals(ItemType.to)) {
@@ -100,8 +98,9 @@ public class RosterIntegrationTest extends AbstractSmackIntegrationTest {
 
         try {
             rosterOne.createItemAndRequestSubscription(conTwo.getUser().asBareJid(), conTwosRosterName, null);
-
-            assertTrue(addedAndSubscribed.waitForResult(2 * connection.getReplyTimeout()));
+            assertResult(addedAndSubscribed, 2 * connection.getReplyTimeout(),
+                "A roster entry for " + conTwo.getUser().asBareJid() + " using the name '" + conTwosRosterName +
+                "' of type 'to' was expected to be added to the roster of " + conOne.getUser() + " (but it was not).");
         }
         finally {
             rosterTwo.removeSubscribeListener(subscribeListener);

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/caps/EntityCapsTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/caps/EntityCapsTest.java
@@ -18,6 +18,7 @@ package org.jivesoftware.smackx.caps;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -96,7 +97,9 @@ public class EntityCapsTest extends AbstractSmackIntegrationTest {
     public void testLocalEntityCaps() throws InterruptedException, NoResponseException, XMPPErrorException, NotConnectedException {
         final String dummyFeature = getNewDummyFeature();
         DiscoverInfo info = EntityCapsManager.getDiscoveryInfoByNodeVer(ecmTwo.getLocalNodeVer());
-        assertFalse(info.containsFeature(dummyFeature));
+        assertFalse(info.containsFeature(dummyFeature),
+            "Expected the service discovery info for node '" + ecmTwo.getLocalNodeVer() +
+            "' to contain the feature '" + dummyFeature + "' (but it did not)."); // TODO Shouldn't this assertion be in a unit test instead of an integration test?
 
         dropWholeEntityCapsCache();
 
@@ -120,8 +123,12 @@ public class EntityCapsTest extends AbstractSmackIntegrationTest {
         // The other connection has to receive this stanza and record the
         // information in order for this test to succeed.
         info = EntityCapsManager.getDiscoveryInfoByNodeVer(ecmTwo.getLocalNodeVer());
-        assertNotNull(info);
-        assertTrue(info.containsFeature(dummyFeature));
+        assertNotNull(info,
+    "Expected '" + conOne.getUser() + "' to have received an 'available' presence from '" + conTwo.getUser() +
+            "' with a new CAPS 'ver' attribute (but it did not).");
+        assertTrue(info.containsFeature(dummyFeature),
+    "Expected the service discovery info for node '" + ecmTwo.getLocalNodeVer() +
+            "' to contain the feature '" + dummyFeature + "' (but it did not)."); // TODO As above: shouldn't this assertion be in a unit test instead of an integration test?
     }
 
     /**
@@ -148,7 +155,7 @@ public class EntityCapsTest extends AbstractSmackIntegrationTest {
         // discover that
         DiscoverInfo info = sdmOne.discoverInfo(conTwo.getUser());
         // that discovery should cause a disco#info
-        assertTrue(discoInfoSend.get());
+        assertTrue(discoInfoSend.get(), "Expected '" + conOne.getUser() + "' to have made a disco/info request to '" + conTwo.getUser() + "', but it did not.");
         assertTrue(info.containsFeature(dummyFeature),
                         "The info response '" + info + "' does not contain the expected feature '" + dummyFeature + '\'');
         discoInfoSend.set(false);
@@ -156,8 +163,9 @@ public class EntityCapsTest extends AbstractSmackIntegrationTest {
         // discover that
         info = sdmOne.discoverInfo(conTwo.getUser());
         // that discovery shouldn't cause a disco#info
-        assertFalse(discoInfoSend.get());
-        assertTrue(info.containsFeature(dummyFeature));
+        assertFalse(discoInfoSend.get(), "Expected '" + conOne.getUser() + "' to not have made a disco/info request to '" + conTwo.getUser() + "' (as CAPS should have been cached), but it did not.");
+        assertTrue(info.containsFeature(dummyFeature),
+            "The info response '" + info + "' does not contain the expected feature '" + dummyFeature + '\'');
     }
 
     @SmackIntegrationTest
@@ -167,7 +175,8 @@ public class EntityCapsTest extends AbstractSmackIntegrationTest {
         addFeatureAndWaitForPresence(conOne, conTwo, dummyFeature);
         String nodeVerAfter = EntityCapsManager.getNodeVersionByJid(conTwo.getUser());
 
-        assertFalse(nodeVerBefore.equals(nodeVerAfter));
+        assertNotEquals(nodeVerBefore, nodeVerAfter,
+            "Expected the reported node 'ver' value to differ after a feature was added (but it did not).");
     }
 
     @SmackIntegrationTest
@@ -193,12 +202,12 @@ public class EntityCapsTest extends AbstractSmackIntegrationTest {
         DiscoverInfo info = sdmOne.discoverInfo(conTwo.getUser());
 
         String u1ver = EntityCapsManager.getNodeVersionByJid(conTwo.getUser());
-        assertNotNull(u1ver);
+        assertNotNull(u1ver, "Expected " + conOne.getUser() + " to have received a CAPS 'ver' value for " + conTwo.getUser() + " (but did not).");
 
         DiscoverInfo entityInfo = EntityCapsManager.CAPS_CACHE.lookup(u1ver);
-        assertNotNull(entityInfo);
+        assertNotNull(entityInfo, "Expected the local static cache to have a value cached for 'ver' value '" + u1ver + "' (but it did not).");
 
-        assertEquals(info.toXML().toString(), entityInfo.toXML().toString());
+        assertEquals(info.toXML().toString(), entityInfo.toXML().toString(), "Expected the cached service/discovery info to be equal to the original (but it was not).");
     }
 
     private static void dropWholeEntityCapsCache() {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/chatstate/ChatStateIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/chatstate/ChatStateIntegrationTest.java
@@ -75,7 +75,7 @@ public class ChatStateIntegrationTest extends AbstractSmackIntegrationTest {
         Chat chat = ChatManager.getInstanceFor(conOne)
                 .chatWith(conTwo.getUser().asEntityBareJid());
         chat.send("Hi!");
-        activeSyncPoint.waitForResult(timeout);
+        assertResult(activeSyncPoint, "Expected " + conTwo.getUser() + " to receive an 'active' chat state from " + conOne + " (but they did not).");
     }
 
     @AfterClass

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandIntegrationTest.java
@@ -73,7 +73,9 @@ public class AdHocCommandIntegrationTest extends AbstractSmackIntegrationTest {
             AdHocCommandData response = result.getResponse();
             DataForm form = response.getForm();
             FormField field = form.getField("my-field");
-            assertNotNull(field);
+            assertNotNull(field, "Expected a field named 'my-field' to exist in the form that " +
+                conTwo.getUser() + " obtained from " + conOne.getUser() + "'s command node '" + commandNode +
+                "' (but it did not).");
         } finally {
             manOne.unregisterCommand(commandNode);
         }
@@ -259,7 +261,10 @@ public class AdHocCommandIntegrationTest extends AbstractSmackIntegrationTest {
             AdHocCommandResult.StatusCompleted completed = command.complete(submitForm).asCompletedOrThrow();
 
             String operationResult = completed.getResponse().getForm().getField("result").getFirstValue();
-            assertEquals("65", operationResult);
+            assertEquals("65", operationResult,
+                "Unexpected value in the field 'result' from the command result that " + conTwo.getUser() +
+                " received from " + conOne.getUser() + " after completing a multi-staged ad-hoc command on node '" +
+                commandNode + "'.");
         } finally {
             manTwo.unregisterCommand(commandNode);
         }
@@ -317,7 +322,10 @@ public class AdHocCommandIntegrationTest extends AbstractSmackIntegrationTest {
             AdHocCommandResult.StatusCompleted completed = command.complete(submitForm).asCompletedOrThrow();
 
             String operationResult = completed.getResponse().getForm().getField("result").getFirstValue();
-            assertEquals("100", operationResult);
+            assertEquals("100", operationResult,
+                "Unexpected value in the field 'result' from the command result that " + conTwo.getUser() +
+                " received from " + conOne.getUser() + " after completing a multi-staged ad-hoc command on node '" +
+                commandNode + "'.");
         } finally {
             manTwo.unregisterCommand(commandNode);
         }
@@ -346,7 +354,9 @@ public class AdHocCommandIntegrationTest extends AbstractSmackIntegrationTest {
             SubmitForm submitForm = form.getSubmitForm();
 
             XMPPErrorException exception = assertThrows(XMPPErrorException.class, () -> command.next(submitForm));
-            assertEquals(exception.getStanzaError().getCondition(), StanzaError.Condition.bad_request);
+            assertEquals(exception.getStanzaError().getCondition(), StanzaError.Condition.bad_request,
+        "Unexpected error condition received after " + conTwo.getUser() + " supplied an invalid argument " +
+                "to the command node '" + commandNode + "' of " + conOne.getUser());
         } finally {
             manTwo.unregisterCommand(commandNode);
         }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/filetransfer/FileTransferIntegrationTest.java
@@ -32,7 +32,7 @@ import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
-import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 
 @SpecificationReference(document = "XEP-0096")
 public class FileTransferIntegrationTest extends AbstractSmackIntegrationTest {
@@ -67,7 +67,7 @@ public class FileTransferIntegrationTest extends AbstractSmackIntegrationTest {
     }
 
     private void genericfileTransferTest() throws Exception {
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
         final FileTransferListener receiveListener = new FileTransferListener() {
             @Override
             public void fileTransferRequest(FileTransferRequest request) {
@@ -84,7 +84,7 @@ public class FileTransferIntegrationTest extends AbstractSmackIntegrationTest {
                     os.flush();
                     dataReceived = os.toByteArray();
                     if (Arrays.equals(dataToSend, dataReceived)) {
-                        resultSyncPoint.signal("Received data matches send data. \\o/");
+                        resultSyncPoint.signal();
                     }
                     else {
                         resultSyncPoint.signal(new Exception("Received data does not match"));
@@ -117,7 +117,9 @@ public class FileTransferIntegrationTest extends AbstractSmackIntegrationTest {
             }
         }
 
-        resultSyncPoint.waitForResult(MAX_FT_DURATION * 1000);
+        assertResult(resultSyncPoint, MAX_FT_DURATION * 1000,
+    "Expected data to be transferred successfully from " + conOne.getUser() + " to " + conTwo.getUser() +
+            " (but it did not).");
 
         ftManagerTwo.removeFileTransferListener(receiveListener);
     }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
@@ -17,7 +17,6 @@
 package org.jivesoftware.smackx.geolocation;
 
 import java.net.URI;
-import java.util.concurrent.TimeoutException;
 
 import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
@@ -37,7 +36,6 @@ import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
-import org.junit.jupiter.api.Assertions;
 import org.jxmpp.util.XmppDateTime;
 
 @SpecificationReference(document = "XEP-0080")
@@ -108,14 +106,9 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
             glm1.publishGeoLocation(data); // for the purpose of this test, this needs not be blocking/use publishAndWait();
 
             // Wait for the data to be received.
-            try {
-                Object result = geoLocationReceived.waitForResult(timeout);
-
-                // Explicitly assert the success case.
-                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
-            } catch (TimeoutException e) {
-                Assertions.fail("Expected to receive a PEP notification, but did not.");
-            }
+            assertResult(geoLocationReceived,
+        "Expected " + conTwo.getUser() + " to receive a PEP notification from " + conOne.getUser() +
+                " that contained '" + data.toXML() + "', but did not.");
         } finally {
             unregisterListener(glm2, geoLocationListener);
         }
@@ -173,14 +166,9 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
             registerListenerAndWait(glm2, ServiceDiscoveryManager.getInstanceFor(conTwo), geoLocationListener);
 
             // Wait for the data to be received.
-            try {
-                Object result = geoLocationReceived.waitForResult(timeout);
-
-                // Explicitly assert the success case.
-                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
-            } catch (TimeoutException e) {
-                Assertions.fail("Expected to receive a PEP notification, but did not.");
-            }
+            assertResult(geoLocationReceived,
+        "Expected " + conTwo.getUser() + " to receive a PEP notification from " + conOne.getUser() +
+                " that contained '" + data.toXML() + "', but did not.");
         } finally {
             unregisterListener(glm2, geoLocationListener);
         }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadIntegrationTest.java
@@ -104,6 +104,6 @@ public class HttpFileUploadIntegrationTest extends AbstractSmackIntegrationTest 
 
         byte[] downBytes = baos.toByteArray();
 
-        assertArrayEquals(upBytes, downBytes);
+        assertArrayEquals(upBytes, downBytes, "Expected the downloaded bytes to be equal to the uploaded bytes (but they were not).");
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTControlIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTControlIntegrationTest.java
@@ -89,7 +89,7 @@ public class IoTControlIntegrationTest extends AbstractSmackIntegrationTest {
 
             SetData data = new SetBoolData(testRunId, true);
             IoTSetResponse response = IoTControlManagerTwo.setUsingIq(conOne.getUser(), data);
-            assertNotNull(response);
+            assertNotNull(response, "Expected " + conOne.getUser() + " to receive an IQ response with an 'setResponse' child element, but no such response was received.");
         }
         finally {
             IoTControlManagerOne.uninstallThing(controlThing);

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTDataIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTDataIntegrationTest.java
@@ -86,23 +86,23 @@ public class IoTDataIntegrationTest extends AbstractSmackIntegrationTest {
             IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
 
-        assertEquals(1, values.size());
+        assertEquals(1, values.size(), "An unexpected amount of momentary values was received by " + conOne.getUser());
         IoTFieldsExtension iotFieldsExtension = values.get(0);
         List<NodeElement> nodes = iotFieldsExtension.getNodes();
 
-        assertEquals(1, nodes.size());
+        assertEquals(1, nodes.size(), "The momentary value received by " + conOne.getUser() + " contains an unexpected amount of nodes.");
         NodeElement node = nodes.get(0);
         List<TimestampElement> timestamps = node.getTimestampElements();
 
-        assertEquals(1, timestamps.size());
+        assertEquals(1, timestamps.size(), "The node received by " + conOne.getUser() + " contains an unexpected amount of timestamps.");
         TimestampElement timestamp = timestamps.get(0);
         List<? extends IoTDataField> fields = timestamp.getDataFields();
 
-        assertEquals(1, fields.size());
+        assertEquals(1, fields.size(), "The timestamp received by " + conOne.getUser() + " contains an unexpected amount of data fields.");
         IoTDataField dataField = fields.get(0);
-        assertTrue(dataField instanceof IoTDataField.IntField);
+        assertTrue(dataField instanceof IoTDataField.IntField, "The data field received by " + conOne.getUser() + " was expected to be an instance of " + IoTDataField.IntField.class.getSimpleName() + ", but instead, it was " + dataField.getClass().getSimpleName());
         IoTDataField.IntField intDataField = (IoTDataField.IntField) dataField;
-        assertEquals(testRunId, intDataField.getName());
-        assertEquals(value, intDataField.getValue());
+        assertEquals(testRunId, intDataField.getName(), "Unexpected name in the data field received by " + conOne.getUser());
+        assertEquals(value, intDataField.getValue(), "Unexpected value in the data field received by " + conOne.getUser());
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTDiscoveryIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/iot/IoTDiscoveryIntegrationTest.java
@@ -62,7 +62,7 @@ public class IoTDiscoveryIntegrationTest extends AbstractSmackIntegrationTest {
         registerThing(discoveryManagerOne, thing);
 
         IoTClaimed iotClaimed = discoveryManagerTwo.claimThing(thing.getMetaTags());
-        assertEquals(conOne.getUser().asBareJid(), iotClaimed.getJid());
+        assertEquals(conOne.getUser().asBareJid(), iotClaimed.getJid(), "Thing claimed by an unexpected JID");
 
         discoveryManagerTwo.disownThing(iotClaimed.getJid());
 

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/iqversion/VersionIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/iqversion/VersionIntegrationTest.java
@@ -47,8 +47,8 @@ public class VersionIntegrationTest extends AbstractSmackIntegrationTest {
         final String versionName = "Smack Integration Test " + testRunId;
         versionManagerTwo.setVersion(versionName, "1.0");
 
-        assertTrue (versionManagerOne.isSupported(conTwo.getUser()));
+        assertTrue(versionManagerOne.isSupported(conTwo.getUser()), "Expected " + conTwo.getUser() + " to support " + Version.NAMESPACE + " (but it does not).");
         Version version = versionManagerOne.getVersion(conTwo.getUser());
-        assertEquals(versionName, version.getName());
+        assertEquals(versionName, version.getName(), "Unexpected version name reported by " + conTwo.getUser());
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mam/MamIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mam/MamIntegrationTest.java
@@ -115,14 +115,14 @@ public class MamIntegrationTest extends AbstractSmackIntegrationTest {
             .build();
         MamQuery mamQuery = mamManagerConTwo.queryArchive(mamQueryArgs);
 
-        assertEquals(1, mamQuery.getMessages().size());
+        assertEquals(1, mamQuery.getMessages().size(), conTwo.getUser() + " received an unexpected amount of messages in response to a MAM query.");
 
         Message mamMessage = mamQuery.getMessages().get(0);
 
-        assertEquals(messageId, mamMessage.getStanzaId());
-        assertEquals(messageBody, mamMessage.getBody());
-        assertEquals(conOne.getUser(), mamMessage.getFrom());
-        assertEquals(userTwo, mamMessage.getTo());
+        assertEquals(messageId, mamMessage.getStanzaId(), "The message received by " + conTwo.getUser() + " via a MAM query has an unexpected stanza ID.");
+        assertEquals(messageBody, mamMessage.getBody(), "The message received by " + conTwo.getUser() + " via a MAM query has an unexpected body.");
+        assertEquals(conOne.getUser(), mamMessage.getFrom(), "The message received by " + conTwo.getUser() + " via a MAM query has an unexpected from-attribute value.");
+        assertEquals(userTwo, mamMessage.getTo(), "The message received by " + conTwo.getUser() + " via a MAM query has an unexpected to-attribute value.");
     }
 
     @SmackIntegrationTest
@@ -176,8 +176,8 @@ public class MamIntegrationTest extends AbstractSmackIntegrationTest {
 
         MamQuery mamQuery = mamManagerConTwo.queryArchive(mamQueryArgs);
 
-        assertFalse(mamQuery.isComplete());
-        assertEquals(messagesPerPage, mamQuery.getMessageCount());
+        assertFalse(mamQuery.isComplete(), "Expected the first MAM response received by " + conTwo.getUser() + " to NOT be complete (but it was).");
+        assertEquals(messagesPerPage, mamQuery.getMessageCount(), "Unexpected message count in MAM response received by " + conTwo.getUser());
 
         List<List<Message>> pages = new ArrayList<>(numPages);
         pages.add(mamQuery.getMessages());
@@ -187,12 +187,12 @@ public class MamIntegrationTest extends AbstractSmackIntegrationTest {
 
             boolean isLastQuery = additionalPageRequestNum == numPages - 2;
             if (isLastQuery) {
-                assertTrue(mamQuery.isComplete());
+                assertTrue(mamQuery.isComplete(), "Expected the last MAM response received by " + conTwo.getUser() + " to be complete (but it was not).");
             } else {
-                assertFalse(mamQuery.isComplete());
+                assertFalse(mamQuery.isComplete(), "Expected an intermediate MAM response received by " + conTwo.getUser() + " to NOT be complete (but it was).");
             }
 
-            assertEquals(messagesPerPage, page.size());
+            assertEquals(messagesPerPage, page.size(), "Unexpected amount of messages in the MAM response page received by " + conTwo.getUser());
 
             pages.add(page);
         }
@@ -202,13 +202,13 @@ public class MamIntegrationTest extends AbstractSmackIntegrationTest {
             queriedMessages.addAll(messages);
         }
 
-        assertEquals(outgoingMessages.size(), queriedMessages.size());
+        assertEquals(outgoingMessages.size(), queriedMessages.size(), "An unexpected total number of messages was received through MAM by " + conTwo.getUser());
 
         for (int i = 0; i < outgoingMessages.size(); i++) {
             Message outgoingMessage = outgoingMessages.get(i);
             Message queriedMessage = queriedMessages.get(i);
 
-            assertEquals(outgoingMessage.getBody(), queriedMessage.getBody());
+            assertEquals(outgoingMessage.getBody(), queriedMessage.getBody(), "Unexpected message body for message number " + (i + 1) + " as received by " + conTwo.getUser() + " (are messages received out of order?)");
         }
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
@@ -16,8 +16,6 @@
  */
 package org.jivesoftware.smackx.mood;
 
-import java.util.concurrent.TimeoutException;
-
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
 
@@ -33,7 +31,6 @@ import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
-import org.junit.jupiter.api.Assertions;
 
 @SpecificationReference(document = "XEP-0107")
 public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
@@ -82,11 +79,7 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
             mm1.setMood(data); // for the purpose of this test, this needs not be blocking/use publishAndWait();
 
             // Wait for the data to be received.
-            try {
-                moodReceived.waitForResult(timeout);
-            } catch (TimeoutException e) {
-                Assertions.fail("Expected to receive a PEP notification, but did not.");
-            }
+            assertResult(moodReceived, "Expected " + conTwo.getUser() + " to receive a PEP notification, but did not.");
         } finally {
             unregisterListener(mm2, moodListener);
         }
@@ -121,14 +114,7 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
             registerListenerAndWait(mm2, ServiceDiscoveryManager.getInstanceFor(conTwo), moodListener);
 
             // Wait for the data to be received.
-            try {
-                Object result = moodReceived.waitForResult(timeout);
-
-                // Explicitly assert the success case.
-                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
-            } catch (TimeoutException e) {
-                Assertions.fail("Expected to receive a PEP notification, but did not.");
-            }
+            assertResult(moodReceived, "Expected " + conTwo.getUser() + " to receive a PEP notification, but did not.");
         } finally {
             unregisterListener(mm2, moodListener);
         }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatLowLevelIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatLowLevelIntegrationTest.java
@@ -85,7 +85,7 @@ public class MultiUserChatLowLevelIntegrationTest extends AbstractSmackLowLevelI
         // So we trigger it manually here.
         MucBookmarkAutojoinManager.getInstanceFor(connection).autojoinBookmarkedConferences();
 
-       assertTrue(muc.isJoined());
+       assertTrue(muc.isJoined(), "Expected " + connection.getUser() + " to automatically join room " + muc.getRoom() + " after a reconnect, but it did not.");
 
        // If the test went well, leave the MUC
        muc.leave();

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatRolesAffiliationsPrivilegesIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatRolesAffiliationsPrivilegesIntegrationTest.java
@@ -23,6 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.TimeoutException;
 
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
@@ -34,6 +37,7 @@ import org.igniterealtime.smack.inttest.TestNotPossibleException;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
 import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.Jid;
@@ -65,12 +69,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByTwo.addUserStatusListener(new UserStatusListener() {
             @Override
             public void moderatorGranted() {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -83,7 +87,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             // success" in §9.6, since it'll throw on either an error IQ or on no response.
             mucAsSeenByOne.grantModerator(nicknameTwo);
 
-            resultSyncPoint.waitForResult(timeout);
+            assertResult(resultSyncPoint, "Expected " + conTwo.getUser() + " to get a presence update after it was granted the role 'moderator' role in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -105,12 +109,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByThree = mucManagerThree.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByThree.addParticipantStatusListener(new ParticipantStatusListener() {
             @Override
             public void moderatorGranted(EntityFullJid participant) {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -122,7 +126,8 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByThree.join(nicknameThree);
 
             mucAsSeenByOne.grantModerator(nicknameTwo);
-            resultSyncPoint.waitForResult(timeout);
+
+            assertResult(resultSyncPoint, "Expected " + conThree.getUser() + " to get a presence update after another user in the room was granted the 'moderator' role in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -144,12 +149,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByTwo.addUserStatusListener(new UserStatusListener() {
             @Override
             public void moderatorRevoked() {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -160,7 +165,8 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
 
             mucAsSeenByOne.grantModerator(nicknameTwo);
             mucAsSeenByOne.revokeModerator(nicknameTwo);
-            resultSyncPoint.waitForResult(timeout);
+
+            assertResult(resultSyncPoint, "Expected " + conTwo.getUser() + " to get a presence update after its 'moderator' role in " + mucAddress + " was revoked (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -182,12 +188,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByThree = mucManagerThree.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByThree.addParticipantStatusListener(new ParticipantStatusListener() {
             @Override
             public void moderatorRevoked(EntityFullJid participant) {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -200,7 +206,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
 
             mucAsSeenByOne.grantModerator(nicknameTwo);
             mucAsSeenByOne.revokeModerator(nicknameTwo);
-            resultSyncPoint.waitForResult(timeout);
+            assertResult(resultSyncPoint, "Expected " + conThree.getUser() + " to get a presence update after the 'moderator' role of another user in the room was revoked in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -221,12 +227,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByTwo.addUserStatusListener(new UserStatusListener() {
             @Override
             public void voiceRevoked() {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -235,7 +241,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             final Resourcepart nicknameTwo = Resourcepart.from("two-" + randomString);
             mucAsSeenByTwo.join(nicknameTwo);
             mucAsSeenByOne.revokeVoice(nicknameTwo);
-            resultSyncPoint.waitForResult(timeout);
+            assertResult(resultSyncPoint, "Expected " + conTwo.getUser() + " to get a presence update after its 'voice' privilege was revoked in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -257,12 +263,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByThree = mucManagerThree.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByThree.addParticipantStatusListener(new ParticipantStatusListener() {
             @Override
             public void voiceRevoked(EntityFullJid participant) {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -274,7 +280,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByThree.join(nicknameThree);
 
             mucAsSeenByOne.revokeVoice(nicknameTwo);
-            resultSyncPoint.waitForResult(timeout);
+            assertResult(resultSyncPoint, "Expected " + conThree.getUser() + " to get a presence update after another user's 'voice' privilege was revoked in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -295,13 +301,13 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
 
         mucAsSeenByTwo.addUserStatusListener(new UserStatusListener() {
             @Override
             public void adminGranted() {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -312,7 +318,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
 
             // This implicitly tests "The service MUST add the user to the admin list and then inform the owner of success" in §10.6, since it'll throw on either an error IQ or on no response.
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
-            resultSyncPoint.waitForResult(timeout);
+            assertResult(resultSyncPoint, "Expected " + conTwo.getUser() + " to get a presence update after its was granted 'admin' affiliation in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -335,12 +341,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByThree = mucManagerThree.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByThree.addParticipantStatusListener(new ParticipantStatusListener() {
             @Override
             public void adminGranted(EntityFullJid participant) {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -352,7 +358,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByThree.join(nicknameThree);
 
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
-            resultSyncPoint.waitForResult(timeout);
+            assertResult(resultSyncPoint, "Expected " + conThree.getUser() + " to get a presence update after another user was granted 'admin' affiliation in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -374,12 +380,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByTwo.addUserStatusListener(new UserStatusListener() {
             @Override
             public void adminRevoked() {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -390,7 +396,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
 
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
             mucAsSeenByOne.revokeAdmin(conTwo.getUser().asEntityBareJid());
-            resultSyncPoint.waitForResult(timeout);
+            assertResult(resultSyncPoint, "Expected " + conTwo.getUser() + " to get a presence update after its 'admin' affiliation was revoked in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -425,12 +431,12 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
         MultiUserChat mucAsSeenByThree = mucManagerThree.getMultiUserChat(mucAddress);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
 
         mucAsSeenByThree.addParticipantStatusListener(new ParticipantStatusListener() {
             @Override
             public void adminRevoked(EntityFullJid participant) {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -443,7 +449,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
 
             mucAsSeenByOne.revokeAdmin(conTwo.getUser().asEntityBareJid());
-            resultSyncPoint.waitForResult(timeout);
+            assertResult(resultSyncPoint, "Expected " + conThree.getUser() + " to get a presence update after another user's 'admin' affiliation was revoked in " + mucAddress + " (but it did not).");
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -477,16 +483,18 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByOne.kickParticipant(nicknameTwo, "Nothing personal. Just a test.");
             Presence kickPresence = resultSyncPoint.waitForResult(timeout);
             MUCUser mucUser = MUCUser.from(kickPresence);
-            assertNotNull(mucUser);
+            assertNotNull(mucUser, "Expected, but unable, to create a MUCUser instance from 'kick' presence: " + kickPresence);
             assertAll(
-                    () -> assertTrue(mucUser.getStatus().contains(MUCUser.Status.PRESENCE_TO_SELF_110), "Missing self-presence status code in kick presence"),
-                    () -> assertTrue(mucUser.getStatus().contains(MUCUser.Status.KICKED_307), "Missing kick status code in kick presence"),
-                    () -> assertEquals(MUCRole.none, mucUser.getItem().getRole(), "Role other than 'none' in kick presence")
+                    () -> assertTrue(mucUser.getStatus().contains(MUCUser.Status.PRESENCE_TO_SELF_110), "Missing self-presence status code in kick presence received by " + conTwo.getUser() + " after being kicked from room " + mucAddress),
+                    () -> assertTrue(mucUser.getStatus().contains(MUCUser.Status.KICKED_307), "Missing kick status code in kick presence received by " + conTwo.getUser() + " after being kicked from room " + mucAddress),
+                    () -> assertEquals(MUCRole.none, mucUser.getItem().getRole(), "Role other than 'none' in kick presence received by " + conTwo.getUser() + " after being kicked from room " + mucAddress)
             );
             Jid itemJid = mucUser.getItem().getJid();
             if (itemJid != null) {
-                assertEquals(conTwo.getUser().asEntityFullJidIfPossible(), itemJid, "Incorrect kicked user in kick presence");
+                assertEquals(conTwo.getUser().asEntityFullJidIfPossible(), itemJid, "Incorrect kicked user in kick presence received by " + conTwo.getUser() + " after being kicked from room " + mucAddress);
             }
+        } catch (TimeoutException e) {
+            fail("Expected " + conTwo.getUser() + " to receive a presence update after it was kicked from room " + mucAddress + " (but it did not).", e);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -522,16 +530,18 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByOne.kickParticipant(nicknameTwo, "Nothing personal. Just a test.");
             Presence kickPresence = resultSyncPoint.waitForResult(timeout);
             MUCUser mucUser = MUCUser.from(kickPresence);
-            assertNotNull(mucUser);
+            assertNotNull(mucUser, "Expected, but unable, to create a MUCUser instance from 'kick' presence: " + kickPresence);
             assertAll(
-                    () -> assertFalse(mucUser.getStatus().contains(MUCUser.Status.PRESENCE_TO_SELF_110), "Incorrect self-presence status code in kick presence"),
-                    () -> assertTrue(mucUser.getStatus().contains(MUCUser.Status.KICKED_307), "Missing kick status code in kick presence"),
-                    () -> assertEquals(MUCRole.none, mucUser.getItem().getRole(), "Role other than 'none' in kick presence")
+                    () -> assertFalse(mucUser.getStatus().contains(MUCUser.Status.PRESENCE_TO_SELF_110), "Incorrect self-presence status code in kick presence received by " + conThree.getUser() + " after another user was kicked from room " + mucAddress),
+                    () -> assertTrue(mucUser.getStatus().contains(MUCUser.Status.KICKED_307), "Missing kick status code in kick presence received by " + conThree.getUser() + " after another user was kicked from room " + mucAddress),
+                    () -> assertEquals(MUCRole.none, mucUser.getItem().getRole(), "Role other than 'none' in kick presence received by " + conThree.getUser() + " after another user was kicked from room " + mucAddress)
             );
             Jid itemJid = mucUser.getItem().getJid();
             if (itemJid != null) {
-                assertEquals(conTwo.getUser().asEntityFullJidIfPossible(), itemJid, "Incorrect kicked user in kick presence");
+                assertEquals(conTwo.getUser().asEntityFullJidIfPossible(), itemJid, "Incorrect kicked user in kick presence received by " + conThree.getUser() + " after another user was kicked from room " + mucAddress);
             }
+        } catch (TimeoutException e) {
+            fail("Expected " + conThree.getUser() + " to receive a presence update after another user was kicked from room " + mucAddress + " (but it did not).", e);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -570,8 +580,8 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByThree.leave();
             Presence p2 = mucAsSeenByTwo.join(nicknameTwo);
             Presence p3 = mucAsSeenByThree.join(nicknameThree);
-            assertEquals(MUCAffiliation.owner, MUCUser.from(p2).getItem().getAffiliation());
-            assertEquals(MUCAffiliation.admin, MUCUser.from(p3).getItem().getAffiliation());
+            assertEquals(MUCAffiliation.owner, MUCUser.from(p2).getItem().getAffiliation(), "Unexpected affiliation of " + conTwo.getUser() + " after it re-joined room " + mucAddress);
+            assertEquals(MUCAffiliation.admin, MUCUser.from(p3).getItem().getAffiliation(), "Unexpected affiliation of " + conThree.getUser() + " after it re-joined room " + mucAddress);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -602,8 +612,9 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByTwo.join(nicknameTwo);
             mucAsSeenByOne.grantModerator(nicknameTwo);
             XMPPException.XMPPErrorException xe = assertThrows(XMPPException.XMPPErrorException.class,
-                            () -> mucAsSeenByTwo.revokeVoice(nicknameOne));
-            assertEquals(xe.getStanzaError().getCondition().toString(), "not-allowed");
+                            () -> mucAsSeenByTwo.revokeVoice(nicknameOne),
+                    "Expected an XMPP error when " + conTwo.getUser() + " was trying to revoke the 'voice' privilege of " + conOne.getUser() + " in room " + mucAddress);
+            assertEquals(xe.getStanzaError().getCondition().toString(), "not-allowed", "Unexpected stanza error condition in error returned when " + conTwo.getUser() + " was trying to revoke the 'voice' privilege of " + conOne.getUser() + " in room " + mucAddress);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -640,16 +651,19 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
 
             // Admin cannot revoke from Owner
             XMPPException.XMPPErrorException xe1 = assertThrows(XMPPException.XMPPErrorException.class,
-                            () -> mucAsSeenByTwo.revokeModerator(nicknameOne));
-            // Moderator cannot revoke from Admin
-            XMPPException.XMPPErrorException xe2 = assertThrows(XMPPException.XMPPErrorException.class,
-                            () -> mucAsSeenByThree.revokeModerator(nicknameOne));
+                            () -> mucAsSeenByTwo.revokeModerator(nicknameOne),
+                    "Expected an XMPP error when " + conTwo.getUser() + " (an admin) was trying to revoke the 'moderator' role of " + conOne.getUser() + " (an owner) in room " + mucAddress);
             // Moderator cannot revoke from Owner
+            XMPPException.XMPPErrorException xe2 = assertThrows(XMPPException.XMPPErrorException.class,
+                            () -> mucAsSeenByThree.revokeModerator(nicknameOne),
+                    "Expected an XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conOne.getUser() + " (an owner) in room " + mucAddress);
+            // Moderator cannot revoke from Admin
             XMPPException.XMPPErrorException xe3 = assertThrows(XMPPException.XMPPErrorException.class,
-                            () -> mucAsSeenByThree.revokeModerator(nicknameTwo));
-            assertEquals(xe1.getStanzaError().getCondition().toString(), "not-allowed");
-            assertEquals(xe2.getStanzaError().getCondition().toString(), "not-allowed");
-            assertEquals(xe3.getStanzaError().getCondition().toString(), "not-allowed");
+                            () -> mucAsSeenByThree.revokeModerator(nicknameTwo),
+                "Expected an XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conTwo.getUser() + " (an admin) in room " + mucAddress);
+            assertEquals(xe1.getStanzaError().getCondition().toString(), "not-allowed", "Unexpected condition in XMPP error when " + conTwo.getUser() + " (an admin) was trying to revoke the 'moderator' role of " + conOne.getUser() + " (an owner) in room " + mucAddress);
+            assertEquals(xe2.getStanzaError().getCondition().toString(), "not-allowed", "Unexpected condition in XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conOne.getUser() + " (an owner) in room " + mucAddress);
+            assertEquals(xe3.getStanzaError().getCondition().toString(), "not-allowed", "Unexpected condition in XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conTwo.getUser() + " (an admin) in room " + mucAddress);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -678,23 +692,23 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByTwo.join(nicknameTwo);
             mucAsSeenByThree.join(nicknameThree);
 
-            final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+            final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
             mucAsSeenByOne.addParticipantStatusListener(new ParticipantStatusListener() {
                 @Override
                 public void adminGranted(EntityFullJid participant) {
-                    resultSyncPoint.signal("done");
+                    resultSyncPoint.signal();
                 }
             });
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
             resultSyncPoint.waitForResult(timeout);
 
-            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3);
-            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(
-                            JidCreate.entityFullFrom(mucAddress, nicknameOne)).getRole());
-            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(
-                            JidCreate.entityFullFrom(mucAddress, nicknameTwo)).getRole());
-            assertEquals(MUCRole.participant, mucAsSeenByOne.getOccupant(
-                            JidCreate.entityFullFrom(mucAddress, nicknameThree)).getRole());
+            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3, "Unexpected occupant count in room " + mucAddress);
+            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameOne)).getRole(),
+                "Unexpected role for occupant " + nicknameOne + " of " + mucAddress);
+            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameTwo)).getRole(),
+                        "Unexpected role for occupant " + nicknameTwo + " of " + mucAddress);
+            assertEquals(MUCRole.participant, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameThree)).getRole(),
+                "Unexpected role for occupant " + nicknameThree + " of " + mucAddress);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -718,11 +732,11 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
         final Resourcepart nicknameTwo = Resourcepart.from("two-" + randomString);
         final Resourcepart nicknameThree = Resourcepart.from("three-" + randomString);
 
-        final ResultSyncPoint<String, Exception> resultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint resultSyncPoint = new SimpleResultSyncPoint();
         mucAsSeenByOne.addParticipantStatusListener(new ParticipantStatusListener() {
             @Override
             public void adminGranted(EntityFullJid participant) {
-                resultSyncPoint.signal("done");
+                resultSyncPoint.signal();
             }
         });
 
@@ -744,13 +758,13 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
             resultSyncPoint.waitForResult(timeout);
 
-            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3);
-            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(
-                            JidCreate.entityFullFrom(mucAddress, nicknameOne)).getRole());
-            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(
-                            JidCreate.entityFullFrom(mucAddress, nicknameTwo)).getRole());
-            assertEquals(threeRole, mucAsSeenByOne.getOccupant(
-                            JidCreate.entityFullFrom(mucAddress, nicknameThree)).getRole());
+            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3, "Unexpected occupant count in room " + mucAddress);
+            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameOne)).getRole(),
+                "Unexpected role for occupant " + nicknameOne + " of " + mucAddress);
+            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameTwo)).getRole(),
+                "Unexpected role for occupant " + nicknameTwo + " of " + mucAddress);
+            assertEquals(threeRole, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameThree)).getRole(),
+                "Unexpected role for occupant " + nicknameThree + " of " + mucAddress);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -780,11 +794,11 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
 
         createMembersOnlyMuc(mucAsSeenByOne, nicknameOne);
 
-        final ResultSyncPoint<String, Exception> adminResultSyncPoint = new ResultSyncPoint<>();
+        final SimpleResultSyncPoint adminResultSyncPoint = new SimpleResultSyncPoint();
         mucAsSeenByOne.addParticipantStatusListener(new ParticipantStatusListener() {
             @Override
             public void adminGranted(EntityFullJid participant) {
-                adminResultSyncPoint.signal("done");
+                adminResultSyncPoint.signal();
             }
         });
 
@@ -796,10 +810,10 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByThree.join(nicknameThree);
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
             adminResultSyncPoint.waitForResult(timeout);
-            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3);
-            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(jidOne).getRole());
-            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(jidTwo).getRole());
-            assertEquals(MUCRole.participant, mucAsSeenByOne.getOccupant(jidThree).getRole());
+            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3, "Unexpected occupant count in room " + mucAddress);
+            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(jidOne).getRole(), "Unexpected role for occupant " + jidOne + " in room " + mucAddress);
+            assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(jidTwo).getRole(), "Unexpected role for occupant " + jidTwo + " in room " + mucAddress);
+            assertEquals(MUCRole.participant, mucAsSeenByOne.getOccupant(jidThree).getRole(), "Unexpected role for occupant " + jidThree + " in room " + mucAddress);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/AbstractTwoUsersOmemoIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/AbstractTwoUsersOmemoIntegrationTest.java
@@ -17,7 +17,7 @@
 package org.jivesoftware.smackx.omemo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
 
@@ -51,7 +51,9 @@ public abstract class AbstractTwoUsersOmemoIntegrationTest extends AbstractOmemo
         alice = OmemoManagerSetupHelper.prepareOmemoManager(conOne);
         bob = OmemoManagerSetupHelper.prepareOmemoManager(conTwo);
 
-        assertFalse(alice.getDeviceId().equals(bob.getDeviceId()));
+        // TODO is this a test assertion, or a bug in the test implementation (in which case an Exception should be thrown instead).
+        assertNotEquals(alice.getDeviceId(), bob.getDeviceId(),
+            "Expected device ID for " + conOne.getUser() + " to differ from that of " + conTwo.getUser() + " (but they did not)");
 
         // Subscribe presences
         IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(alice.getConnection(), bob.getConnection(), timeout);
@@ -59,8 +61,10 @@ public abstract class AbstractTwoUsersOmemoIntegrationTest extends AbstractOmemo
         OmemoManagerSetupHelper.trustAllIdentitiesWithTests(alice, bob);    // Alice trusts Bob's devices
         OmemoManagerSetupHelper.trustAllIdentitiesWithTests(bob, alice);    // Bob trusts Alice' and Mallory's devices
 
-        assertEquals(bob.getOwnFingerprint(), alice.getActiveFingerprints(bob.getOwnJid()).get(bob.getOwnDevice()));
-        assertEquals(alice.getOwnFingerprint(), bob.getActiveFingerprints(alice.getOwnJid()).get(alice.getOwnDevice()));
+        assertEquals(bob.getOwnFingerprint(), alice.getActiveFingerprints(bob.getOwnJid()).get(bob.getOwnDevice()),
+            "Expected fingerprint of " + conTwo.getUser() + "'s device as known to " + conOne.getUser() + " to be equal to " + conTwo.getUser() + "'s own fingerprint (but it was not).");
+        assertEquals(alice.getOwnFingerprint(), bob.getActiveFingerprints(alice.getOwnJid()).get(alice.getOwnDevice()),
+            "Expected fingerprint of " + conOne.getUser() + "'s device as known to " + conTwo.getUser() + " to be equal to " + conOne.getUser() + "'s own fingerprint (but it was not).");
     }
 
     @AfterClass

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoMamDecryptionTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/omemo/OmemoMamDecryptionTest.java
@@ -73,11 +73,12 @@ public class OmemoMamDecryptionTest extends AbstractTwoUsersOmemoIntegrationTest
         alicesConnection.sendStanza(encrypted.buildMessage(messageBuilder, bob.getOwnJid()));
 
         MamManager.MamQuery query = bobsMamManager.queryArchive(MamManager.MamQueryArgs.builder().limitResultsToJid(alice.getOwnJid()).build());
-        assertEquals(1, query.getMessageCount());
+        assertEquals(1, query.getMessageCount(), "Unexpected message count in MAM query result of " + bob.getConnection().getUser());
 
         List<MessageOrOmemoMessage> decryptedMamQuery = bob.decryptMamQueryResult(query);
 
-        assertEquals(1, decryptedMamQuery.size());
-        assertEquals(body, decryptedMamQuery.get(decryptedMamQuery.size() - 1).getOmemoMessage().getBody());
+        assertEquals(1, decryptedMamQuery.size(), "Unexpected decrypted message count in MAM query result of " + bob.getConnection().getUser());
+        assertEquals(body, decryptedMamQuery.get(decryptedMamQuery.size() - 1).getOmemoMessage().getBody(),
+            "Expected decrypted body of message retrieved via a MAM query to be equal to the original body that was sent (but it was not).");
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/pubsub/PubSubIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/pubsub/PubSubIntegrationTest.java
@@ -125,9 +125,9 @@ public class PubSubIntegrationTest extends AbstractSmackIntegrationTest {
 
                 Item item = new PayloadItem<>(itemId, dummyPayload);
                 leafNode.publish(item);
-            });
-            assertEquals(StanzaError.Type.MODIFY, e.getStanzaError().getType());
-            assertNotNull(e.getStanzaError().getExtension("item-forbidden", "http://jabber.org/protocol/pubsub#errors"));
+            }, "Expected an error after publishing item " + itemId + " (but none occurred).");
+            assertEquals(StanzaError.Type.MODIFY, e.getStanzaError().getType(), "Unexpected error type");
+            assertNotNull(e.getStanzaError().getExtension("item-forbidden", "http://jabber.org/protocol/pubsub#errors"), "Expected error to contain 'item-forbidden', but it did not.");
         }
         finally {
             pubSubManagerOne.deleteNode(nodename);

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/softwareInfo/SoftwareInfoIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/softwareInfo/SoftwareInfoIntegrationTest.java
@@ -64,7 +64,8 @@ public class SoftwareInfoIntegrationTest extends AbstractSmackIntegrationTest {
             }
         });
         SoftwareInfoForm softwareInfoFormReceived = sim2.fromJid(conOne.getUser());
-        assertEquals(softwareInfoSent, softwareInfoFormReceived);
+        assertEquals(softwareInfoSent, softwareInfoFormReceived,
+            "Expected " + conOne.getUser() + "'s software version info as received by " + conTwo.getUser() + " to be equal to what " + conOne.getUser() + " publishes (but it is not).");
     }
 
     private static SoftwareInfoForm createSoftwareInfoForm() throws URISyntaxException {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
@@ -17,7 +17,6 @@
 package org.jivesoftware.smackx.usertune;
 
 import java.net.URI;
-import java.util.concurrent.TimeoutException;
 
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NotLoggedInException;
@@ -140,14 +139,7 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
             registerListenerAndWait(utm2, ServiceDiscoveryManager.getInstanceFor(conTwo), userTuneListener);
 
             // Wait for the data to be received.
-            try {
-                Object result = userTuneReceived.waitForResult(timeout);
-
-                // Explicitly assert the success case.
-                Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
-            } catch (TimeoutException e) {
-                Assertions.fail("Expected to receive a PEP notification, but did not.");
-            }
+            assertResult(userTuneReceived, "Expected " + conTwo.getUser() + " to receive a PEP notification from " + conOne.getUser() + ", but did not.");
         } finally {
             unregisterListener(utm2, userTuneListener);
         }


### PR DESCRIPTION
This adds text to nearly all assertions in SINT. It is intended that these, together with an XMPP dump of the traffic that was exchanged during the test, allows an observer to have a chance to determine why a particular test failed, without analyzing the test code itself.

~Note that this PR currently pulls in all changes from #582. This PR should be rebased after #582 gets merged.~ (now rebased)