### PR TITLE
OkHttpWebSocket: add proxy support

### DIFF
--- a/smack-websocket-okhttp/src/main/java/org/jivesoftware/smack/websocket/okhttp/OkHttpWebSocket.java
+++ b/smack-websocket-okhttp/src/main/java/org/jivesoftware/smack/websocket/okhttp/OkHttpWebSocket.java
@@ -16,16 +16,17 @@
  */
 package org.jivesoftware.smack.websocket.okhttp;
 
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.util.logging.Level;
-
-import javax.net.ssl.SSLSession;
-
 import org.jivesoftware.smack.c2s.internal.ModularXmppClientToServerConnectionInternal;
 import org.jivesoftware.smack.proxy.ProxyInfo;
 import org.jivesoftware.smack.websocket.impl.AbstractWebSocket;
 import org.jivesoftware.smack.websocket.rce.WebSocketRemoteConnectionEndpoint;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.logging.Level;
+
+import javax.net.ssl.SSLSession;
 
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
@@ -41,6 +42,13 @@ public final class OkHttpWebSocket extends AbstractWebSocket {
 
     OkHttpWebSocket(WebSocketRemoteConnectionEndpoint endpoint,
                     ModularXmppClientToServerConnectionInternal connectionInternal) {
+        this(endpoint, null, connectionInternal);
+    }
+
+    OkHttpWebSocket(WebSocketRemoteConnectionEndpoint endpoint,
+                    Long connectionTimeout,
+                    ModularXmppClientToServerConnectionInternal connectionInternal) {
+
         super(endpoint, connectionInternal);
 
         var okHttpClientBuilder = new OkHttpClient.Builder();
@@ -51,6 +59,10 @@ public final class OkHttpWebSocket extends AbstractWebSocket {
                 okHttpClientBuilder.sslSocketFactory(tlsContext.sslContext.getSocketFactory(), customTrustManager);
             }
         }
+
+        if (connectionTimeout != null)
+            okHttpClientBuilder.connectTimeout(Duration.ofMillis(connectionTimeout));
+
         // Checking if connection is not null is only necessary since we use mocked objects where it may be null in test
         // cases. Otherwise, the 'connection' field will always be non-null.
         if (connectionInternal.connection != null) {
@@ -73,38 +85,83 @@ public final class OkHttpWebSocket extends AbstractWebSocket {
     }
 
     private void applyProxySettings(OkHttpClient.Builder okHttpClientBuilder, ProxyInfo proxyInfo) {
-        if (proxyInfo == null
-                || proxyInfo.getProxyType() != ProxyInfo.ProxyType.HTTP
-                || proxyInfo.getProxyAddress() == null
-                || proxyInfo.getProxyPort() == 0) {
+        if (proxyInfo == null || proxyInfo.getProxyType() == null) {
             return;
         }
 
-        var proxy = new Proxy(Proxy.Type.HTTP,
-                new InetSocketAddress(proxyInfo.getProxyAddress(), proxyInfo.getProxyPort()));
+        switch (proxyInfo.getProxyType()) {
+            case HTTP:
+                applyHttpProxy(okHttpClientBuilder, proxyInfo);
+                break;
+            case SOCKS4:
+            case SOCKS5:
+                applySOCKSProxy(okHttpClientBuilder, proxyInfo);
+                break;
+            default:
+                throw new IllegalStateException("Unsupported proxy type");
+        }
+    }
+
+    private void applySOCKSProxy(OkHttpClient.Builder okHttpClientBuilder, ProxyInfo proxyInfo) {
+        if (proxyInfo == null) {
+            return;
+        }
+        String proxyHost = proxyInfo.getProxyAddress();
+        int proxyPort = proxyInfo.getProxyPort();
+        if (proxyHost == null || proxyHost.isBlank()
+                || proxyPort == 0) {
+            return;
+        }
+
+
+        Proxy proxy = new Proxy(Proxy.Type.SOCKS, InetSocketAddress.createUnresolved(proxyHost, proxyPort));
+        okHttpClientBuilder.proxy(proxy);
+        // The authenticator must be set e.g. via java.net.Authenticator.setDefault();
+    }
+
+    private void applyHttpProxy(OkHttpClient.Builder okHttpClientBuilder, ProxyInfo proxyInfo) {
+
+        final String PROXY_AUTH_HEADER = "Proxy-Authorization";
+
+        if (proxyInfo == null) {
+            return;
+        }
+        String proxyHost = proxyInfo.getProxyAddress();
+        int proxyPort = proxyInfo.getProxyPort();
+        if (proxyHost == null || proxyHost.isBlank()
+                || proxyPort == 0) {
+            return;
+        }
+
+
+        var proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
         okHttpClientBuilder.proxy(proxy);
 
-        if (proxyInfo.getProxyUsername() != null) {
-            Authenticator proxyAuthenticator = (route, response) ->
-            {
-                // If the proxy header is already set, the credentials are probably wrong.
-                // So do nothing!
-                if (response.request().header("Proxy-Authorization") != null) {
-                    return null;
-                }
-
-                // Generate Basic Auth credentials
-                String credentials = Credentials.basic(proxyInfo.getProxyUsername(),
-                        proxyInfo.getProxyPassword());
-
-                // Add the 'Proxy-Authorization' header to the request
-                return response.request()
-                        .newBuilder()
-                        .header("Proxy-Authorization", credentials)
-                        .build();
-            };
-            okHttpClientBuilder.proxyAuthenticator(proxyAuthenticator);
+        String username = proxyInfo.getProxyUsername();
+        if (username == null || username.isBlank()) {
+            return;
         }
+        String password = proxyInfo.getProxyPassword() != null ? proxyInfo.getProxyPassword() : "";
+
+        Authenticator proxyAuthenticator = (route, response) ->
+        {
+            // If the proxy header is already set, the credentials are probably wrong.
+            // So do nothing!
+            if (response.request().header(PROXY_AUTH_HEADER) != null) {
+                return null;
+            }
+
+            // Generate Basic Auth credentials
+            String credentials = Credentials.basic(username, password);
+
+            // Add the 'Proxy-Authorization' header to the request
+            return response.request()
+                    .newBuilder()
+                    .header(PROXY_AUTH_HEADER, credentials)
+                    .build();
+        };
+        okHttpClientBuilder.proxyAuthenticator(proxyAuthenticator);
+
     }
 
     private final WebSocketListener listener = new WebSocketListener() {

--- a/smack-websocket-okhttp/src/main/java/org/jivesoftware/smack/websocket/okhttp/OkHttpWebSocket.java
+++ b/smack-websocket-okhttp/src/main/java/org/jivesoftware/smack/websocket/okhttp/OkHttpWebSocket.java
@@ -16,14 +16,19 @@
  */
 package org.jivesoftware.smack.websocket.okhttp;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.logging.Level;
 
 import javax.net.ssl.SSLSession;
 
 import org.jivesoftware.smack.c2s.internal.ModularXmppClientToServerConnectionInternal;
+import org.jivesoftware.smack.proxy.ProxyInfo;
 import org.jivesoftware.smack.websocket.impl.AbstractWebSocket;
 import org.jivesoftware.smack.websocket.rce.WebSocketRemoteConnectionEndpoint;
 
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -53,6 +58,8 @@ public final class OkHttpWebSocket extends AbstractWebSocket {
             if (customHostnameVerifier != null) {
                 okHttpClientBuilder.hostnameVerifier(customHostnameVerifier);
             }
+
+            applyProxySettings(okHttpClientBuilder, connectionInternal.connection.getConfiguration().getProxyInfo());
         }
         var okHttpClient = okHttpClientBuilder.build();
 
@@ -63,6 +70,41 @@ public final class OkHttpWebSocket extends AbstractWebSocket {
                               .build();
 
         okHttpWebSocket = okHttpClient.newWebSocket(request, listener);
+    }
+
+    private void applyProxySettings(OkHttpClient.Builder okHttpClientBuilder, ProxyInfo proxyInfo) {
+        if (proxyInfo == null
+                || proxyInfo.getProxyType() != ProxyInfo.ProxyType.HTTP
+                || proxyInfo.getProxyAddress() == null
+                || proxyInfo.getProxyPort() == 0) {
+            return;
+        }
+
+        var proxy = new Proxy(Proxy.Type.HTTP,
+                new InetSocketAddress(proxyInfo.getProxyAddress(), proxyInfo.getProxyPort()));
+        okHttpClientBuilder.proxy(proxy);
+
+        if (proxyInfo.getProxyUsername() != null) {
+            Authenticator proxyAuthenticator = (route, response) ->
+            {
+                // If the proxy header is already set, the credentials are probably wrong.
+                // So do nothing!
+                if (response.request().header("Proxy-Authorization") != null) {
+                    return null;
+                }
+
+                // Generate Basic Auth credentials
+                String credentials = Credentials.basic(proxyInfo.getProxyUsername(),
+                        proxyInfo.getProxyPassword());
+
+                // Add the 'Proxy-Authorization' header to the request
+                return response.request()
+                        .newBuilder()
+                        .header("Proxy-Authorization", credentials)
+                        .build();
+            };
+            okHttpClientBuilder.proxyAuthenticator(proxyAuthenticator);
+        }
     }
 
     private final WebSocketListener listener = new WebSocketListener() {


### PR DESCRIPTION
In class `OkHttpWebSocket` the HTTP proxy support was missing