### PR TITLE
Fix Sock5Proxy remains unchanges when network connection changes

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5Proxy.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/bytestreams/socks5/Socks5Proxy.java
@@ -298,6 +298,9 @@ public class Socks5Proxy {
         }
         this.serverThread = null;
         this.serverSocket = null;
+
+        // Stop Sock5Proxy so a new localAddresses are retrieved on new authentication process.
+        socks5Server = null;
     }
 
     /**

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_s5b/JingleS5BTransportManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/jingle/transports/jingle_s5b/JingleS5BTransportManager.java
@@ -45,7 +45,7 @@ import org.jxmpp.jid.FullJid;
 import org.jxmpp.jid.Jid;
 
 /**
- * Manager for Jingle SOCKS5 Bytestream transports (XEP-0261).
+ * Manager for Jingle SOCKS5 Bytestream transports (XEP-0260).
  */
 public final class JingleS5BTransportManager extends JingleTransportManager<JingleS5BTransport> {
 
@@ -133,7 +133,7 @@ public final class JingleS5BTransportManager extends JingleTransportManager<Jing
 
     @Override
     public void authenticated(XMPPConnection connection, boolean resumed) {
-        if (!resumed) try {
+        try {
             Socks5Proxy socks5Proxy = Socks5Proxy.getSocks5Proxy();
             if (!socks5Proxy.isRunning()) {
                 socks5Proxy.start();
@@ -143,6 +143,19 @@ public final class JingleS5BTransportManager extends JingleTransportManager<Jing
         } catch (InterruptedException | SmackException.NoResponseException | SmackException.NotConnectedException | XMPPException.XMPPErrorException e) {
             LOGGER.log(Level.WARNING, "Could not query available StreamHosts: " + e, e);
         }
+    }
+
+    @Override
+    public void connectionClosed() {
+        Socks5Proxy proxy = Socks5Proxy.getSocks5Proxy();
+        if (proxy.isRunning()) {
+            Socks5Proxy.getSocks5Proxy().stop();
+        }
+    }
+
+    @Override
+    public void connectionClosedOnError(Exception e) {
+        connectionClosed();
     }
 
     public Jingle createCandidateUsed(FullJid recipient, FullJid initiator, String sessionId, JingleContent.Senders contentSenders,


### PR DESCRIPTION
See links below for the details.
[Smack 4.4.8: localAddresses values in Socks5Proxy remain unchanged when there is a change in the network connection](https://discourse.igniterealtime.org/t/smack-4-4-8-localaddresses-values-in-socks5proxy-remain-unchanged-when-there-is-a-change-in-the-network-connection/95411)