### PR TITLE
[sinttest] Fix processing of SpecificationReference

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -138,7 +138,7 @@ public class SmackIntegrationTestFramework {
             for (FailedTest failedTest : testRunResult.failedIntegrationTests) {
                 final Throwable cause = failedTest.failureReason;
                 LOGGER.log(Level.SEVERE, failedTest.concreteTest + " failed: " + cause, cause);
-                if (failedTest.concreteTest.method.isAnnotationPresent(SpecificationReference.class)) {
+                if (failedTest.concreteTest.method.getDeclaringClass().isAnnotationPresent(SpecificationReference.class)) {
                     final String specificationReference = getSpecificationReference(failedTest.concreteTest.method);
                     if (specificationReference != null) {
                         bySpecification.add("- " + specificationReference + " (as tested by '" + failedTest.concreteTest + "')");


### PR DESCRIPTION
When refactoring the original implementation, this annotation was expected to be present on methods. It later was changed to be a type-based annotation. This particular usage of the annotation was not properly modified to account for that change.