### PR TITLE
[sint] Debugger shouldn't error on pre-existing dirs

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/debugger/StandardSinttestDebugger.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/debugger/StandardSinttestDebugger.java
@@ -112,9 +112,11 @@ public class StandardSinttestDebugger implements SinttestDebugger {
             Path outsideTestLogFile = this.basePath.resolve("outsideTestLog");
             Path testsFile = this.basePath.resolve("tests");
             try {
-                boolean created = this.basePath.toFile().mkdirs();
-                if (!created) {
-                    throw new IOException("Could not create directory " + this.basePath);
+                if (!this.basePath.toFile().exists()) {
+                    boolean created = this.basePath.toFile().mkdirs();
+                    if (!created) {
+                        throw new IOException("Could not create directory " + this.basePath);
+                    }
                 }
 
                 completeWriter = Files.newBufferedWriter(completeLogFile);
@@ -184,9 +186,11 @@ public class StandardSinttestDebugger implements SinttestDebugger {
         }
         currentTestMethodDirectory = testClassDirectory.resolve(testName.toString());
 
-        boolean created = currentTestMethodDirectory.toFile().mkdirs();
-        if (!created) {
-            throw new IOException("Could not create directory " + currentTestMethodDirectory);
+        if (!currentTestMethodDirectory.toFile().exists()) {
+            boolean created = currentTestMethodDirectory.toFile().mkdirs();
+            if (!created) {
+                throw new IOException("Could not create directory " + currentTestMethodDirectory);
+            }
         }
 
         Path logFile = currentTestMethodDirectory.resolve("log");


### PR DESCRIPTION
The StandardSinttestDebugger attempts to create directories in which output is stored. This code throws an error when the directory was not created.

If the directory already exists, it is not _created_, and thus an error is thrown.

With this code change, a directory creation attempt is performed only when the directory does not exist.
