### PR TITLE
[sinttest] Add new config option: 'host'

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -72,6 +72,8 @@ public final class Configuration {
 
     public final DomainBareJid service;
 
+    public final String host;
+
     public final String serviceTlsPin;
 
     public final SslContextFactory sslContextFactory;
@@ -138,6 +140,7 @@ public final class Configuration {
     private Configuration(Configuration.Builder builder) throws KeyManagementException, NoSuchAlgorithmException {
         service = Objects.requireNonNull(builder.service,
                         "'service' must be set. Either via 'properties' files or via system property 'sinttest.service'.");
+        host = builder.host;
         serviceTlsPin = builder.serviceTlsPin;
         if (serviceTlsPin != null) {
             SSLContext sslContext = Java7Pinning.forPin(serviceTlsPin);
@@ -197,6 +200,9 @@ public final class Configuration {
             }
             b.setSecurityMode(securityMode);
             b.setXmppDomain(service);
+            if (host != null) {
+                b.setHost(host);
+            }
 
             if (debuggerFactory != null) {
                 b.setDebuggerFactory(debuggerFactory);
@@ -221,6 +227,8 @@ public final class Configuration {
     public static final class Builder {
 
         private DomainBareJid service;
+
+        private String host;
 
         private String serviceTlsPin;
 
@@ -284,6 +292,11 @@ public final class Configuration {
 
         public Builder setService(DomainBareJid service) {
             this.service = service;
+            return this;
+        }
+
+        private Builder setHost(String host) {
+            this.host = host;
             return this;
         }
 
@@ -521,6 +534,7 @@ public final class Configuration {
 
         Builder builder = builder();
         builder.setService(properties.getProperty("service"));
+        builder.setHost(properties.getProperty("host"));
         builder.setServiceTlsPin(properties.getProperty("serviceTlsPin"));
         builder.setSecurityMode(properties.getProperty("securityMode"));
         builder.setReplyTimeout(properties.getProperty("replyTimeout", "47000"));

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
@@ -80,6 +80,10 @@
  * <td>XMPP service to run the tests on</td>
  * </tr>
  * <tr>
+ * <td>host</td>
+ * <td>IP address or DNS name of the XMPP service to run the tests on</td>
+ * </tr>
+ * <tr>
  * <td>serviceTlsPin</td>
  * <td>TLS Pin (used by <a href="https://github.com/Flowdalic/java-pinning">java-pinning</a>)</td>
  * </tr>


### PR DESCRIPTION
An optional configuration option for the Smack Integration Test framework has been added that allows one to bypass DNS when resolving a host for the XMPP domain that is the subject of the test.

The `host` option can be used with IP addresses (eg: `-Dsinttest.host=127.0.0.1`) and DNS names (eg: `-Dsinttest.host=example.org`).

The new option was tested with:
- not being defined (making sure it's optional)
- a reachable IP address
- an unreachable IP address
- a reachable DNS name
- an non-resolvable DNS name