### PR TITLE
[core] Unique names for threads of Smack Cached Executor service

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/AbstractXMPPConnection.java
@@ -334,10 +334,13 @@ public abstract class AbstractXMPPConnection implements XMPPConnection {
      * them 'daemon'.
      */
     private static final ExecutorService CACHED_EXECUTOR_SERVICE = Executors.newCachedThreadPool(new ThreadFactory() {
+
+        private final AtomicInteger counter = new AtomicInteger(0);
+
         @Override
         public Thread newThread(Runnable runnable) {
             Thread thread = new Thread(runnable);
-            thread.setName("Smack Cached Executor");
+            thread.setName("Smack Cached Executor (" + counter.incrementAndGet() + ")");
             thread.setDaemon(true);
             thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
                 @Override


### PR DESCRIPTION
Having unique names for threads of Smack's own executor service can help with debugging issues.
