### PR TITLE
[sinttest] Add error message to subscribe request failure

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/IntegrationTestRosterUtil.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/util/IntegrationTestRosterUtil.java
@@ -79,7 +79,7 @@ public class IntegrationTestRosterUtil {
         try {
             presenceRequestingRoster.sendSubscriptionRequest(presenceRequestReceiverAddress.asBareJid());
 
-            syncPoint.waitForResult(timeout);
+            syncPoint.waitForResult(timeout, "Timeout while waiting for subscription request of '" + presenceRequestingAddress + "' to '" + presenceRequestReceiverAddress + "' to be answered.");
         } finally {
             presenceRequestReceiverRoster.removeSubscribeListener(subscribeListener);
             presenceRequestingRoster.removePresenceEventListener(presenceEventListener);


### PR DESCRIPTION
Have a descriptive error message when a subscription request times out.