### PR TITLE
[build] Use fixed versions for jxmpp and minidns

### DIFF
--- a/build-logic/src/main/groovy/org.igniterealtime.smack.java-common-conventions.gradle
+++ b/build-logic/src/main/groovy/org.igniterealtime.smack.java-common-conventions.gradle
@@ -29,8 +29,8 @@ ext {
 	builtDate = (new java.text.SimpleDateFormat("yyyy-MM-dd")).format(new Date())
 	oneLineDesc = 'An Open Source XMPP (Jabber) client library'
 
-	jxmppVersion = '[1.1.0, 1.1.999]'
-	miniDnsVersion = '[1.1.0-alpha3, 1.1.999]'
+	jxmppVersion = '1.1.0'
+	miniDnsVersion = '1.1.1'
 	junitVersion = '5.12.2'
 	commonsIoVersion = '2.17.0'
 	bouncyCastleVersion = '1.73'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	// have a ideaProject task, so let's add one.
 	id 'idea'
 
+	id 'org.igniterealtime.smack.java-common-conventions'
 	id 'org.igniterealtime.smack.javadoc-conventions'
 }
 
@@ -32,12 +33,10 @@ tasks.register('javadocAll', Javadoc) {
 	}
 
 	doFirst {
-		def staticJxmppVersion = getResolvedVersion('org.jxmpp:jxmpp-core')
-		def staticMiniDnsVersion = getResolvedVersion('org.minidns:minidns-core')
 		options.links = [
 			"https://docs.oracle.com/en/java/javase/${javaMajor}/docs/api/",
-			"https://jxmpp.org/releases/${staticJxmppVersion}/javadoc/",
-			"https://minidns.org/releases/${staticMiniDnsVersion}/javadoc/",
+			"https://jxmpp.org/releases/${jxmppVersion}/javadoc/",
+			"https://minidns.org/releases/${miniDnsVersion}/javadoc/",
 		] as String[]
 	}
 
@@ -93,25 +92,4 @@ task inttestFull {
 		sinttest,
 		omemoSignalIntTest,
 	]}
-}
-
-def getResolvedVersion(queriedProject = 'smack-core', component) {
-	def configuration = project(queriedProject)
-		.configurations
-		.compileClasspath
-
-	def artifact = configuration
-		.resolvedConfiguration
-		.resolvedArtifacts
-		.findAll {
-			// 'it' is of type ResolvedArtifact, 'id' of
-			// Component*Artifact*Identifier, and we check the
-			// ComponentIdentifier.
-			it.id.getComponentIdentifier() instanceof org.gradle.api.artifacts.component.ModuleComponentIdentifier
-		}
-	    .find {
-			it.id.getComponentIdentifier().toString().startsWith(component + ':')
-		}
-
-	artifact.getModuleVersion().getId().getVersion()
 }

--- a/smack-android/build.gradle
+++ b/smack-android/build.gradle
@@ -14,13 +14,13 @@ smack-extensions and smack-experimental."""
 // sourceSet.test of the core subproject
 dependencies {
 	implementation project(':smack-xmlparser-xpp3')
-	// Depend on minidns-android21 as optional dependency, even if may
+	// Depend on minidns-android23 as optional dependency, even if may
 	// not need it. Can't hurt to have it in the programm path with
 	// the correct MiniDNS version as it won't hurt even if the
-	// Android version is smaller then 21. Note that we deliberatly do
+	// Android version is smaller then 23. Note that we deliberately do
 	// not add this to smack-minidns, as this dependency may also be
 	// used in non-Android projects.
-	implementation "org.minidns:minidns-android21:$miniDnsVersion"
+	implementation "org.minidns:minidns-android23:$miniDnsVersion"
 
 	api project(':smack-core')
 	api project(':smack-im')


### PR DESCRIPTION
The jxmpp and minidns libraries are declared with a version range. You remember #61 where I first time proposed to fixate the version to make IntelliJ happy.

In the Spark I faced another problem that the minidns was resolved into the lowest version. I had to add the dependency manually and also [exclude the minidns from smack transitives](https://github.com/igniterealtime/Spark/blob/697b41f3ef3e03cdad6bdd39c6c84ebc65815677/core/pom.xml#L140-L139) because the Maven Enforcer "version convergence" rule failed because two versions of the same library in a dependency tree.

We should avoid using ranges. Instead it must be specified the latest know version of library that works fine with the Smack. If an xmpp clients (e.g. Spark, aTalk) needs to use a different version they can define the dependency explicitly.

Also the version range hided the problem that `org.minidns:minidns-android21` should be changed to `org.minidns:minidns-android23`.

