### PR TITLE
[muc] Bookmarks.getConferenceStorage() don't parse empty <nick/>

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bookmarks/Bookmarks.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bookmarks/Bookmarks.java
@@ -194,7 +194,9 @@ public class Bookmarks implements PrivateData {
             buf.attribute("jid", conference.getJid());
             buf.rightAngleBracket();
 
-            buf.optElement("nick", conference.getNickname());
+            if (conference.getNickname() != null) {
+                buf.optElement("nick", conference.getNickname());
+            }
             buf.optElement("password", conference.getPassword());
 
             buf.closeElement("conference");
@@ -282,7 +284,9 @@ public class Bookmarks implements PrivateData {
             XmlPullParser.Event eventType = parser.next();
             if (eventType == XmlPullParser.Event.START_ELEMENT && "nick".equals(parser.getName())) {
                 String nickString = parser.nextText();
-                conf.setNickname(Resourcepart.from(nickString));
+                if (!nickString.isEmpty()) {
+                    conf.setNickname(Resourcepart.fromOrNull(nickString));
+                }
             }
             else if (eventType == XmlPullParser.Event.START_ELEMENT && "password".equals(parser.getName())) {
                 conf.setPassword(parser.nextText());


### PR DESCRIPTION
For a conference a server may return empty <nick/> element.
This will cause an exception on parsing and the whole conference won't appear in a client. A similar problem will occur if something wrong with the nick format. The nick in a conference is optional thing, and we are safe to ignore any problems with it. In this case a default account JID must be used.


Strictly speaking this change may potentially cause NPE in other places. I found that there are some checks for the Nickname to be empty in the 
`org/jivesoftware/smackx/muc/bookmarkautojoin/MucBookmarkAutojoinManager.java:125`:

```java
            Resourcepart nick = bookmarkedConference.getNickname();
            if (nick == null) {
                nick = defaultNick;
            }
```

The second place where the getNickname() is called is a serialization method `toXML` and I made it not to print the `<nick>null</nick>` element.
So I hope no one will be affected by the change or at least the problem will be now better localized.


I do have the problem IRL:
```xml
<iq xmlns="jabber:client" xml:lang="en" to="stokito@conversations.im/gajim.K4OZSDIV" from="stokito@conversations.im" type="result" id="adc7083e-b00a-45b8-98cd-bf31a8bfb2c3">
  <pubsub xmlns="http://jabber.org/protocol/pubsub">
    <items node="urn:xmpp:bookmarks:1">
      <item id="ru@chat.404.city">
        <conference xmlns="urn:xmpp:bookmarks:1" name="RuChat:  Чат русско-язычного XMPP" autojoin="false">
          <nick />
          <extensions />
</conference>
```

So here I joined a conference `ru@chat.404.city` from my account `stokito@conversations.im` from Gajim. It looks like I didn't specified my nickname and on the server it was set to empty.

The [XEP-0402](https://xmpp.org/extensions/xep-0402.html) says that the whole `nick` element is optional. This is an issue of the XEP that didn't clearly specified this and an XMPP server that it mustn't return the empty nick element. Both 404.city and conversations.im use latest ejaberd and I'll report a corresponding bug there. **UPD** https://github.com/processone/ejabberd/issues/4272

Still we need this check in the Smack to avoid problems with old versions and other badly implemented servers.



