### PR TITLE
[sinttest] Carry over assertion message when sync point times out

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/AbstractSmackIntTest.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/AbstractSmackIntTest.java
@@ -101,7 +101,7 @@ public abstract class AbstractSmackIntTest {
 
     public static <R> R assertResult(ResultSyncPoint<R, ?> syncPoint, long timeout, String message) throws InterruptedException, TimeoutException, AssertionFailedError {
         try {
-            return syncPoint.waitForResult(timeout);
+            return syncPoint.waitForResult(timeout, message);
         } catch (InterruptedException | TimeoutException e) {
             throw e;
         } catch (Exception e) {

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/ResultSyncPoint.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/ResultSyncPoint.java
@@ -26,6 +26,10 @@ public class ResultSyncPoint<R, E extends Exception> {
     private E exception;
 
     public R waitForResult(long timeout) throws E, InterruptedException, TimeoutException {
+        return waitForResult(timeout, null);
+    }
+
+    public R waitForResult(long timeout, String timeoutMessage) throws E, InterruptedException, TimeoutException {
         synchronized (this) {
             if (result != null) {
                 return result;
@@ -46,7 +50,7 @@ public class ResultSyncPoint<R, E extends Exception> {
         if (exception != null) {
             throw exception;
         }
-        throw new TimeoutException("Timeout expired");
+        throw new TimeoutException(timeoutMessage == null ? "Timeout expired" : timeoutMessage);
     }
 
 


### PR DESCRIPTION
`AbstractSmackIntTest#assertResult()` takes an argument that is an assertion message. When the sync point times out, that message should be logged.

The following illustrates the change, as a result of this assertion failing:

```
assertResult(resultSyncPoint, "Expected " + conTwo.getUser() + " to receive message that was sent by " + conOne.getUser() + " in room " + mucAddress + " (but it did not).");
```

Prior to this change, this is logged:

```
SEVERE: MultiUserChatIntegrationTest.mucTest (Normal) failed: java.util.concurrent.TimeoutException: Timeout expired
java.util.concurrent.TimeoutException: Timeout expired
	at org.igniterealtime.smack.inttest.util.ResultSyncPoint.waitForResult(ResultSyncPoint.java:49)
	at org.igniterealtime.smack.inttest.AbstractSmackIntTest.assertResult(AbstractSmackIntTest.java:104)
	at org.igniterealtime.smack.inttest.AbstractSmackIntTest.assertResult(AbstractSmackIntTest.java:99)
	at org.jivesoftware.smackx.muc.MultiUserChatIntegrationTest.mucTest(MultiUserChatIntegrationTest.java:132)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	(snip)
```

With the change in this commit, that becomes:

```
SEVERE: MultiUserChatIntegrationTest.mucTest (Normal) failed: java.util.concurrent.TimeoutException: Expected smack-inttest-two-jskr4@example.org/two-jskr4 to receive message that was sent by smack-inttest-one-jskr4@example.org/one-jskr4 in room smack-inttest-message-jskr4-aud43i@conference.example.org (but it did not).
java.util.concurrent.TimeoutException: Expected smack-inttest-two-jskr4@example.org/two-jskr4 to receive message that was sent by smack-inttest-one-jskr4@example.org/one-jskr4 in room smack-inttest-message-jskr4-aud43i@conference.example.org (but it did not).
	at org.igniterealtime.smack.inttest.util.ResultSyncPoint.waitForResult(ResultSyncPoint.java:53)
	at org.igniterealtime.smack.inttest.AbstractSmackIntTest.assertResult(AbstractSmackIntTest.java:104)
	at org.igniterealtime.smack.inttest.AbstractSmackIntTest.assertResult(AbstractSmackIntTest.java:99)
	at org.jivesoftware.smackx.muc.MultiUserChatIntegrationTest.mucTest(MultiUserChatIntegrationTest.java:132)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	(snip)
```