### PR TITLE
[muc] State of MUC should reflect room destruction

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -292,6 +292,7 @@ public class MultiUserChat {
                         for (UserStatusListener listener : userStatusListeners) {
                             listener.roomDestroyed(alternateMuc, destroy.getPassword(), destroy.getReason());
                         }
+                        userHasLeft();
                     }
 
                     if (isUserStatusModification) {


### PR DESCRIPTION
After a room is destroyed, the MultiUserChat-stored representation of the 'join' state of any occupant should be updated to reflect that the user is no longer in the room.

This fixes a problem where an occupant (that not itself triggered the destruction) appears to continue be part of a room after its destruction.

Additional integration test assertions are added to check for the invalid state fixed by this commit.

fixes SMACK-949