### PR TITLE
[core] Presence: add isActive() to check if user is online and can answer

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/packet/Presence.java
@@ -107,7 +107,8 @@ public final class Presence extends MessageOrPresence<PresenceBuilder>
      * equivalent to <code>getType() == Presence.Type.available</code>. Note that even
      * when the user is available, their presence mode may be {@link Mode#away away},
      * {@link Mode#xa extended away} or {@link Mode#dnd do not disturb}. Use
-     * {@link #isAway()} to determine if the user is away.
+     * {@link #isAway()} to determine if the user is away, or {@link #isActive()}
+     * to determine if user is available an not away.
      *
      * @return true if the presence type is available.
      */
@@ -127,6 +128,19 @@ public final class Presence extends MessageOrPresence<PresenceBuilder>
      */
     public boolean isAway() {
         return type == Type.available && (mode == Mode.away || mode == Mode.xa || mode == Mode.dnd);
+    }
+
+    /**
+     * Returns true if the presence signals availability ({@link #isAvailable()}) and no away mode ({@link #isAway()}). Otherwise, returns false.
+     * mode is {@link Mode#available available}, or {@link Mode#chat ready to chat}. False will be returned when the type or mode
+     * is any other value, including when the presence type is unavailable (offline).
+     * This is a convenience method equivalent to
+     * <code>isAvailable() &amp;&amp; !isAway()</code>.
+     *
+     * @return true if the presence type is available and the presence mode is available or chat.
+     */
+    public boolean isActive() {
+        return isAvailable() && !isAway();
     }
 
     @Override

--- a/smack-core/src/test/java/org/jivesoftware/smack/packet/PresenceTest.java
+++ b/smack-core/src/test/java/org/jivesoftware/smack/packet/PresenceTest.java
@@ -172,9 +172,11 @@ public class PresenceTest {
         PresenceBuilder presence = getNewPresence();
         presence.setMode(Presence.Mode.away);
         assertTrue(presence.build().isAway());
+        assertFalse(presence.build().isActive());
 
         presence.setMode(Presence.Mode.chat);
         assertFalse(presence.build().isAway());
+        assertTrue(presence.build().isActive());
     }
 
     @Test


### PR DESCRIPTION
The Spark has many places where we need to determine if user is currently online i.e. its status is available or free for chat.
There is even a separate method for this:
https://github.com/igniterealtime/Spark/blob/a64185ad3b4527f764dff680686fc262af48cac1/core/src/main/java/org/jivesoftware/spark/PresenceManager.java#L148
Still there are places in code where to detect it a user is active manually like this:
```
usersPresence.isAvailable() && !usersPresence.isAway()
```

I would like to propose a separate method `isActive` to simplify usage.