### PR TITLE
VCard fixes and improvements

### DIFF
--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -67,7 +68,7 @@ import org.jxmpp.jid.EntityBareJid;
  * vCard.setOrganization("Jetbrains, s.r.o");
  * vCard.setNickName("KIR");
  *
- * vCard.setField("TITLE", "Mr");
+ * vCard.setTitle("Mr");
  * vCard.setAddressFieldHome("STREET", "Some street");
  * vCard.setAddressFieldWork("CTRY", "US");
  * vCard.setPhoneWork("FAX", "3443233");
@@ -135,6 +136,13 @@ public final class VCard extends IQ {
 
     /**
      * Get the content of a generic VCard field.
+     * You should use more specific getters instead:
+     * {@link #getFullName()}
+     * {@link #getTitle()}
+     * {@link #getRole()}
+     * {@link #getBirthday()}
+     * {@link #getUrl()}
+     * {@link #getNote()}
      *
      * @param field value of field. Possible values: NICKNAME, PHOTO, BDAY, JABBERID, MAILER, TZ,
      *              GEO, TITLE, ROLE, LOGO, NOTE, PRODID, REV, SORT-STRING, SOUND, UID, URL, DESC.
@@ -146,6 +154,12 @@ public final class VCard extends IQ {
 
     /**
      * Set generic VCard field.
+     * You should use more specific setters instead:
+     * {@link #setTitle(String)}
+     * {@link #setRole(String)}
+     * {@link #setBirthday(LocalDate)}
+     * {@link #setUrl(String)}
+     * {@link #setNote(String)}
      *
      * @param value value of field
      * @param field field to set. See {@link #getField(String)}
@@ -220,6 +234,10 @@ public final class VCard extends IQ {
         updateFN();
     }
 
+    public String getFullName() {
+        return getField("FN");
+    }
+
     public String getNickName() {
         return getField("NICKNAME");
     }
@@ -266,6 +284,52 @@ public final class VCard extends IQ {
 
     public void setOrganizationUnit(String organizationUnit) {
         this.organizationUnit = organizationUnit;
+    }
+
+    public String getTitle() {
+        return getField("TITLE");
+    }
+
+    public void setTitle(String title) {
+        setField("TITLE", title);
+    }
+
+    public String getRole() {
+        return getField("ROLE");
+    }
+
+    public void setRole(String role) {
+        setField("ROLE", role);
+    }
+
+    public LocalDate getBirthday() {
+        String dobStr = getField("BDAY");
+        return dobStr != null && !dobStr.isEmpty() ? LocalDate.parse(dobStr) : null;
+    }
+
+    public void setBirthday(LocalDate dob) {
+        String dobStr = dob != null ? dob.toString() : null;
+        setField("BDAY", dobStr);
+    }
+
+    public String getUrl() {
+        return getField("URL");
+    }
+
+    public void setUrl(String url) {
+        setField("URL", url);
+    }
+
+    /**
+     * Get the Note (Description) field. It used for bio.
+     * @return value of DESC field.
+     */
+    public String getNote() {
+        return getField("DESC");
+    }
+
+    public void setNote(String note) {
+        setField("DESC", note);
     }
 
     /**

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -155,6 +155,7 @@ public final class VCard extends IQ {
     /**
      * Set generic VCard field.
      * You should use more specific setters instead:
+     * {@link #setFullName(String)}
      * {@link #setTitle(String)}
      * {@link #setRole(String)}
      * {@link #setBirthday(LocalDate)}
@@ -236,6 +237,15 @@ public final class VCard extends IQ {
 
     public String getFullName() {
         return getField("FN");
+    }
+
+    /**
+     * Set the FN fields with a full name (i.e., first name + middle name + last name).
+     * NOTE: The FN will be overwritten on call of {@link #setFirstName(String)}, {@link #setLastName(String)} etc.
+     * @param fullName the full name for FN field.
+     */
+    public void setFullName(String fullName) {
+        setField("FN", fullName);
     }
 
     public String getNickName() {
@@ -600,7 +610,7 @@ public final class VCard extends IQ {
         if (lastName != null) {
             sb.append(StringUtils.escapeForXml(lastName));
         }
-        setField("FN", sb.toString());
+        setFullName(sb.toString());
     }
 
     /**

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -100,7 +100,7 @@ public final class VCard extends IQ {
 
     /**
      * Address types:
-     * POSTAL?, PARCEL?, (DOM | INTL)?, PREF?, POBOX?, EXTADR?, STREET?, LOCALITY?,
+     * POSTAL?, PARCEL?, (DOM | INTL)?, PREF?, POBOX?, EXTADD?, STREET?, LOCALITY?,
      * REGION?, PCODE?, CTRY?
      */
     private final Map<String, String> homeAddr = new HashMap<>();
@@ -271,7 +271,7 @@ public final class VCard extends IQ {
     /**
      * Get home address field.
      *
-     * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADR, STREET,
+     * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADD, STREET,
      *                  LOCALITY, REGION, PCODE, CTRY
      * @return content of home address field.
      */
@@ -282,7 +282,7 @@ public final class VCard extends IQ {
     /**
      * Set home address field.
      *
-     * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADR, STREET,
+     * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADD, STREET,
      *                  LOCALITY, REGION, PCODE, CTRY
      * @param value new value for the field.
      */
@@ -293,7 +293,7 @@ public final class VCard extends IQ {
     /**
      * Get work address field.
      *
-     * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADR, STREET,
+     * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADD, STREET,
      *                  LOCALITY, REGION, PCODE, CTRY
      * @return content of work address field.
      */
@@ -304,7 +304,7 @@ public final class VCard extends IQ {
     /**
      * Set work address field.
      *
-     * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADR, STREET,
+     * @param addrField one of POSTAL, PARCEL, (DOM | INTL), PREF, POBOX, EXTADD, STREET,
      *                  LOCALITY, REGION, PCODE, CTRY
      * @param value new value for the field.
      */

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/packet/VCard.java
@@ -221,11 +221,11 @@ public final class VCard extends IQ {
     }
 
     public String getNickName() {
-        return otherSimpleFields.get("NICKNAME");
+        return getField("NICKNAME");
     }
 
     public void setNickName(String nickName) {
-        otherSimpleFields.put("NICKNAME", nickName);
+        setField("NICKNAME", nickName);
     }
 
     public String getEmailHome() {
@@ -245,11 +245,11 @@ public final class VCard extends IQ {
     }
 
     public String getJabberId() {
-        return otherSimpleFields.get("JABBERID");
+        return getField("JABBERID");
     }
 
     public void setJabberId(CharSequence jabberId) {
-        otherSimpleFields.put("JABBERID", jabberId.toString());
+        setField("JABBERID", jabberId.toString());
     }
 
     public String getOrganization() {

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
@@ -46,7 +46,7 @@ public class VCardProvider extends IqProvider<VCard> {
         "INTL",
         "PREF",
         "POBOX",
-        "EXTADR",
+        "EXTADD",
         "STREET",
         "LOCALITY",
         "REGION",

--- a/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
+++ b/smack-extensions/src/main/java/org/jivesoftware/smackx/vcardtemp/provider/VCardProvider.java
@@ -74,6 +74,7 @@ public class VCardProvider extends IqProvider<VCard> {
     public VCard parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment, JxmppContext jxmppContext) throws XmlPullParserException, IOException {
         VCard vCard = new VCard();
         String name = null;
+        String fullName = null;
 
         outerloop: while (true) {
             XmlPullParser.Event eventType = parser.next();
@@ -81,6 +82,9 @@ public class VCardProvider extends IqProvider<VCard> {
             case START_ELEMENT:
                 name = parser.getName();
                 switch (name) {
+                case "FN":
+                    fullName = parser.nextText();
+                    break;
                 case "N":
                     parseName(parser, vCard);
                     break;
@@ -123,6 +127,12 @@ public class VCardProvider extends IqProvider<VCard> {
             default:
                 break;
             }
+        }
+
+        // The FN field is generated on setFirstName, setLastName, setMiddleName, setPrefix, setSuffix.
+        // So we should set it manually at end.
+        if (fullName != null && !fullName.isEmpty()) {
+            vCard.setFullName(fullName);
         }
 
         return vCard;

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
@@ -62,7 +62,7 @@ public class VCardTest extends SmackTestSuite {
                 + "<TEL><WORK/><MSG/><NUMBER/></TEL>"
                 + "<ADR>"
                     + "<WORK/>"
-                    + "<EXTADD></EXTADD>"
+                    + "<EXTADD>Work Ext. address</EXTADD>"
                     + "<STREET>Work Street</STREET>"
                     + "<LOCALITY>Work Locality</LOCALITY>"
                     + "<REGION>Work Region</REGION>"
@@ -118,6 +118,7 @@ public class VCardTest extends SmackTestSuite {
         assertEquals("123-456-7890", vCard.getPhoneWork("VOICE"));
 
         assertEquals("Work Street", vCard.getAddressFieldWork("STREET"));
+        assertEquals("Work Ext. address", vCard.getAddressFieldWork("EXTADD"));
         assertEquals("Work Locality", vCard.getAddressFieldWork("LOCALITY"));
         assertEquals("Work Region", vCard.getAddressFieldWork("REGION"));
         assertEquals("Work Post Code", vCard.getAddressFieldWork("PCODE"));

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
@@ -93,7 +93,7 @@ public class VCardTest extends SmackTestSuite {
 
         VCard vCard = ElementParserUtils.parseStanza(request);
 
-        assertEquals("User PJ Name", vCard.getFullName());
+        assertEquals("User Name", vCard.getFullName());
         assertEquals("User", vCard.getFirstName());
         assertEquals("Name", vCard.getLastName());
         assertEquals("PJ", vCard.getMiddleName());

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
@@ -50,7 +50,7 @@ public class VCardTest extends SmackTestSuite {
                 + "</N>"
                 + "<NICKNAME>User dude</NICKNAME>"
                 + "<URL>http://www.igniterealtime.org</URL>"
-                + "<BDAY>1970-17-03</BDAY>"
+                + "<BDAY>1970-03-17</BDAY>"
                 + "<ORG>"
                     + "<ORGNAME>Ignite Realtime</ORGNAME>"
                     + "<ORGUNIT>Smack</ORGUNIT>"
@@ -104,6 +104,7 @@ public class VCardTest extends SmackTestSuite {
         assertEquals("Programmer & tester", vCard.getField("TITLE"));
         assertEquals("Bug fixer", vCard.getField("ROLE"));
         assertEquals("<Check out our website: http://www.igniterealtime.org>", vCard.getField("DESC"));
+        assertEquals("1970-03-17", vCard.getField("BDAY"));
         assertEquals("http://www.igniterealtime.org", vCard.getField("URL"));
 
         assertEquals("user@igniterealtime.org", vCard.getEmailHome());
@@ -116,6 +117,7 @@ public class VCardTest extends SmackTestSuite {
         assertEquals("123-098-7654", vCard.getPhoneHome("VOICE"));
         assertEquals("123-456-7890", vCard.getPhoneWork("VOICE"));
 
+        assertEquals("Work Street", vCard.getAddressFieldWork("STREET"));
         assertEquals("Work Locality", vCard.getAddressFieldWork("LOCALITY"));
         assertEquals("Work Region", vCard.getAddressFieldWork("REGION"));
         assertEquals("Work Post Code", vCard.getAddressFieldWork("PCODE"));

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
@@ -16,10 +16,11 @@
  */
 package org.jivesoftware.smackx.vcardtemp;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.Arrays;
+import java.time.LocalDate;
 
 import org.jivesoftware.smack.test.util.ElementParserUtils;
 import org.jivesoftware.smack.test.util.SmackTestSuite;
@@ -28,8 +29,6 @@ import org.jivesoftware.smack.util.stringencoder.Base64;
 import org.jivesoftware.smackx.vcardtemp.packet.VCard;
 
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class VCardTest extends SmackTestSuite {
 
@@ -94,6 +93,7 @@ public class VCardTest extends SmackTestSuite {
 
         VCard vCard = ElementParserUtils.parseStanza(request);
 
+        assertEquals("User PJ Name", vCard.getFullName());
         assertEquals("User", vCard.getFirstName());
         assertEquals("Name", vCard.getLastName());
         assertEquals("PJ", vCard.getMiddleName());
@@ -101,11 +101,11 @@ public class VCardTest extends SmackTestSuite {
         assertEquals("Mr.", vCard.getPrefix());
         assertEquals("III", vCard.getSuffix());
 
-        assertEquals("Programmer & tester", vCard.getField("TITLE"));
-        assertEquals("Bug fixer", vCard.getField("ROLE"));
-        assertEquals("<Check out our website: http://www.igniterealtime.org>", vCard.getField("DESC"));
-        assertEquals("1970-03-17", vCard.getField("BDAY"));
-        assertEquals("http://www.igniterealtime.org", vCard.getField("URL"));
+        assertEquals("Programmer & tester", vCard.getTitle());
+        assertEquals("Bug fixer", vCard.getRole());
+        assertEquals("<Check out our website: http://www.igniterealtime.org>", vCard.getNote());
+        assertEquals(LocalDate.of(1970, 3, 17), vCard.getBirthday());
+        assertEquals("http://www.igniterealtime.org", vCard.getUrl());
 
         assertEquals("user@igniterealtime.org", vCard.getEmailHome());
         assertEquals("work@igniterealtime.org", vCard.getEmailWork());
@@ -132,6 +132,22 @@ public class VCardTest extends SmackTestSuite {
         byte[] expectedAvatar = getAvatarBinary();
         assertArrayEquals(expectedAvatar, vCard.getAvatar());
         assertEquals(MIME_TYPE, vCard.getAvatarMimeType());
+    }
+
+    @Test
+    public void testBirthday() throws Throwable {
+        // @formatter:off
+        final String request =
+                "<iq id='v1' to='user@igniterealtime.org/mobile' type='result'>"
+                        + "<vCard xmlns='vcard-temp'><BDAY></BDAY></vCard>"
+                        + "</iq>";
+        // @formatter:on
+
+        VCard vCard = ElementParserUtils.parseStanza(request);
+        assertNull(vCard.getBirthday(), "Empty BDAY field should be parsed to Birthday=null");
+
+        vCard.setBirthday(LocalDate.of(1970, 3, 17));
+        assertEquals(LocalDate.of(1970, 3, 17), vCard.getBirthday());
     }
 
     @Test
@@ -251,7 +267,7 @@ public class VCardTest extends SmackTestSuite {
 
         VCard vCard = ElementParserUtils.parseStanza(request);
 
-        assertEquals("kir max", vCard.getField("FN"));
+        assertEquals("kir max", vCard.getFullName());
     }
 
     private static final String MIME_TYPE = "testtype";

--- a/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
+++ b/smack-extensions/src/test/java/org/jivesoftware/smackx/vcardtemp/VCardTest.java
@@ -29,6 +29,8 @@ import org.jivesoftware.smackx.vcardtemp.packet.VCard;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class VCardTest extends SmackTestSuite {
 
     @Test
@@ -125,7 +127,7 @@ public class VCardTest extends SmackTestSuite {
         assertEquals("Home Country", vCard.getAddressFieldHome("CTRY"));
 
         byte[] expectedAvatar = getAvatarBinary();
-        assertTrue(Arrays.equals(vCard.getAvatar(), expectedAvatar));
+        assertArrayEquals(expectedAvatar, vCard.getAvatar());
         assertEquals(MIME_TYPE, vCard.getAvatarMimeType());
     }
 
@@ -267,10 +269,10 @@ public class VCardTest extends SmackTestSuite {
 
         byte[] avatar = vCard.getAvatar();
         String mimeType = vCard.getAvatarMimeType();
-        assertEquals(mimeType, MIME_TYPE);
+        assertEquals(MIME_TYPE, mimeType);
 
         byte[] expectedAvatar = getAvatarBinary();
-        assertTrue(Arrays.equals(avatar, expectedAvatar));
+        assertArrayEquals(expectedAvatar, avatar);
     }
 
     public static byte[] getAvatarBinary() {


### PR DESCRIPTION
The VCard is not easy to use because we have to call the `getField("SOMETHING")` method. I added getters to simplify this i.e. `getSomething()`.
I added getter only for those fields that are in XEP. The `DESC` field used have a getter named `getNote()` because later in the VCard v4 it the DESC was renamed to NOTE. So to minimize code changes on migration I made it called `getNote()`. I guess the same VCard class will be used once the VCard v4 will be used. BTW the Prosody sets the `<NOTE>` field, not the `<DESC>` and that was confusing for me. I'll report this to them.

Also I noticed a problem that the Address Extended field wasn't properly named: it was EXTAD**R** but should be EXTAD**D** as in XEP (and Tigease). This change breaks old VCards with the EXTADR field but I'm pretty sure that no one IRL used it.

And last change is for the Full Name (FN): it shouldn't be auto generated from first and last names but a user may specify it according to their locale (e.g. Family name + Given name). The backward compatibility is preserved.

Links:

- https://xmpp.org/extensions/xep-0054.html
- https://xmpp.org/extensions/xep-0292.html vCard4 Over XMPP
- [Openfire VCardBean](https://github.com/igniterealtime/Openfire/blob/main/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardBean.java)
- [tigase VCard](https://github.com/tigase/jaxmpp/blob/master/jaxmpp-vcard/src/main/java/tigase/jaxmpp/core/client/xmpp/modules/vcard/VCard.java)