### PR TITLE
PEP features: fix subscription_notifications name

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/PubSubFeature.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/pubsub/PubSubFeature.java
@@ -73,7 +73,7 @@ public enum PubSubFeature implements CharSequence {
     retrieve_subscriptions(Support.recommended),
     subscribe(Support.required),
     subscription_options(Support.optional),
-    subscriptions_notifications(Support.optional),
+    subscription_notifications(Support.optional),
     ;
 
     private final String feature;


### PR DESCRIPTION
I compared the PEP features with the [spec](https://xmpp.org/extensions/xep-0060.html#features).
The subscription-notifications in the Smack called incorrectly subscription**s**-notifications.

Also there was missing `multi_items` and `publish_node_full`, so I added them and made enum order same as in spec to make it easier to compare next time.