### PR TITLE
[muc] Improve fix for deadlock on destroy/leave

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChat.java
@@ -261,7 +261,7 @@ public class MultiUserChat {
                     Set<Status> status = mucUser.getStatus();
                     if (mucUser != null && !status.isEmpty()) {
                         if (isUserStatusModification && !status.contains(MUCUser.Status.NEW_NICKNAME_303)
-                                        && !leaving) {
+                                        && !leaving && !destroying) {
                             userHasLeft();
                         }
                         // Fire events according to the received presence code


### PR DESCRIPTION
The fix for 6b67c8a1e6667ee95ae3a4319f1fbf3248ead3fb intends to resolve a race condition. It does so (partially), by not invoking userHasLeft() when the user is destroying the room.

This commit applies the same fix when the presence unavailable that is received when destroying a room contains the status code `110`, which is a case that was not covered by the original fix.