### PR TITLE
[sinttest]: Fix order of arguments in assertEquals()

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/commands/AdHocCommandIntegrationTest.java
@@ -354,7 +354,7 @@ public class AdHocCommandIntegrationTest extends AbstractSmackIntegrationTest {
             SubmitForm submitForm = form.getSubmitForm();
 
             XMPPErrorException exception = assertThrows(XMPPErrorException.class, () -> command.next(submitForm));
-            assertEquals(exception.getStanzaError().getCondition(), StanzaError.Condition.bad_request,
+            assertEquals(StanzaError.Condition.bad_request, exception.getStanzaError().getCondition(),
         "Unexpected error condition received after " + conTwo.getUser() + " supplied an invalid argument " +
                 "to the command node '" + commandNode + "' of " + conOne.getUser());
         } finally {

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatEntityIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatEntityIntegrationTest.java
@@ -185,7 +185,7 @@ public class MultiUserChatEntityIntegrationTest extends AbstractMultiUserChatInt
             expectedCondition = StanzaError.Condition.not_acceptable;
             break;
         }
-        assertEquals(xe.getStanzaError().getCondition(), expectedCondition,
+        assertEquals(expectedCondition, xe.getStanzaError().getCondition(),
             "Unexpected error condition in error returned when " + conTwo.getUser() + " was trying to discover items of " + mucAsSeenByOneUserJid);
     }
 }

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatRolesAffiliationsPrivilegesIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatRolesAffiliationsPrivilegesIntegrationTest.java
@@ -614,7 +614,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             XMPPException.XMPPErrorException xe = assertThrows(XMPPException.XMPPErrorException.class,
                             () -> mucAsSeenByTwo.revokeVoice(nicknameOne),
                     "Expected an XMPP error when " + conTwo.getUser() + " was trying to revoke the 'voice' privilege of " + conOne.getUser() + " in room " + mucAddress);
-            assertEquals(xe.getStanzaError().getCondition().toString(), "not-allowed", "Unexpected stanza error condition in error returned when " + conTwo.getUser() + " was trying to revoke the 'voice' privilege of " + conOne.getUser() + " in room " + mucAddress);
+            assertEquals("not-allowed", xe.getStanzaError().getCondition().toString(), "Unexpected stanza error condition in error returned when " + conTwo.getUser() + " was trying to revoke the 'voice' privilege of " + conOne.getUser() + " in room " + mucAddress);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -661,9 +661,9 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             XMPPException.XMPPErrorException xe3 = assertThrows(XMPPException.XMPPErrorException.class,
                             () -> mucAsSeenByThree.revokeModerator(nicknameTwo),
                 "Expected an XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conTwo.getUser() + " (an admin) in room " + mucAddress);
-            assertEquals(xe1.getStanzaError().getCondition().toString(), "not-allowed", "Unexpected condition in XMPP error when " + conTwo.getUser() + " (an admin) was trying to revoke the 'moderator' role of " + conOne.getUser() + " (an owner) in room " + mucAddress);
-            assertEquals(xe2.getStanzaError().getCondition().toString(), "not-allowed", "Unexpected condition in XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conOne.getUser() + " (an owner) in room " + mucAddress);
-            assertEquals(xe3.getStanzaError().getCondition().toString(), "not-allowed", "Unexpected condition in XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conTwo.getUser() + " (an admin) in room " + mucAddress);
+            assertEquals("not-allowed", xe1.getStanzaError().getCondition().toString(), "Unexpected condition in XMPP error when " + conTwo.getUser() + " (an admin) was trying to revoke the 'moderator' role of " + conOne.getUser() + " (an owner) in room " + mucAddress);
+            assertEquals("not-allowed", xe2.getStanzaError().getCondition().toString(), "Unexpected condition in XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conOne.getUser() + " (an owner) in room " + mucAddress);
+            assertEquals("not-allowed", xe3.getStanzaError().getCondition().toString(), "Unexpected condition in XMPP error when " + conThree.getUser() + " (a moderator) was trying to revoke the 'moderator' role of " + conTwo.getUser() + " (an admin) in room " + mucAddress);
         } finally {
             tryDestroy(mucAsSeenByOne);
         }
@@ -702,7 +702,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
             resultSyncPoint.waitForResult(timeout);
 
-            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3, "Unexpected occupant count in room " + mucAddress);
+            assertEquals(3, mucAsSeenByOne.getOccupantsCount(), "Unexpected occupant count in room " + mucAddress);
             assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameOne)).getRole(),
                 "Unexpected role for occupant " + nicknameOne + " of " + mucAddress);
             assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameTwo)).getRole(),
@@ -758,7 +758,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
             resultSyncPoint.waitForResult(timeout);
 
-            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3, "Unexpected occupant count in room " + mucAddress);
+            assertEquals(3, mucAsSeenByOne.getOccupantsCount(), "Unexpected occupant count in room " + mucAddress);
             assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameOne)).getRole(),
                 "Unexpected role for occupant " + nicknameOne + " of " + mucAddress);
             assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(JidCreate.entityFullFrom(mucAddress, nicknameTwo)).getRole(),
@@ -810,7 +810,7 @@ public class MultiUserChatRolesAffiliationsPrivilegesIntegrationTest extends Abs
             mucAsSeenByThree.join(nicknameThree);
             mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
             adminResultSyncPoint.waitForResult(timeout);
-            assertEquals(mucAsSeenByOne.getOccupantsCount(), 3, "Unexpected occupant count in room " + mucAddress);
+            assertEquals(3, mucAsSeenByOne.getOccupantsCount(), "Unexpected occupant count in room " + mucAddress);
             assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(jidOne).getRole(), "Unexpected role for occupant " + jidOne + " in room " + mucAddress);
             assertEquals(MUCRole.moderator, mucAsSeenByOne.getOccupant(jidTwo).getRole(), "Unexpected role for occupant " + jidTwo + " in room " + mucAddress);
             assertEquals(MUCRole.participant, mucAsSeenByOne.getOccupant(jidThree).getRole(), "Unexpected role for occupant " + jidThree + " in room " + mucAddress);

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/xdata/FormTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/xdata/FormTest.java
@@ -148,8 +148,9 @@ public class FormTest extends AbstractSmackIntegrationTest {
             assertNotNull(completedForm2.getField("name"));
             assertNotNull(completedForm2.getField("description"));
             assertEquals(
-                 completedForm2.getField("name").getValues().get(0).toString(),
-                "Credit card number invalid");
+                 "Credit card number invalid",
+                 completedForm2.getField("name").getValues().get(0).toString()
+                );
             assertNotNull(completedForm2.getField("time"));
             assertNotNull(completedForm2.getField("age"));
             assertEquals("20", completedForm2.getField("age").getValues().get(0).toString(), "The age is bad");

--- a/smack-jingle-old/src/integration-test/java/org/jivesoftware/smackx/jingle/nat/STUNResolverTest.java
+++ b/smack-jingle-old/src/integration-test/java/org/jivesoftware/smackx/jingle/nat/STUNResolverTest.java
@@ -99,7 +99,7 @@ public class STUNResolverTest extends SmackTestCase {
         stunResolver.addCandidate(cand3);
         stunResolver.addCandidate(cand4);
 
-        assertEquals(stunResolver.getPreferredCandidate(), candH);
+        assertEquals(candH, stunResolver.getPreferredCandidate());
     }
 
     /**
@@ -127,7 +127,7 @@ public class STUNResolverTest extends SmackTestCase {
         iceResolver.addCandidate(cand3);
         iceResolver.addCandidate(cand4);
 
-        assertEquals(iceResolver.getPreferredCandidate(), candH);
+        assertEquals(candH, iceResolver.getPreferredCandidate());
     }
 
     /**

--- a/smack-jingle-old/src/integration-test/java/org/jivesoftware/smackx/jingle/nat/TransportCandidateTest.java
+++ b/smack-jingle-old/src/integration-test/java/org/jivesoftware/smackx/jingle/nat/TransportCandidateTest.java
@@ -65,7 +65,7 @@ public class TransportCandidateTest extends SmackTestCase {
         candList.add(cand4);
 
         Collections.sort(candList);
-        assertEquals(candList.get(candList.size() - 1), candH);
+        assertEquals(candH, candList.get(candList.size() - 1));
     }
 
     protected int getMaxConnections() {


### PR DESCRIPTION
When using 'assertEquals', the first argument is to be the _expected_ value, the second the _actual_ value. When this is inverted, the functional test will still succeed, but any generated error message ("Expected X, got Y") will be wrong.

This commit fixes the order of arguments, mostly in the sinttest module.