### PR TITLE
EnhancedDebugger.addReadPacketToTable(): avoid NPE when messagesTable is null on after cancel()

### DIFF
--- a/smack-debug/src/main/java/org/jivesoftware/smackx/debugger/EnhancedDebugger.java
+++ b/smack-debug/src/main/java/org/jivesoftware/smackx/debugger/EnhancedDebugger.java
@@ -763,6 +763,11 @@ public class EnhancedDebugger extends SmackDebugger {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
+                // Ensure the table is not null before attempting to access it
+                var messagesTable = EnhancedDebugger.this.messagesTable;
+                if (messagesTable == null) {
+                    return;
+                }
                 String messageType;
                 Jid from;
                 String stanzaId;


### PR DESCRIPTION
I started Spark with a debugger and during the Spark exiting there was a few exceptions:
```
java.lang.NullPointerException: Cannot invoke "javax.swing.table.DefaultTableModel.getRowCount()" because "this.this$0.messagesTable" is null
	at org.jivesoftware.smackx.debugger.EnhancedDebugger$20.run(EnhancedDebugger.java:806)
```
So here is a null check to avoid such an error. Some description from AI:

> To provide a long-term fix, we need to add a null check before accessing messagesTable inside the EnhancedDebugger class. Since this is happening inside a run() method (likely an anonymous inner class or lambda passed to SwingUtilities.invokeLater), we need to ensure the debugger's UI state is valid before proceeding.
