### PR TITLE
[sinttest] Normalization of SpecificationReference to include dash-seperator

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -773,6 +773,6 @@ public final class Configuration {
         if (specification == null || specification.isBlank()) {
             return null;
         }
-        return specification.replaceAll("\\s", "").toUpperCase();
+        return specification.replaceAll("[\\s-]", "").toUpperCase();
     }
 }

--- a/smack-integration-test/src/test/java/org/igniterealtime/smack/inttest/ConfigurationTest.java
+++ b/smack-integration-test/src/test/java/org/igniterealtime/smack/inttest/ConfigurationTest.java
@@ -1,0 +1,98 @@
+/**
+ *
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the functionality that's implemented in {@link Configuration}.
+ */
+public class ConfigurationTest {
+    @Test
+    public void testNormalizeXepUpperCaseNoSeperator() {
+        // Setup test fixture.
+        final String input = "XEP0001";
+
+        // Execute system under test.
+        final String output = Configuration.normalizeSpecification(input);
+
+        // Verify results.
+        assertEquals("XEP0001", output);
+    }
+
+    @Test
+    public void testNormalizeXepLowerCaseNoSeperator() {
+        // Setup test fixture.
+        final String input = "xep0001";
+
+        // Execute system under test.
+        final String output = Configuration.normalizeSpecification(input);
+
+        // Verify results.
+        assertEquals("XEP0001", output);
+    }
+
+    @Test
+    public void testNormalizeXepUpperCaseDash() {
+        // Setup test fixture.
+        final String input = "XEP-0001";
+
+        // Execute system under test.
+        final String output = Configuration.normalizeSpecification(input);
+
+        // Verify results.
+        assertEquals("XEP0001", output);
+    }
+
+    @Test
+    public void testNormalizeXepLowerCaseDash() {
+        // Setup test fixture.
+        final String input = "xep-0001";
+
+        // Execute system under test.
+        final String output = Configuration.normalizeSpecification(input);
+
+        // Verify results.
+        assertEquals("XEP0001", output);
+    }
+
+    @Test
+    public void testNormalizeXepUpperCaseSpace() {
+        // Setup test fixture.
+        final String input = "XEP 0001";
+
+        // Execute system under test.
+        final String output = Configuration.normalizeSpecification(input);
+
+        // Verify results.
+        assertEquals("XEP0001", output);
+    }
+
+    @Test
+    public void testNormalizeXepLowerCaseSpace() {
+        // Setup test fixture.
+        final String input = "xep 0001";
+
+        // Execute system under test.
+        final String output = Configuration.normalizeSpecification(input);
+
+        // Verify results.
+        assertEquals("XEP0001", output);
+    }
+}


### PR DESCRIPTION
When comparing SINT-configuration to annotations, a bit of normalization occurs, to ensure that common variations in denoting a specification are detected to be equal to each-other.

The dash (`-`) character is commonly used when referencing a specification (eg: `XEP-0001`).

This commit ensures that usage of a dash (`-`) character is included in the normalization process, making `XEP 0001`, `XEP0001` and `XEP-0001` all to be identified as the same reference.