### PR TITLE
[conf] Switch order of Maven repositories

### DIFF
--- a/build-logic/src/main/groovy/org.igniterealtime.smack.global-conventions.gradle
+++ b/build-logic/src/main/groovy/org.igniterealtime.smack.global-conventions.gradle
@@ -7,8 +7,8 @@ ext {
 }
 
 repositories {
-	mavenLocal()
 	mavenCentral()
+	mavenLocal()
 }
 
 def getAndroidRuntimeJar() {


### PR DESCRIPTION
With this change, mavenCentral is going to be preferred to the local Maven repository.

This works around an issue where Gradle fails to find the jxmpp-jid test artifact.