### PR TITLE
xdata: Fix definition of the `muc#roomconfig_roomsecret` field

### DIFF
--- a/smack-extensions/src/main/resources/org.igniterealtime.smack/xdata/form-registry/muc/muc-roomconfig.xml
+++ b/smack-extensions/src/main/resources/org.igniterealtime.smack/xdata/form-registry/muc/muc-roomconfig.xml
@@ -84,7 +84,7 @@
       label='Full List of Room Owners'/>
   <field
       var='muc#roomconfig_roomsecret'
-      type='text-single'
+      type='text-private'
       label='The Room Password'/>
   <field
       var='muc#roomconfig_whois'


### PR DESCRIPTION
Per discusson on https://mail.jabber.org/hyperkitty/list/standards@xmpp.org/thread/K7QCGVMT3XNE4LV3ILHKU3CPV5N63VQC/
