### PR TITLE
[sinttest] Allow tests to be ordered

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -309,7 +309,8 @@ public class SmackIntegrationTestFramework {
         List<PreparedTest> tests = new ArrayList<>(classes.size());
         int numberOfAvailableTests = 0;
 
-        for (Class<? extends AbstractSmackIntTest> testClass : classes) {
+        List<Class<? extends AbstractSmackIntTest>> possiblySorted = config.sortTestClasses(classes);
+        for (Class<? extends AbstractSmackIntTest> testClass : possiblySorted) {
             final String testClassName = testClass.getName();
 
             // TODO: Move the whole "skipping section" below one layer up?
@@ -478,7 +479,9 @@ public class SmackIntegrationTestFramework {
 
             List<ConcreteTest> concreteTests = new ArrayList<>(smackIntegrationTestMethods.size());
 
-            for (Method testMethod : smackIntegrationTestMethods) {
+            final List<Method> possiblySortedMethods = config.sortTestMethods(smackIntegrationTestMethods);
+
+            for (Method testMethod : possiblySortedMethods) {
                 switch (testType) {
                 case Normal: {
                     ConcreteTest.Executor concreteTestExecutor = () -> {

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
@@ -176,6 +176,10 @@
  * <td>One of ‘minidns’, ‘javax’ or ‘dnsjava’. Defaults to ‘minidns’.</td>
  * </tr>
  * <tr>
+ * <td>executionOrder</td>
+ * <td>Causes tests to be executed in an order defined by their declaring class and method name. One of ‘alphabetical’ or ‘reversed’. When not set, no explicit order is applied.</td>
+ * </tr>
+ * <tr>
  * <td>testRunResultProcessors</td>
  * <td>List of class names for generating test run output. Defaults to 'org.igniterealtime.smack.inttest.SmackIntegrationTestFramework$ConsoleTestRunResultProcessor'</td>
  * </tr>


### PR DESCRIPTION
This commit introduces a new optional configuration property (`executionOrder`) that can be used to apply a strict order to the execution of tests.

Two options are provided:
- 'alphabetic'
- 'reversed'

Both sort the test based on the natural order of their declaring class name, followed by the test method name. The 'reversed' option used the reverse ordering of the 'alphabetic' option.

The new property is optional: when not defined, no explicit order is applied. Java's default implementation does not guarantee a specific order (and indeed, through experience we've learned that the order of test execution isn't consistent between test runs).

The rationale for this change is provided in https://github.com/XMPP-Interop-Testing/smack-sint-server-extensions/issues/114 : By being able to run tests in a specific order, and then once more in the reverse order, it becomes a lot easier to identify tests that have an undesired effect on each-other.
