### PR TITLE
[sint] MUC tests should test for room creation permission

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatLowLevelIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatLowLevelIntegrationTest.java
@@ -68,7 +68,12 @@ public class MultiUserChatLowLevelIntegrationTest extends AbstractSmackLowLevelI
         final MultiUserChat muc = multiUserChatManager.getMultiUserChat(JidCreate.entityBareFrom(
                         Localpart.from(randomMucName), mucComponent));
 
-        MucCreateConfigFormHandle handle = muc.createOrJoin(mucNickname);
+        MucCreateConfigFormHandle handle;
+        try {
+            handle = muc.createOrJoin(mucNickname);
+        } catch (XMPPException.XMPPErrorException e) {
+            throw new TestNotPossibleException("MUC service does not allow test users to create a new room.");
+        }
         if (handle != null) {
             handle.makeInstant();
         }


### PR DESCRIPTION
When the service under test does not allow SINT's test users to create a room, the tests should not fail. They should be skipped instead.
