### PR TITLE
[sinttest] Improve TestNotPossible message

### DIFF
--- a/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/AbstractMultiUserChatIntegrationTest.java
+++ b/smack-integration-test/src/main/java/org/jivesoftware/smackx/muc/AbstractMultiUserChatIntegrationTest.java
@@ -171,7 +171,7 @@ public abstract class AbstractMultiUserChatIntegrationTest extends AbstractSmack
         try {
             configManager.applyAndSubmit(applier);
         } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
-            throw new TestNotPossibleException("todo", e);
+            throw new TestNotPossibleException("Unable to modify MUC room: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Have a better message than 'todo' when reporting that a test can't be executed.

Instead of logging something like this:

> XEP-0045: could not run 3 test(s) because: todo

have this:

> XEP-0045: could not run 3 test(s) because: Unable to modify MUC room: The MUC configuration 'muc#roomconfig_passwordprotectedroom' is not supported by the MUC service
