### PR TITLE
xdata: fix submit of cancel form

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MucConfigFormManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MucConfigFormManager.java
@@ -23,11 +23,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.jivesoftware.smack.packet.IQ;
+
 import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPException.XMPPErrorException;
 
 import org.jivesoftware.smackx.muc.MultiUserChatException.MucConfigurationNotSupportedException;
+import org.jivesoftware.smackx.muc.packet.MUCOwner;
 import org.jivesoftware.smackx.xdata.BooleanFormField;
 import org.jivesoftware.smackx.xdata.FormField;
 import org.jivesoftware.smackx.xdata.form.FillableForm;
@@ -527,7 +530,11 @@ public class MucConfigFormManager {
 
     public void cancel() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
         var cancelForm = FillableForm.newCancelForm();
-        multiUserChat.sendConfigurationForm(cancelForm);
+        var iq = new MUCOwner();
+        iq.setTo(multiUserChat.getRoom());
+        iq.setType(IQ.Type.set);
+        iq.addExtension(cancelForm);
+        multiUserChat.getXmppConnection().sendIqRequestAndWaitForResponse(iq);
     }
 
     public interface MucConfigApplier {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/FillableForm.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/xdata/form/FillableForm.java
@@ -296,8 +296,7 @@ public class FillableForm extends FilledForm {
         return new SubmitForm(form);
     }
 
-    public static FillableForm newCancelForm() {
-        var cancelDataForm = DataForm.builder(DataForm.Type.cancel).build();
-        return new FillableForm(cancelDataForm);
+    public static DataForm newCancelForm() {
+        return DataForm.builder(DataForm.Type.cancel).build();
     }
 }


### PR DESCRIPTION
A cancel form isn't a fillable form, leading to exceptions. This commit works around the problem by directly sending the form, rather than wrapping it in a FillableForm first.
