### PR TITLE
SMACK-943: Prevent duplicate processing of mediated invitations

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -148,6 +148,7 @@ public final class MultiUserChatManager extends Manager {
     private static final StanzaFilter DIRECT_INVITATION_FILTER =
         new AndFilter(StanzaTypeFilter.MESSAGE,
                       new ExtensionElementFilter<GroupChatInvitation>(GroupChatInvitation.class),
+                      new NotFilter(new ExtensionElementFilter<>(MUCUser.class)),
                       new NotFilter(MessageTypeFilter.ERROR));
 
     private static final ExpirationCache<DomainBareJid, DiscoverInfo> KNOWN_MUC_SERVICES = new ExpirationCache<>(


### PR DESCRIPTION
When a MUC mediated invitation includes the `<x xmlns='jabber:x:conference'>` element (for backwards compatibility), then Smack should not fire the 'direct invitation' event listener. The value for 'inviter' that's used to invoke that listener will be false.