### PR TITLE
build.gradle: set miniDnsVersion version to the latest 1.0.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ allprojects {
 		// - https://issues.apache.org/jira/browse/MNG-6232
 		// - https://issues.igniterealtime.org/browse/SMACK-858
 		jxmppVersion = '[1.0.0, 1.0.999]'
-		miniDnsVersion = '[1.0.0, 1.0.999]'
+		miniDnsVersion = '1.0.5'
 		smackMinAndroidSdk = 19
 		junitVersion = '5.7.1'
 		commonsIoVersion = '2.6'


### PR DESCRIPTION
The minidns dependency use the range to pick the latest version in range of 1.0.x.
This caused some problems in the Spark that I fixed https://github.com/igniterealtime/Spark/pull/866
Anyway, the minidns now released an alpha version of the 1.1 so it shouldn't be any new versions in the 1.0.x series. So here I changed the range to the latest 1.0.5.