### PR TITLE
[sinttest] Fix config for custom debugger

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -406,7 +406,7 @@ public final class Configuration {
                 break;
             default:
                 try {
-                    debuggerFactory = Class.forName(debuggerString)
+                    debuggerFactory = Class.forName(debugger)
                                     .asSubclass(SinttestDebuggerMetaFactory.class)
                                     .getDeclaredConstructor().newInstance()
                                     .create(debuggerOptions);


### PR DESCRIPTION
The provided `debuggerString` value is split into a implementation identifier, and options.

The implementation identifier part (instead of the whole `debuggerString` value) should be used to instantiate a custom class. This obviously was intended, as the `debuggerOptions` value would otherwise be unusable.
