### PR TITLE
[sinttest] Expand list of default test packages

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -223,7 +223,7 @@ public class SmackIntegrationTestFramework {
 
         String[] testPackages;
         if (config.testPackages == null || config.testPackages.isEmpty()) {
-            testPackages = new String[] { "org.jivesoftware.smackx", "org.jivesoftware.smack" };
+            testPackages = new String[] { "org.jivesoftware.smackx", "org.jivesoftware.smack", "org.igniterealtime.smackx", "org.igniterealtime.smack" };
         }
         else {
             testPackages = config.testPackages.toArray(new String[config.testPackages.size()]);


### PR DESCRIPTION
The default set of packages that is scanned for integration tests are referencing jivesoftware. This commit adds igniterealtime-oriented package names.
