### PR TITLE
SmackFuture: get(timeout) always threw a TimeoutException

### DIFF
--- a/smack-core/src/main/java/org/jivesoftware/smack/SmackFuture.java
+++ b/smack-core/src/main/java/org/jivesoftware/smack/SmackFuture.java
@@ -144,18 +144,21 @@ public abstract class SmackFuture<V, E extends Exception> implements Future<V>, 
     public final synchronized V get(long timeout, TimeUnit unit)
                     throws InterruptedException, ExecutionException, TimeoutException {
         final long deadline = System.currentTimeMillis() + unit.toMillis(timeout);
-        while (result != null && exception != null) {
+        while (result == null && exception == null) {
             final long waitTimeRemaining = deadline - System.currentTimeMillis();
-            if (waitTimeRemaining > 0) {
-                futureWait(waitTimeRemaining);
+            if (waitTimeRemaining <= 0
+                    // this may be the case when the system time was changed meanwhile!
+                    && unit.toMillis(timeout) < waitTimeRemaining) {
+                break;
             }
+            futureWait(waitTimeRemaining);
         }
 
         if (cancelled) {
             throw new CancellationException();
         }
 
-        if (result == null || exception == null) {
+        if (result == null && exception == null) {
             throw new TimeoutException();
         }
 


### PR DESCRIPTION
I have got always TimeoutException using `org.jivesoftware.smack.SmackFuture#get(long, java.util.concurrent.TimeUnit)`  of Smack 4.5.0-rc1.

I had a look a the code:

The condition ` while (result != null && exception != null)` will never become true, as only one of both (result or exception) should be set. So the loop never executes.

Then the condition  `if (result == null || exception == null) { throw new TimeoutException(); }` always becomes true, as one of both (result or exception) should never be set.