### PR TITLE
[sint] Fix typo in class names

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -47,9 +47,9 @@ import org.jivesoftware.smack.util.SslContextFactory;
 import org.jivesoftware.smack.util.StringUtils;
 
 import org.igniterealtime.smack.inttest.debugger.EnhancedSinttestDebugger;
-import org.igniterealtime.smack.inttest.debugger.SinttesDebuggerFactory;
-import org.igniterealtime.smack.inttest.debugger.SinttesDebuggerMetaFactory;
 import org.igniterealtime.smack.inttest.debugger.SinttestDebugger;
+import org.igniterealtime.smack.inttest.debugger.SinttestDebuggerFactory;
+import org.igniterealtime.smack.inttest.debugger.SinttestDebuggerMetaFactory;
 import org.igniterealtime.smack.inttest.debugger.StandardSinttestDebugger;
 
 import eu.geekplace.javapinning.java7.Java7Pinning;
@@ -104,7 +104,7 @@ public final class Configuration {
 
     public final String accountThreePassword;
 
-    private final SinttesDebuggerFactory debuggerFactory;
+    private final SinttestDebuggerFactory debuggerFactory;
 
     public final Set<String> enabledTests;
 
@@ -255,7 +255,7 @@ public final class Configuration {
 
         public String accountThreePassword;
 
-        private SinttesDebuggerFactory debuggerFactory;
+        private SinttestDebuggerFactory debuggerFactory;
 
         private Set<String> enabledTests;
 
@@ -407,7 +407,7 @@ public final class Configuration {
             default:
                 try {
                     debuggerFactory = Class.forName(debuggerString)
-                                    .asSubclass(SinttesDebuggerMetaFactory.class)
+                                    .asSubclass(SinttestDebuggerMetaFactory.class)
                                     .getDeclaredConstructor().newInstance()
                                     .create(debuggerOptions);
                 } catch (Exception e) {
@@ -417,7 +417,7 @@ public final class Configuration {
             return this;
         }
 
-        public Builder setDebugger(SinttesDebuggerFactory factory) {
+        public Builder setDebugger(SinttestDebuggerFactory factory) {
             debuggerFactory = factory;
             return this;
         }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/debugger/SinttestDebuggerFactory.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/debugger/SinttestDebuggerFactory.java
@@ -16,9 +16,11 @@
  */
 package org.igniterealtime.smack.inttest.debugger;
 
-@FunctionalInterface
-public interface SinttesDebuggerMetaFactory {
+import java.time.ZonedDateTime;
 
-    SinttesDebuggerFactory create(String debuggerOptions);
+@FunctionalInterface
+public interface SinttestDebuggerFactory {
+
+    SinttestDebugger create(ZonedDateTime testRunStart, String testRunId);
 
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/debugger/SinttestDebuggerMetaFactory.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/debugger/SinttestDebuggerMetaFactory.java
@@ -16,11 +16,9 @@
  */
 package org.igniterealtime.smack.inttest.debugger;
 
-import java.time.ZonedDateTime;
-
 @FunctionalInterface
-public interface SinttesDebuggerFactory {
+public interface SinttestDebuggerMetaFactory {
 
-    SinttestDebugger create(ZonedDateTime testRunStart, String testRunId);
+    SinttestDebuggerFactory create(String debuggerOptions);
 
 }

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
@@ -129,7 +129,7 @@
  * </tr>
  * <tr>
  * <td>debugger</td>
- * <td>'standard' for the standard debugger, ‘console’ for console debugger, ‘enhanced’ for the enhanced debugger, or the name of a class that implements SinttesDebuggerMetaFactory for a custom debugger</td>
+ * <td>'standard' for the standard debugger, ‘console’ for console debugger, ‘enhanced’ for the enhanced debugger, or the name of a class that implements SinttestDebuggerMetaFactory for a custom debugger</td>
  * </tr>
  * <tr>
  * <td>enabledTests</td>


### PR DESCRIPTION
Fixed an obvious typo in class names of as of yet unreleased code:
- `org.igniterealtime.smack.inttest.debugger.SinttesDebuggerFactory` to `SinttestDebuggerFactory`
- `org.igniterealtime.smack.inttest.debugger.SinttesDebuggerMetaFactory` to `SinttestDebuggerMetaFactory`