### PR TITLE
XMPP-Bosh reconnect failure on network changed.

### DIFF
--- a/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
+++ b/smack-bosh/src/main/java/org/jivesoftware/smack/bosh/XMPPBOSHConnection.java
@@ -289,7 +289,7 @@ public class XMPPBOSHConnection extends AbstractXMPPConnection {
         done = true;
         authenticated = false;
         connected = false;
-        isFirstInitialization = false;
+        isFirstInitialization = true;
 
         // Close down the readers and writers.
         CloseableUtil.maybeClose(readerPipe, LOGGER);


### PR DESCRIPTION
This pull request fixes the following:
a. Bosh debug messages not shown in logcat or not in proper send/response order.
b. XMPP-Bossh reconnect attempt always failed with not response timeout when there is a change in the network connection e.g. from WiFi to Mobile.
c. Fixes SMACK-956
