### PR TITLE
[sinttest] Cleanup of test fixtures

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/geolocation/GeolocationIntegrationTest.java
@@ -111,6 +111,7 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
                 " that contained '" + data.toXML() + "', but did not.");
         } finally {
             unregisterListener(glm2, geoLocationListener);
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
     }
 
@@ -171,6 +172,7 @@ public class GeolocationIntegrationTest extends AbstractSmackIntegrationTest {
                 " that contained '" + data.toXML() + "', but did not.");
         } finally {
             unregisterListener(glm2, geoLocationListener);
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
     }
 

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/mood/MoodIntegrationTest.java
@@ -82,6 +82,7 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
             assertResult(moodReceived, "Expected " + conTwo.getUser() + " to receive a PEP notification, but did not.");
         } finally {
             unregisterListener(mm2, moodListener);
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
     }
 
@@ -117,6 +118,7 @@ public class MoodIntegrationTest extends AbstractSmackIntegrationTest {
             assertResult(moodReceived, "Expected " + conTwo.getUser() + " to receive a PEP notification, but did not.");
         } finally {
             unregisterListener(mm2, moodListener);
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
     }
 

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/softwareInfo/SoftwareInfoIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/softwareInfo/SoftwareInfoIntegrationTest.java
@@ -31,6 +31,7 @@ import org.jivesoftware.smackx.softwareinfo.form.SoftwareInfoForm;
 
 import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
 import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.annotations.AfterClass;
 import org.igniterealtime.smack.inttest.annotations.BeforeClass;
 import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
 import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
@@ -52,6 +53,11 @@ public class SoftwareInfoIntegrationTest extends AbstractSmackIntegrationTest {
     @BeforeClass
     public void setUp() throws Exception {
         IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
+    }
+
+    @AfterClass
+    public void cleanUp() throws Exception {
+        IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
     }
 
     @SmackIntegrationTest

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/usertune/UserTuneIntegrationTest.java
@@ -98,6 +98,7 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
             Assertions.assertNotNull(result, "Expected to receive a PEP notification, but did not.");
         } finally {
             unregisterListener(utm2, userTuneListener);
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
     }
 
@@ -142,6 +143,7 @@ public class UserTuneIntegrationTest extends AbstractSmackIntegrationTest {
             assertResult(userTuneReceived, "Expected " + conTwo.getUser() + " to receive a PEP notification from " + conOne.getUser() + ", but did not.");
         } finally {
             unregisterListener(utm2, userTuneListener);
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
     }
 


### PR DESCRIPTION
Additional cleanup of test fixtures:
- various tests that change roster/subscription get a roster-reset
- one test that registers a listener now deregisters that listener