### PR TITLE
[im] Add RosterListener.ownPresenceChanged(Presence)

### DIFF
--- a/smack-im/src/main/java/org/jivesoftware/smack/roster/RosterListener.java
+++ b/smack-im/src/main/java/org/jivesoftware/smack/roster/RosterListener.java
@@ -79,4 +79,13 @@ public interface RosterListener {
      * @see Roster#getPresence(org.jxmpp.jid.BareJid)
      */
     void presenceChanged(Presence presence);
+
+    /**
+     * Called when the presence of one of the own available resources is changed.
+     *
+     * @param presence the presence that changed.
+     * @see Roster#getPresence(org.jxmpp.jid.BareJid)
+     * @since 4.5
+     */
+    default void ownPresenceChanged(Presence presence) { };
 }


### PR DESCRIPTION
Reflected own-presences where not processed by the RosterListener. However, most UIs probably want to display also the own presence, especially the presence status of other available resources of the own account. The new ownPresenceChanged() method allows to listen for those presences.