### PR TITLE
[sinttest] Add optional version to specification reference

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -179,6 +179,9 @@ public class SmackIntegrationTestFramework {
             return null;
         }
         String line = spec.document().trim();
+        if (!spec.version().isBlank()) {
+            line += " (version " + spec.version() + ")";
+        }
 
         final SmackIntegrationTest test = method.getAnnotation(SmackIntegrationTest.class);
         if (!test.section().isBlank()) {

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/annotations/SpecificationReference.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/annotations/SpecificationReference.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Reference to a specific part of a specification.
+ * Reference to a specification document.
  *
  * @author Guus der Kinderen, guus@goodbytes.nl
  */
@@ -38,4 +38,11 @@ public @interface SpecificationReference {
      * @return a document identifier
      */
     String document();
+
+    /**
+     * An optional version number, such as '1.2.0'.
+     *
+     * @return a version number
+     */
+    String version() default "";
 }


### PR DESCRIPTION
Some specifications are versioned. XEPs, for example, typicaly are. It is useful to annotate an implementation with the specific version of the specification that is being tested.