### PR TITLE
Revert "[ci] Add java 11 to build matrix"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - 11
           - 17
           - 21
     env:


### PR DESCRIPTION
This reverts commit 6857ac6b877644656797529de34851eff903d7e9.

The setup-android@v3 task installing android-21 requires Java 17.
