### PR TITLE
ConsistentColors: Upgdare HsLuv to v1 and fix negative RGB values

### DIFF
--- a/smack-experimental/build.gradle
+++ b/smack-experimental/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 	api project(':smack-core')
 	api project(':smack-extensions')
 
-	implementation "org.hsluv:hsluv:0.2"
+	implementation "org.hsluv:hsluv:1.0"
 
 	testFixturesApi(testFixtures(project(":smack-extensions")))
 }

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/colors/ConsistentColor.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/colors/ConsistentColor.java
@@ -16,6 +16,8 @@
  */
 package org.jivesoftware.smackx.colors;
 
+import static java.lang.Byte.toUnsignedInt;
+
 import org.jivesoftware.smack.util.Objects;
 import org.jivesoftware.smack.util.SHA1;
 
@@ -68,7 +70,7 @@ public class ConsistentColor {
      */
     private static double createAngle(CharSequence input) {
         byte[] h = SHA1.bytes(input.toString());
-        double v = u(h[0]) + (256 * u(h[1]));
+        double v = toUnsignedInt(h[0]) + (256 * toUnsignedInt(h[1]));
         double d = v / 65536;
         return d * 360;
     }
@@ -124,17 +126,6 @@ public class ConsistentColor {
         rgbi[0] = 0.2f * (1 - rgbb[0]) + 0.8f * rgbi[0];
         rgbi[1] = 0.2f * (1 - rgbb[1]) + 0.8f * rgbi[1];
         rgbi[2] = 0.2f * (1 - rgbb[2]) + 0.8f * rgbi[2];
-    }
-
-    /**
-     * Treat a signed java byte as unsigned to get its numerical value.
-     *
-     * @param b signed java byte
-     * @return integer value of its unsigned representation
-     */
-    private static int u(byte b) {
-        // Get unsigned value of signed byte as an integer.
-        return b & 0xFF;
     }
 
     /**

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/colors/ConsistentColor.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/colors/ConsistentColor.java
@@ -107,7 +107,7 @@ public class ConsistentColor {
      *
      * @see <a href="https://xmpp.org/extensions/xep-0392.html#algorithm-rgb">XEP-0392 §5.4: RGB generation</a>
      */
-    private static double[] hsluvToRgb(double hue) {
+    private static float[] hsluvToRgb(double hue) {
         HsluvColorConverter conv = new HsluvColorConverter();
         conv.hsluv_h = hue;
         conv.hsluv_s = 100;
@@ -117,15 +117,13 @@ public class ConsistentColor {
         conv.rgb_r = Math.max(0, conv.rgb_r);
         conv.rgb_g = Math.max(0, conv.rgb_g);
         conv.rgb_b = Math.max(0, conv.rgb_b);
-        return new double[] {conv.rgb_r, conv.rgb_g, conv.rgb_b};
+        return new float[] {(float) conv.rgb_r, (float) conv.rgb_g, (float) conv.rgb_b};
     }
 
-    private static double[] mixWithBackground(double[] rgbi, float[] rgbb) {
-        return new double[] {
-                0.2 * (1 - rgbb[0]) + 0.8 * rgbi[0],
-                0.2 * (1 - rgbb[1]) + 0.8 * rgbi[1],
-                0.2 * (1 - rgbb[2]) + 0.8 * rgbi[2]
-        };
+    private static void mixWithBackground(float[] rgbi, float[] rgbb) {
+        rgbi[0] = 0.2f * (1 - rgbb[0]) + 0.8f * rgbi[0];
+        rgbi[1] = 0.2f * (1 - rgbb[1]) + 0.8f * rgbi[1];
+        rgbi[2] = 0.2f * (1 - rgbb[2]) + 0.8f * rgbi[2];
     }
 
     /**
@@ -162,12 +160,12 @@ public class ConsistentColor {
     public static float[] RGBFrom(CharSequence input, ConsistentColorSettings settings) {
         double angle = createAngle(input);
         double correctedAngle = applyColorDeficiencyCorrection(angle, settings.getDeficiency());
-        double[] rgb = hsluvToRgb(correctedAngle);
+        float[] rgb = hsluvToRgb(correctedAngle);
         if (settings.backgroundRGB != null) {
-            rgb = mixWithBackground(rgb, settings.backgroundRGB);
+            mixWithBackground(rgb, settings.backgroundRGB);
         }
 
-        return new float[] {(float) rgb[0], (float) rgb[1], (float) rgb[2]};
+        return rgb;
     }
 
     public static int[] floatRgbToInts(float[] floats) {

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/colors/ConsistentColor.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/colors/ConsistentColor.java
@@ -19,7 +19,7 @@ package org.jivesoftware.smackx.colors;
 import org.jivesoftware.smack.util.Objects;
 import org.jivesoftware.smack.util.SHA1;
 
-import org.hsluv.HUSLColorConverter;
+import org.hsluv.HsluvColorConverter;
 
 /**
  * Smack API for Consistent Color Generation (XEP-0392).
@@ -108,21 +108,12 @@ public class ConsistentColor {
      * @see <a href="https://xmpp.org/extensions/xep-0392.html#algorithm-rgb">XEP-0392 §5.4: RGB generation</a>
      */
     private static double[] hsluvToRgb(double hue) {
-        return hsluvToRgb(hue, 100, 50);
-    }
-
-    /**
-     * Converting a HSLuv angle to RGB.
-     *
-     * @param hue angle 0 <= hue < 360
-     * @param saturation saturation 0 <= saturation <= 100
-     * @param lightness lightness 0 <= lightness <= 100
-     * @return rbg array with values 0 <= (r,g,b) <= 1
-     *
-     * @see <a href="https://www.rapidtables.com/convert/color/hsl-to-rgb.html">HSL to RGB conversion</a>
-     */
-    private static double[] hsluvToRgb(double hue, double saturation, double lightness) {
-        return HUSLColorConverter.hsluvToRgb(new double[] {hue, saturation, lightness});
+        HsluvColorConverter conv = new HsluvColorConverter();
+        conv.hsluv_h = hue;
+        conv.hsluv_s = 100;
+        conv.hsluv_l = 50;
+        conv.hsluvToRgb();
+        return new double[] {conv.rgb_r, conv.rgb_g, conv.rgb_b};
     }
 
     private static double[] mixWithBackground(double[] rgbi, float[] rgbb) {

--- a/smack-experimental/src/main/java/org/jivesoftware/smackx/colors/ConsistentColor.java
+++ b/smack-experimental/src/main/java/org/jivesoftware/smackx/colors/ConsistentColor.java
@@ -113,6 +113,10 @@ public class ConsistentColor {
         conv.hsluv_s = 100;
         conv.hsluv_l = 50;
         conv.hsluvToRgb();
+        // avoid negative values
+        conv.rgb_r = Math.max(0, conv.rgb_r);
+        conv.rgb_g = Math.max(0, conv.rgb_g);
+        conv.rgb_b = Math.max(0, conv.rgb_b);
         return new double[] {conv.rgb_r, conv.rgb_g, conv.rgb_b};
     }
 

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/colors/ConsistentColorsTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/colors/ConsistentColorsTest.java
@@ -50,7 +50,7 @@ public class ConsistentColorsTest extends SmackTestSuite {
 
     @Test
     public void romeoRedGreenBlindnessTest() {
-        float[] expected = new float[] {0.865f, 0.000f, 0.686f};
+        float[] expected = new float[] {0.865f, 0.000f, 0.68620354f};
         float[] actual = ConsistentColor.RGBFrom(romeo, redGreenDeficiency);
         assertRGBEquals(expected, actual);
     }
@@ -65,7 +65,7 @@ public class ConsistentColorsTest extends SmackTestSuite {
     @Test
     public void julietNickTest() {
         // may have a negative Red
-        float[] expected = new float[] {-2.7433055E-13f, 0.5226505f, 0.50349814f};
+        float[] expected = new float[] {0f, 0.5226505f, 0.50349814f};
         float[] actual = ConsistentColor.RGBFrom("juliet");
         assertRGBEquals(expected, actual);
     }

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/colors/ConsistentColorsTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/colors/ConsistentColorsTest.java
@@ -63,6 +63,14 @@ public class ConsistentColorsTest extends SmackTestSuite {
     }
 
     @Test
+    public void julietNickTest() {
+        // may have a negative Red
+        float[] expected = new float[] {-2.7433055E-13f, 0.5226505f, 0.50349814f};
+        float[] actual = ConsistentColor.RGBFrom("juliet");
+        assertRGBEquals(expected, actual);
+    }
+
+    @Test
     public void julietNoDeficiencyTest() {
         float[] expected = new float[] {0.000f, 0.515f, 0.573f};
         float[] actual = ConsistentColor.RGBFrom(juliet, noDeficiency);

--- a/smack-experimental/src/test/java/org/jivesoftware/smackx/colors/ConsistentColorsTest.java
+++ b/smack-experimental/src/test/java/org/jivesoftware/smackx/colors/ConsistentColorsTest.java
@@ -45,84 +45,84 @@ public class ConsistentColorsTest extends SmackTestSuite {
     @Test
     public void romeoNoDeficiencyTest() {
         float[] rgb = new float[] {0.865f, 0.000f, 0.686f};
-        assertRGBEquals(rgb, ConsistentColor.RGBFrom(romeo), EPS);
+        assertRGBEquals(rgb, ConsistentColor.RGBFrom(romeo));
     }
 
     @Test
     public void romeoRedGreenBlindnessTest() {
         float[] expected = new float[] {0.865f, 0.000f, 0.686f};
         float[] actual = ConsistentColor.RGBFrom(romeo, redGreenDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void romeoBlueBlindnessTest() {
         float[] expected = new float[] {0.000f, 0.535f, 0.350f};
         float[] actual = ConsistentColor.RGBFrom(romeo, blueBlindnessDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void julietNoDeficiencyTest() {
         float[] expected = new float[] {0.000f, 0.515f, 0.573f};
         float[] actual = ConsistentColor.RGBFrom(juliet, noDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void julietRedGreenBlindnessTest() {
         float[] expected = new float[] {0.742f, 0.359f, 0.000f};
         float[] actual = ConsistentColor.RGBFrom(juliet, redGreenDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void julietBlueBlindnessTest() {
         float[] expected = new float[] {0.742f, 0.359f, 0.000f};
         float[] actual = ConsistentColor.RGBFrom(juliet, blueBlindnessDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void emojiNoDeficiencyTest() {
         float[] expected = new float[] {0.872f, 0.000f, 0.659f};
         float[] actual = ConsistentColor.RGBFrom(emoji, noDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void emojiRedGreenBlindnessTest() {
         float[] expected = new float[] {0.872f, 0.000f, 0.659f};
         float[] actual = ConsistentColor.RGBFrom(emoji, redGreenDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void emojiBlueBlindnessTest() {
         float[] expected = new float[] {0.000f, 0.533f, 0.373f};
         float[] actual = ConsistentColor.RGBFrom(emoji, blueBlindnessDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void councilNoDeficiencyTest() {
         float[] expected = new float[] {0.918f, 0.000f, 0.394f};
         float[] actual = ConsistentColor.RGBFrom(council, noDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void councilRedGreenBlindnessTest() {
         float[] expected = new float[] {0.918f, 0.000f, 0.394f};
         float[] actual = ConsistentColor.RGBFrom(council, redGreenDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     @Test
     public void councilBlueBlindnessTest() {
         float[] expected = new float[] {0.000f, 0.524f, 0.485f};
         float[] actual = ConsistentColor.RGBFrom(council, blueBlindnessDeficiency);
-        assertRGBEquals(expected, actual, EPS);
+        assertRGBEquals(expected, actual);
     }
 
     /**
@@ -130,14 +130,13 @@ public class ConsistentColorsTest extends SmackTestSuite {
      *
      * @param expected expected values
      * @param actual actual values
-     * @param eps allowed error
      */
-    private static void assertRGBEquals(float[] expected, float[] actual, float eps) {
+    private static void assertRGBEquals(float[] expected, float[] actual) {
         assertEquals(3, expected.length);
         assertEquals(3, actual.length);
 
-        for (int i = 0; i < actual.length; i++) {
-            assertEquals(expected[i], actual[i], eps);
-        }
+        assertEquals(expected[0], actual[0], EPS);
+        assertEquals(expected[1], actual[1], EPS);
+        assertEquals(expected[2], actual[2], EPS);
     }
 }


### PR DESCRIPTION
The `ConsistentColor.RGBFrom("juliet")` call returns RGB values array with negative red close to zero. Then when calling `new java.awt.Color(float, float, float)` it will throw an exception on the bad range IllegalArgumentException: Color parameter outside of expected range: Red.

I reported the problem to the hsluv https://github.com/hsluv/hsluv-java/pull/2 but meanwhile here is a fix.