### PR TITLE
[core] Make AccountManager.getRegistrationInfo() public

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/iqregister/AccountManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/iqregister/AccountManager.java
@@ -354,15 +354,17 @@ public final class AccountManager extends Manager {
     /**
      * Gets the account registration info from the server.
      *
+     * @return Registration information
      * @throws XMPPErrorException if there was an XMPP error returned.
      * @throws NoResponseException if there was no response from the remote entity.
      * @throws NotConnectedException if the XMPP connection is not connected.
      * @throws InterruptedException if the calling thread was interrupted.
      */
-    private synchronized void getRegistrationInfo() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
+    public synchronized Registration getRegistrationInfo() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         Registration reg = new Registration();
         reg.setTo(connection().getXMPPServiceDomain());
         info = createStanzaCollectorAndSend(reg).nextResultOrThrow();
+        return info;
     }
 
     private StanzaCollector createStanzaCollectorAndSend(IQ req) throws NotConnectedException, InterruptedException {


### PR DESCRIPTION
The getRegistrationInfo() returns a registration form that may also contain a CAPTCHA. We need to get the full Registration object to get the fields. Also it should be possible to call it multiple times to update the form.

This is related to https://github.com/igniterealtime/Spark/pull/877