### PR TITLE
[extensions] MultiUserChatManager.getRoomsHostedBy() don't fail if so…

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/HostedRoom.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/HostedRoom.java
@@ -16,8 +16,6 @@
  */
 package org.jivesoftware.smackx.muc;
 
-import org.jivesoftware.smack.util.Objects;
-
 import org.jivesoftware.smackx.disco.packet.DiscoverItems;
 
 import org.jxmpp.jid.EntityBareJid;
@@ -40,8 +38,8 @@ public class HostedRoom {
     private final String name;
 
     public HostedRoom(DiscoverItems.Item item) {
-        jid = Objects.requireNonNull(item.getEntityID().asEntityBareJidIfPossible(),
-                        "The discovered item must be an entity bare JID");
+        // The discovered item must be an entity bare JID
+        jid = item.getEntityID().asEntityBareJidOrThrow();
         name = item.getName();
     }
 

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatManager.java
@@ -479,7 +479,13 @@ public final class MultiUserChatManager extends Manager {
 
         Map<EntityBareJid, HostedRoom> answer = new HashMap<>(items.size());
         for (DiscoverItems.Item item : items) {
-            HostedRoom hostedRoom = new HostedRoom(item);
+            HostedRoom hostedRoom;
+            try {
+                hostedRoom = new HostedRoom(item);
+            } catch (Exception e) {
+                LOGGER.warning("Bad hosted room: " + e.getMessage());
+                continue;
+            }
             HostedRoom previousRoom = answer.put(hostedRoom.getJid(), hostedRoom);
             assert previousRoom == null;
         }


### PR DESCRIPTION
…me room JIDs are broken

If some room in a response has invalid JID then the entire call fails with an exception. Instead we may show a warning and continue process other rooms. The HostedRoom constructor trows an exception without the JID so it's complicated to trace it. Instead use asEntityBareJidOrThrow() that will include the JID to a message.

*Motivation*
This fixes a real problem in Spark: When getting list of rooms from the `chat.yax.im` it returns many room jids like `670@chat.yax.im` but one room is just `chat.yax.im` i.e. it has a jid without `@`.