### PR TITLE
[ide] Improve junit5-platform hack (for IntelliJ)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -309,7 +309,7 @@ tasks.withType(Javadoc) {
 		testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
 		testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 		// https://stackoverflow.com/a/77274251/194894
-		testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+		testRuntimeOnly "org.junit.platform:junit-platform-launcher:[1.0.0,)"
 
 		// The smack-extensions subproject uses mockito in its fest
 		// fixtures, and we want to have mockito also available in


### PR DESCRIPTION
The build definition uses a hack to make Eclipse play nice(r) with JUnit 5. This seems to cause issues for IntelliJ, that fails to properly setup a project, citing many of these errors:

```
Could not find org.junit.platform:junit-platform-launcher:.
```

Usage of the `.` in that error made me wonder if this is a version resolution issue. After adding an explicit version range (that covers basically any version of the dependency) the problem in Intellij goes away.
