### PR TITLE
[sint] Correct for recent API change

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/ParticipantStatusIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/ParticipantStatusIntegrationTest.java
@@ -28,6 +28,7 @@ import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 /**
  * Tests that verify the correct functionality of Smack's {@link ParticipantStatusListener}.
@@ -35,7 +36,7 @@ import org.jxmpp.jid.parts.Resourcepart;
 @SpecificationReference(document = "XEP-0045", version = "1.34.6")
 public class ParticipantStatusIntegrationTest extends AbstractMultiUserChatIntegrationTest {
 
-    public ParticipantStatusIntegrationTest(SmackIntegrationTestEnvironment environment) throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, InterruptedException, TestNotPossibleException {
+    public ParticipantStatusIntegrationTest(SmackIntegrationTestEnvironment environment) throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, XmppStringprepException, MultiUserChatException.NotAMucServiceException {
         super(environment);
     }
 

--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/UserStatusIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/UserStatusIntegrationTest.java
@@ -30,6 +30,7 @@ import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 /**
  * Tests that verify the correct functionality of Smack's {@link UserStatusListener}.
@@ -37,7 +38,7 @@ import org.jxmpp.jid.parts.Resourcepart;
 @SpecificationReference(document = "XEP-0045", version = "1.34.6")
 public class UserStatusIntegrationTest extends AbstractMultiUserChatIntegrationTest {
 
-    public UserStatusIntegrationTest(SmackIntegrationTestEnvironment environment) throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, InterruptedException, TestNotPossibleException {
+    public UserStatusIntegrationTest(SmackIntegrationTestEnvironment environment) throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, XmppStringprepException, MultiUserChatException.NotAMucServiceException {
         super(environment);
     }
 


### PR DESCRIPTION
The commit that introduced these tests was merged at the same time with an API change.