### PR TITLE
XmlStringBuilder.toString

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/util/XmlStringBuilder.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/util/XmlStringBuilder.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.smack.util;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -668,9 +669,18 @@ public class XmlStringBuilder implements Appendable, CharSequence, Element {
         return sb.subSequence(start, end);
     }
 
+    /**
+     * toString() and write() should match, otherwise we're not logging exactly what we send on the wire.
+     */
     @Override
     public String toString() {
-        return sb.toString();
+        try {
+            StringWriter sw = new StringWriter();
+            write(sw, XmlEnvironment.EMPTY);
+            return sw.toString();
+        } catch (IOException e) {
+            return sb.toString();
+        }
     }
 
     @Override

--- a/smack-core/src/test/java/org/jivesoftware/smack/util/PacketParserUtilsTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/util/PacketParserUtilsTest.java
@@ -837,7 +837,7 @@ public class PacketParserUtilsTest {
         final String errorXml = XMLBuilder
                 .create(StanzaError.ERROR).a("type", "cancel").up()
                 .element("internal-server-error", StanzaError.ERROR_CONDITION_AND_TEXT_NAMESPACE).up()
-                .element("text", StanzaError.ERROR_CONDITION_AND_TEXT_NAMESPACE).t(text).up()
+                .element("text").t(text).up()
                 .asString();
         assertXmlSimilar(errorXml, error.toXML(StreamOpen.CLIENT_NAMESPACE));
     }

--- a/smack-core/src/test/java/org/jivesoftware/smack/util/XmlStringBuilderTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/util/XmlStringBuilderTest.java
@@ -22,6 +22,8 @@ import org.jivesoftware.smack.test.util.XmlAssertUtil;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.function.*;
+
 public class XmlStringBuilderTest {
 
     /**
@@ -43,5 +45,94 @@ public class XmlStringBuilderTest {
         StringBuilder actualXmlTwo = actualXml.toXML(XmlEnvironment.EMPTY);
 
         XmlAssertUtil.assertXmlSimilar(expectedXml, actualXmlTwo);
+    }
+
+    /**
+     * XmlStringBuilder toString may be somewhat slow with many nested elements.
+     *
+     * This is meant to be run manually.
+     */
+    // @Test
+    public void performanceTest() {
+        final int countOuter = 500;
+        final int countInner = 50;
+
+        System.err.println("XmlStringBuilder.toString() performance");
+        test1(countOuter, countInner);
+        test2(countOuter, countInner);
+        test3(countOuter, countInner);
+    }
+
+    private static void test1(int countOuter, int countInner) {
+        System.err.println("Test 1");
+        XmlStringBuilder parent = new XmlStringBuilder();
+        XmlStringBuilder child = new XmlStringBuilder();
+        XmlStringBuilder child2 = new XmlStringBuilder();
+
+        for (int i = 1; i < countOuter; i++) {
+            XmlStringBuilder cs = new XmlStringBuilder();
+            for (int j = 0; j < countInner; j++) {
+                cs.append("abc");
+            }
+            child2.append((CharSequence) cs);
+        }
+
+        child.append((CharSequence) child2);
+        parent.append((CharSequence) child);
+
+        time("test1: parent", () -> "len=" + parent.toString().length());
+        time("test1: child", () -> "len=" + child.toString().length());
+        time("test1: child2", () -> "len=" + child2.toString().length());
+    }
+
+    private static void test2(int countOuter, int countInner) {
+        System.err.println("Test 2: evaluate children first");
+        XmlStringBuilder parent = new XmlStringBuilder();
+        XmlStringBuilder child = new XmlStringBuilder();
+        XmlStringBuilder child2 = new XmlStringBuilder();
+
+        for (int i = 1; i < countOuter; i++) {
+            XmlStringBuilder cs = new XmlStringBuilder();
+            for (int j = 0; j < countInner; j++) {
+                cs.append("abc");
+            }
+            child2.append((CharSequence) cs);
+        }
+
+        child.append((CharSequence) child2);
+        parent.append((CharSequence) child);
+
+        time("test2: child2", () -> "len=" + child2.toString().length());
+        time("test2: child", () -> "len=" + child.toString().length());
+        time("test2: parent", () -> "len=" + parent.toString().length());
+    }
+
+    private static void test3(int countOuter, int countInner) {
+        System.err.println("Test 3: use append(XmlStringBuilder)");
+        XmlStringBuilder parent = new XmlStringBuilder();
+        XmlStringBuilder child = new XmlStringBuilder();
+        XmlStringBuilder child2 = new XmlStringBuilder();
+
+        for (int i = 1; i < countOuter; i++) {
+            XmlStringBuilder cs = new XmlStringBuilder();
+            for (int j = 0; j < countInner; j++) {
+                cs.append("abc");
+            }
+            child2.append(cs);
+        }
+
+        child.append(child2);
+        parent.append(child);
+
+        time("test3: parent", () -> "len=" + parent.toString().length());
+        time("test3: child", () -> "len=" + child.toString().length());
+        time("test3: child2", () -> "len=" + child2.toString().length());
+    }
+
+    private static void time(String name, Supplier<String> block) {
+        long start = System.currentTimeMillis();
+        String result = block.get();
+        long end = System.currentTimeMillis();
+        System.err.println(name + " took " + (end - start) + "ms: " + result);
     }
 }


### PR DESCRIPTION
- **test: Add a performance test for XmlStringBuilder.toString().**
- **fix: Make sure toString() matches write().**

The toString() change has two effects:
1. Improves performance. The "Test 1" case goes from ~100 ms down to ~ 3 ms on my machine.
2. Provides consistency between what's logged if you use a debugger to log stanzas (using toString()) and what's sent via TCP (using write()). 

We've noticed inconsistencies due to the code in`write()` that tries to keep track of the current xmlns. For example, something like this correctly includes the namespace for both child elements using `sb.toString()`, but `write()` drops the namespace from the second child element. But that's another problem, and I don't think it's easily solvable with the current XmlStringBuilder design.
```kt
XmlStringBuilder buf = new XmlStringBuilder();
buf.halfOpenElement("parent");
buf.xmlnsAttribute("parent:parent-ns");
buf.closeEmptyElement();

buf.halfOpenElement("child");
buf.xmlnsAttribute("child:child-ns");
buf.closeEmptyElement();

buf.halfOpenElement("child");
buf.xmlnsAttribute("child:child-ns");
buf.closeEmptyElement();

buf.closeElement("parent");
```