### PR TITLE
[sinttest] Couple AccountManager's security config to SecurityMode

### DIFF
--- a/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
+++ b/smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/Configuration.java
@@ -50,6 +50,8 @@ import org.jivesoftware.smack.util.SslContextFactory;
 import org.jivesoftware.smack.util.StringUtils;
 import org.jivesoftware.smack.util.TLSUtils;
 
+import org.jivesoftware.smackx.iqregister.AccountManager;
+
 import org.igniterealtime.smack.inttest.debugger.EnhancedSinttestDebugger;
 import org.igniterealtime.smack.inttest.debugger.SinttestDebugger;
 import org.igniterealtime.smack.inttest.debugger.SinttestDebuggerFactory;
@@ -179,6 +181,7 @@ public final class Configuration {
             sslContextFactory = null;
         }
         securityMode = builder.securityMode;
+        AccountManager.sensitiveOperationOverInsecureConnectionDefault(securityMode == SecurityMode.disabled);
         if (builder.replyTimeout > 0) {
             replyTimeout = builder.replyTimeout;
         } else {


### PR DESCRIPTION
When the integration tests are configured without an administrative account (that creates test accounts) or explicit test accounts, the application will attempt to use In-Band Registration to create test accounts.

The AccountManager implementation by default refuses to operate, when the connection is not encrypted. This causes the In-Band Registration method to provision test accounts to fail, when running with SecurityMode.disabled / without encryption.

When security is disabled by configuration, it stands to reason that the user wants to allow AccountManager to work over an insecure connection. In this commit, a change is applied that ties the configuration together.
