### PR TITLE
[muc] MultiUserChat should have consistent API

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -90,7 +90,6 @@ import org.jivesoftware.smackx.xdata.packet.DataForm;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
-import org.jxmpp.jid.EntityJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
@@ -1757,7 +1756,7 @@ public class MultiUserChat {
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    public void revokeAdmin(EntityJid jid) throws XMPPErrorException, NoResponseException, NotConnectedException, InterruptedException {
+    public void revokeAdmin(Jid jid) throws XMPPErrorException, NoResponseException, NotConnectedException, InterruptedException {
         changeAffiliationByAdmin(jid, MUCAffiliation.member);
     }
 


### PR DESCRIPTION
`org.jivesoftware.smackx.muc.MultiUserChat` has various methods that change affiliation of entities in the room. All of these work on instances of `Jid`, except for `org.jivesoftware.smackx.muc.MultiUserChat#revokeAdmin(org.jxmpp.jid.EntityJid)` (which uses `EntityJid`).

The API ideally is consistent - even `grantAdmin()` uses `Jid`. `revokeAdmin()` should also use `Jid` instead of `EntityJid`.

Fixes [SMACK-948](https://igniterealtime.atlassian.net/browse/SMACK-948).

[SMACK-948]: https://igniterealtime.atlassian.net/browse/SMACK-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ