### PR TITLE
[sinttest] prevent NullPointerException in RosterIntegrationTest

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/RosterIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smack/roster/RosterIntegrationTest.java
@@ -412,7 +412,7 @@ public class RosterIntegrationTest extends AbstractSmackIntegrationTest {
         final SimpleResultSyncPoint received = new SimpleResultSyncPoint();
         final StanzaListener stanzaListener = stanza -> {
             final Presence presence = (Presence) stanza;
-            if (presence.getStatus().equals(needle)) {
+            if (needle.equals(presence.getStatus())) {
                 received.signal();
             }
         };


### PR DESCRIPTION
When listening for a presence stanza, assuming that every stanza will have a 'status' can cause NullPointerExceptions to be logged. This commit prevents that.