### PR TITLE
HostedRoom: throw error on parsing room JID instead of checking for a null

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/HostedRoom.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/muc/HostedRoom.java
@@ -16,8 +16,6 @@
  */
 package org.jivesoftware.smackx.muc;
 
-import org.jivesoftware.smack.util.Objects;
-
 import org.jivesoftware.smackx.disco.packet.DiscoverItems;
 
 import org.jxmpp.jid.EntityBareJid;
@@ -40,8 +38,8 @@ public class HostedRoom {
     private final String name;
 
     public HostedRoom(DiscoverItems.Item item) {
-        jid = Objects.requireNonNull(item.getEntityID().asEntityBareJidIfPossible(),
-                        "The discovered item must be an entity bare JID");
+        // The discovered item must be an entity bare JID
+        jid = item.getEntityID().asEntityBareJidOrThrow();
         name = item.getName();
     }
 


### PR DESCRIPTION
It was hard to debug which room exactly caused and exception because the error message was only about null value. Using the `.asEntityBareJidOrThrow()` will also have the room JID in the error message.

Part of the declined #694