### PR TITLE
[sinttest] add 'fail on impossible' configuration

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -141,6 +141,8 @@ public final class Configuration {
 
     public final ConnectionConfigurationBuilderApplier configurationApplier;
 
+    public final boolean failOnImpossibleTest;
+
     public final boolean failFast;
 
     public final boolean verbose;
@@ -238,6 +240,7 @@ public final class Configuration {
             }
         };
 
+        this.failOnImpossibleTest = builder.failOnImpossibleTest;
         this.failFast = builder.failFast;
         this.verbose = builder.verbose;
 
@@ -303,6 +306,8 @@ public final class Configuration {
         private Set<String> disabledConnections;
 
         private Set<String> testPackages;
+
+        private boolean failOnImpossibleTest;
 
         private boolean failFast;
 
@@ -546,6 +551,20 @@ public final class Configuration {
             return this;
         }
 
+        public Builder setFailOnImpossibleTest(boolean failOnImpossibleTest) {
+            this.failOnImpossibleTest = failOnImpossibleTest;
+            return this;
+        }
+
+        public Builder setFailOnImpossibleTest(String failOnImpossibleTestBooleanString) {
+            if (failOnImpossibleTestBooleanString == null) {
+                return this;
+            }
+
+            boolean failOnImpossibleTest = ParserUtils.parseXmlBoolean(failOnImpossibleTestBooleanString);
+            return setFailOnImpossibleTest(failOnImpossibleTest);
+        }
+
         public Builder setFailFast(boolean failFast) {
             this.failFast = failFast;
             return this;
@@ -685,6 +704,7 @@ public final class Configuration {
         builder.addTestPackages(properties.getProperty("testPackages"));
         builder.addTestPackages(testPackages);
 
+        builder.setFailOnImpossibleTest(properties.getProperty("failOnImpossibleTest"));
         builder.setFailFast(properties.getProperty("failFast"));
         builder.setVerbose(properties.getProperty("verbose"));
 

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
@@ -114,7 +114,10 @@ public class SmackIntegrationTestFramework {
         SmackIntegrationTestFramework sinttest = new SmackIntegrationTestFramework(config);
         TestRunResult testRunResult = sinttest.run();
 
-        final int exitStatus = testRunResult.failedIntegrationTests.isEmpty() ? 0 : 2;
+        int exitStatus = testRunResult.failedIntegrationTests.isEmpty() ? 0 : 2;
+        if (config.failOnImpossibleTest && (!testRunResult.impossibleTestClasses.isEmpty() || !testRunResult.impossibleIntegrationTests.isEmpty())) {
+            exitStatus += 4;
+        }
         System.exit(exitStatus);
     }
 
@@ -138,6 +141,10 @@ public class SmackIntegrationTestFramework {
             final int availableTests = testRunResult.getNumberOfAvailableTests();
             LOGGER.info("SmackIntegrationTestFramework[" + testRunResult.testRunId + ']' + " finished: "
                 + successfulTests + '/' + availableTests + " [" + failedTests + " failed]");
+
+            if (!testRunResult.impossibleTestClasses.isEmpty() || !testRunResult.impossibleIntegrationTests.isEmpty()) {
+                LOGGER.info("It was not possible to run all Smack Integration tests.");
+            }
 
             if (failedTests == 0) {
                 LOGGER.info("All possible Smack Integration Tests completed successfully. \\o/");

--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/package-info.java
@@ -168,6 +168,10 @@
  * <td>List of packages with tests</td>
  * </tr>
  * <tr>
+ * <td>failOnImpossibleTest</td>
+ * <td>If <code>true</code> the exit code of the process will be non-zero when a test was impossible to run.</td>
+ * </tr>
+ * <tr>
  * <td>failFast</td>
  * <td>If <code>true</code> exit immediatly on the first failure.</td>
  * </tr>


### PR DESCRIPTION
Adds a new configuration option (`sinttest.failOnImpossibleTest`) that causes the test run process to exit with a non-zero exit code, if tests were impossible to run.

Test may be impossible to run, for example, because the server that's being tested does not support a particular feature.

It is not unreasonable for users to assume that, upon a successful test execution result, all tests have passed. In the case of 'impossible' tests, this isn't necessarily the case: some test might not have executed at all.

Especially in scenarios where users have configured the test run to enable a specific subset of the tests (through configuration such as `enabledTests` and `enabledSpecifications`) it may be desirable to hard fail when a test was impossible to execute. This enforces that a test run was strictly successful in all tests it was configured to execute.
