### PR TITLE
[sinttest] Fix race condition in MUC test

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOccupantIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOccupantIntegrationTest.java
@@ -214,16 +214,15 @@ public class MultiUserChatOccupantIntegrationTest extends AbstractMultiUserChatI
         final Resourcepart nicknameThree = Resourcepart.from("three-" + randomString);
 
         createMuc(mucAsSeenByOne, nicknameOne);
-        mucAsSeenByTwo.join(nicknameTwo);
-
         SimpleResultSyncPoint oneSeesTwo = new SimpleResultSyncPoint();
         mucAsSeenByOne.addParticipantListener(presence -> {
             if (nicknameTwo.equals(presence.getFrom().getResourceOrEmpty())) {
                 oneSeesTwo.signal();
             }
         });
-        mucAsSeenByOne.grantModerator(nicknameTwo);
+        mucAsSeenByTwo.join(nicknameTwo);
         oneSeesTwo.waitForResult(timeout);
+        mucAsSeenByOne.grantModerator(nicknameTwo);
 
         List<Presence> results = new ArrayList<>();
         mucAsSeenByThree.addParticipantListener(results::add);


### PR DESCRIPTION
When occupant One waits for occupant Two to join the room, One should register the corresponding listener _before_ Two joins.

Without this, a race conditions occurs, where Two could have joined the room before One registered the listener, thus missing the event.
