### PR TITLE
[sinttest] Configuration.normalizeSpecification() should be public

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -769,7 +769,7 @@ public final class Configuration {
         return disabledSpecifications.contains(normalizeSpecification(specification));
     }
 
-    static String normalizeSpecification(String specification) {
+    public static String normalizeSpecification(String specification) {
         if (specification == null || specification.isBlank()) {
             return null;
         }


### PR DESCRIPTION
It is likely to be desirable to re-use the normalization of specification references, for example in implementations of `TestRunResultProcessor`.